### PR TITLE
Add slug map

### DIFF
--- a/migrate/slug_map.json
+++ b/migrate/slug_map.json
@@ -1,0 +1,26562 @@
+[
+  {
+    "cppref": "index",
+    "cppdoc": null
+  },
+  {
+    "cppref": "c",
+    "cppdoc": null
+  },
+  {
+    "cppref": "Main_Page",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/ranges",
+    "cppdoc": "cpp/library/ranges"
+  },
+  {
+    "cppref": "cpp/atomic",
+    "cppdoc": "cpp/library/atomic"
+  },
+  {
+    "cppref": "cpp/freestanding",
+    "cppdoc": "cpp/library/freestanding"
+  },
+  {
+    "cppref": "cpp/index",
+    "cppdoc": "cpp/library/index"
+  },
+  {
+    "cppref": "cpp/11",
+    "cppdoc": "cpp/language/11"
+  },
+  {
+    "cppref": "cpp/thread",
+    "cppdoc": "cpp/library/thread"
+  },
+  {
+    "cppref": "cpp/numeric",
+    "cppdoc": "cpp/library/numeric"
+  },
+  {
+    "cppref": "cpp/container",
+    "cppdoc": "cpp/library/container"
+  },
+  {
+    "cppref": "cpp/17",
+    "cppdoc": "cpp/language/17"
+  },
+  {
+    "cppref": "cpp/string",
+    "cppdoc": "cpp/library/string"
+  },
+  {
+    "cppref": "cpp/filesystem",
+    "cppdoc": "cpp/library/filesystem"
+  },
+  {
+    "cppref": "cpp/26",
+    "cppdoc": "cpp/language/26"
+  },
+  {
+    "cppref": "cpp/compiler_support",
+    "cppdoc": "cpp/library/compiler_support"
+  },
+  {
+    "cppref": "cpp/headers",
+    "cppdoc": "cpp/library/headers"
+  },
+  {
+    "cppref": "cpp/standard_library",
+    "cppdoc": "cpp/library/standard_library"
+  },
+  {
+    "cppref": "cpp/error",
+    "cppdoc": "cpp/library/error"
+  },
+  {
+    "cppref": "cpp/memory",
+    "cppdoc": "cpp/library/memory"
+  },
+  {
+    "cppref": "cpp/current_status",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/feature_test",
+    "cppdoc": "cpp/library/feature_test"
+  },
+  {
+    "cppref": "cpp/20",
+    "cppdoc": "cpp/language/20"
+  },
+  {
+    "cppref": "cpp/iterator",
+    "cppdoc": "cpp/library/iterator"
+  },
+  {
+    "cppref": "cpp/io",
+    "cppdoc": "cpp/library/io"
+  },
+  {
+    "cppref": "cpp/23",
+    "cppdoc": "cpp/language/23"
+  },
+  {
+    "cppref": "cpp/experimental",
+    "cppdoc": "cpp/library/experimental"
+  },
+  {
+    "cppref": "cpp/chrono",
+    "cppdoc": "cpp/library/chrono"
+  },
+  {
+    "cppref": "cpp/text",
+    "cppdoc": "cpp/library/text"
+  },
+  {
+    "cppref": "cpp/named_req",
+    "cppdoc": "cpp/library/named_req"
+  },
+  {
+    "cppref": "cpp/language",
+    "cppdoc": "cpp/language"
+  },
+  {
+    "cppref": "cpp/execution",
+    "cppdoc": "cpp/library/execution"
+  },
+  {
+    "cppref": "cpp/links",
+    "cppdoc": "cpp/library/links"
+  },
+  {
+    "cppref": "cpp/meta",
+    "cppdoc": "cpp/library/meta"
+  },
+  {
+    "cppref": "cpp/header",
+    "cppdoc": "cpp/library/header"
+  },
+  {
+    "cppref": "cpp/14",
+    "cppdoc": "cpp/language/14"
+  },
+  {
+    "cppref": "cpp/locale",
+    "cppdoc": "cpp/library/text/locale"
+  },
+  {
+    "cppref": "cpp/concepts",
+    "cppdoc": "cpp/library/concepts"
+  },
+  {
+    "cppref": "cpp/algorithm",
+    "cppdoc": "cpp/library/algorithm"
+  },
+  {
+    "cppref": "cpp/symbol_index",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/utility",
+    "cppdoc": "cpp/library/utility"
+  },
+  {
+    "cppref": "cpp/preprocessor",
+    "cppdoc": "cpp/language/preprocessor"
+  },
+  {
+    "cppref": "cpp/preprocessor/replace",
+    "cppdoc": "cpp/language/preprocessor/replace"
+  },
+  {
+    "cppref": "cpp/preprocessor/impl",
+    "cppdoc": "cpp/language/preprocessor/impl"
+  },
+  {
+    "cppref": "cpp/preprocessor/conditional",
+    "cppdoc": "cpp/language/preprocessor/conditional"
+  },
+  {
+    "cppref": "cpp/preprocessor/line",
+    "cppdoc": "cpp/language/preprocessor/line"
+  },
+  {
+    "cppref": "cpp/preprocessor/error",
+    "cppdoc": "cpp/language/preprocessor/error"
+  },
+  {
+    "cppref": "cpp/preprocessor/include",
+    "cppdoc": "cpp/language/preprocessor/include"
+  },
+  {
+    "cppref": "cpp/concepts/floating_point",
+    "cppdoc": "cpp/library/concepts/floating_point"
+  },
+  {
+    "cppref": "cpp/concepts/copy_constructible",
+    "cppdoc": "cpp/library/concepts/copy_constructible"
+  },
+  {
+    "cppref": "cpp/concepts/default_initializable",
+    "cppdoc": "cpp/library/concepts/default_initializable"
+  },
+  {
+    "cppref": "cpp/concepts/integral",
+    "cppdoc": "cpp/library/concepts/integral"
+  },
+  {
+    "cppref": "cpp/concepts/equivalence_relation",
+    "cppdoc": "cpp/library/concepts/equivalence_relation"
+  },
+  {
+    "cppref": "cpp/concepts/movable",
+    "cppdoc": "cpp/library/concepts/movable"
+  },
+  {
+    "cppref": "cpp/concepts/invocable",
+    "cppdoc": "cpp/library/concepts/invocable"
+  },
+  {
+    "cppref": "cpp/concepts/swappable",
+    "cppdoc": "cpp/library/concepts/swappable"
+  },
+  {
+    "cppref": "cpp/concepts/predicate",
+    "cppdoc": "cpp/library/concepts/predicate"
+  },
+  {
+    "cppref": "cpp/concepts/totally_ordered",
+    "cppdoc": "cpp/library/concepts/totally_ordered"
+  },
+  {
+    "cppref": "cpp/concepts/semiregular",
+    "cppdoc": "cpp/library/concepts/semiregular"
+  },
+  {
+    "cppref": "cpp/concepts/relation",
+    "cppdoc": "cpp/library/concepts/relation"
+  },
+  {
+    "cppref": "cpp/concepts/constructible_from",
+    "cppdoc": "cpp/library/concepts/constructible_from"
+  },
+  {
+    "cppref": "cpp/concepts/unsigned_integral",
+    "cppdoc": "cpp/library/concepts/unsigned_integral"
+  },
+  {
+    "cppref": "cpp/concepts/copyable",
+    "cppdoc": "cpp/library/concepts/copyable"
+  },
+  {
+    "cppref": "cpp/concepts/same_as",
+    "cppdoc": "cpp/library/concepts/same_as"
+  },
+  {
+    "cppref": "cpp/concepts/signed_integral",
+    "cppdoc": "cpp/library/concepts/signed_integral"
+  },
+  {
+    "cppref": "cpp/concepts/destructible",
+    "cppdoc": "cpp/library/concepts/destructible"
+  },
+  {
+    "cppref": "cpp/concepts/boolean-testable",
+    "cppdoc": "cpp/library/concepts/boolean-testable"
+  },
+  {
+    "cppref": "cpp/concepts/convertible_to",
+    "cppdoc": "cpp/library/concepts/convertible_to"
+  },
+  {
+    "cppref": "cpp/concepts/common_with",
+    "cppdoc": "cpp/library/concepts/common_with"
+  },
+  {
+    "cppref": "cpp/concepts/equality_comparable",
+    "cppdoc": "cpp/library/concepts/equality_comparable"
+  },
+  {
+    "cppref": "cpp/concepts/strict_weak_order",
+    "cppdoc": "cpp/library/concepts/strict_weak_order"
+  },
+  {
+    "cppref": "cpp/concepts/derived_from",
+    "cppdoc": "cpp/library/concepts/derived_from"
+  },
+  {
+    "cppref": "cpp/concepts/move_constructible",
+    "cppdoc": "cpp/library/concepts/move_constructible"
+  },
+  {
+    "cppref": "cpp/concepts/assignable_from",
+    "cppdoc": "cpp/library/concepts/assignable_from"
+  },
+  {
+    "cppref": "cpp/concepts/common_reference_with",
+    "cppdoc": "cpp/library/concepts/common_reference_with"
+  },
+  {
+    "cppref": "cpp/concepts/regular",
+    "cppdoc": "cpp/library/concepts/regular"
+  },
+  {
+    "cppref": "cpp/header/istream",
+    "cppdoc": "cpp/library/headers/istream"
+  },
+  {
+    "cppref": "cpp/header/stack",
+    "cppdoc": "cpp/library/headers/stack"
+  },
+  {
+    "cppref": "cpp/header/ranges",
+    "cppdoc": "cpp/library/headers/ranges"
+  },
+  {
+    "cppref": "cpp/header/span",
+    "cppdoc": "cpp/library/headers/span"
+  },
+  {
+    "cppref": "cpp/header/atomic",
+    "cppdoc": "cpp/library/headers/atomic"
+  },
+  {
+    "cppref": "cpp/header/cinttypes",
+    "cppdoc": "cpp/library/headers/cinttypes"
+  },
+  {
+    "cppref": "cpp/header/cuchar",
+    "cppdoc": "cpp/library/headers/cuchar"
+  },
+  {
+    "cppref": "cpp/header/unordered_set",
+    "cppdoc": "cpp/library/headers/unordered_set"
+  },
+  {
+    "cppref": "cpp/header/cwctype",
+    "cppdoc": "cpp/library/headers/cwctype"
+  },
+  {
+    "cppref": "cpp/header/typeindex",
+    "cppdoc": "cpp/library/headers/typeindex"
+  },
+  {
+    "cppref": "cpp/header/latch",
+    "cppdoc": "cpp/library/headers/latch"
+  },
+  {
+    "cppref": "cpp/header/unordered_map",
+    "cppdoc": "cpp/library/headers/unordered_map"
+  },
+  {
+    "cppref": "cpp/header/typeinfo",
+    "cppdoc": "cpp/library/headers/typeinfo"
+  },
+  {
+    "cppref": "cpp/header/mdspan",
+    "cppdoc": "cpp/library/headers/mdspan"
+  },
+  {
+    "cppref": "cpp/header/stdexcept",
+    "cppdoc": "cpp/library/headers/stdexcept"
+  },
+  {
+    "cppref": "cpp/header/limits",
+    "cppdoc": "cpp/library/headers/limits"
+  },
+  {
+    "cppref": "cpp/header/iomanip",
+    "cppdoc": "cpp/library/headers/iomanip"
+  },
+  {
+    "cppref": "cpp/header/future",
+    "cppdoc": "cpp/library/headers/future"
+  },
+  {
+    "cppref": "cpp/header/initializer_list",
+    "cppdoc": "cpp/library/headers/initializer_list"
+  },
+  {
+    "cppref": "cpp/header/mutex",
+    "cppdoc": "cpp/library/headers/mutex"
+  },
+  {
+    "cppref": "cpp/header/debugging",
+    "cppdoc": "cpp/library/headers/debugging"
+  },
+  {
+    "cppref": "cpp/header/source_location",
+    "cppdoc": "cpp/library/headers/source_location"
+  },
+  {
+    "cppref": "cpp/header/cerrno",
+    "cppdoc": "cpp/library/headers/cerrno"
+  },
+  {
+    "cppref": "cpp/header/cstring",
+    "cppdoc": "cpp/library/headers/cstring"
+  },
+  {
+    "cppref": "cpp/header/any",
+    "cppdoc": "cpp/library/headers/any"
+  },
+  {
+    "cppref": "cpp/header/streambuf",
+    "cppdoc": "cpp/library/headers/streambuf"
+  },
+  {
+    "cppref": "cpp/header/thread",
+    "cppdoc": "cpp/library/headers/thread"
+  },
+  {
+    "cppref": "cpp/header/cstdarg",
+    "cppdoc": "cpp/library/headers/cstdarg"
+  },
+  {
+    "cppref": "cpp/header/csetjmp",
+    "cppdoc": "cpp/library/headers/csetjmp"
+  },
+  {
+    "cppref": "cpp/header/tuple",
+    "cppdoc": "cpp/library/headers/tuple"
+  },
+  {
+    "cppref": "cpp/header/ostream",
+    "cppdoc": "cpp/library/headers/ostream"
+  },
+  {
+    "cppref": "cpp/header/condition_variable",
+    "cppdoc": "cpp/library/headers/condition_variable"
+  },
+  {
+    "cppref": "cpp/header/numeric",
+    "cppdoc": "cpp/library/headers/numeric"
+  },
+  {
+    "cppref": "cpp/header/valarray",
+    "cppdoc": "cpp/library/headers/valarray"
+  },
+  {
+    "cppref": "cpp/header/stdatomic.h",
+    "cppdoc": "cpp/library/headers/stdatomic.h"
+  },
+  {
+    "cppref": "cpp/header/format",
+    "cppdoc": "cpp/library/headers/format"
+  },
+  {
+    "cppref": "cpp/header/variant",
+    "cppdoc": "cpp/library/headers/variant"
+  },
+  {
+    "cppref": "cpp/header/codecvt",
+    "cppdoc": "cpp/library/headers/codecvt"
+  },
+  {
+    "cppref": "cpp/header/list",
+    "cppdoc": "cpp/library/headers/list"
+  },
+  {
+    "cppref": "cpp/header/ratio",
+    "cppdoc": "cpp/library/headers/ratio"
+  },
+  {
+    "cppref": "cpp/header/barrier",
+    "cppdoc": "cpp/library/headers/barrier"
+  },
+  {
+    "cppref": "cpp/header/cfenv",
+    "cppdoc": "cpp/library/headers/cfenv"
+  },
+  {
+    "cppref": "cpp/header/cstdio",
+    "cppdoc": "cpp/library/headers/cstdio"
+  },
+  {
+    "cppref": "cpp/header/stdfloat",
+    "cppdoc": "cpp/library/headers/stdfloat"
+  },
+  {
+    "cppref": "cpp/header/regex",
+    "cppdoc": "cpp/library/headers/regex"
+  },
+  {
+    "cppref": "cpp/header/ccomplex",
+    "cppdoc": "cpp/library/headers/ccomplex"
+  },
+  {
+    "cppref": "cpp/header/string",
+    "cppdoc": "cpp/library/headers/string"
+  },
+  {
+    "cppref": "cpp/header/syncstream",
+    "cppdoc": "cpp/library/headers/syncstream"
+  },
+  {
+    "cppref": "cpp/header/cmath",
+    "cppdoc": "cpp/library/headers/cmath"
+  },
+  {
+    "cppref": "cpp/header/ciso646",
+    "cppdoc": "cpp/library/headers/ciso646"
+  },
+  {
+    "cppref": "cpp/header/filesystem",
+    "cppdoc": "cpp/library/headers/filesystem"
+  },
+  {
+    "cppref": "cpp/header/inplace_vector",
+    "cppdoc": "cpp/library/headers/inplace_vector"
+  },
+  {
+    "cppref": "cpp/header/clocale",
+    "cppdoc": "cpp/library/headers/clocale"
+  },
+  {
+    "cppref": "cpp/header/iostream",
+    "cppdoc": "cpp/library/headers/iostream"
+  },
+  {
+    "cppref": "cpp/header/iosfwd",
+    "cppdoc": "cpp/library/headers/iosfwd"
+  },
+  {
+    "cppref": "cpp/header/string_view",
+    "cppdoc": "cpp/library/headers/string_view"
+  },
+  {
+    "cppref": "cpp/header/bitset",
+    "cppdoc": "cpp/library/headers/bitset"
+  },
+  {
+    "cppref": "cpp/header/new",
+    "cppdoc": "cpp/library/headers/new"
+  },
+  {
+    "cppref": "cpp/header/linalg",
+    "cppdoc": "cpp/library/headers/linalg"
+  },
+  {
+    "cppref": "cpp/header/memory",
+    "cppdoc": "cpp/library/headers/memory"
+  },
+  {
+    "cppref": "cpp/header/coroutine",
+    "cppdoc": "cpp/library/headers/coroutine"
+  },
+  {
+    "cppref": "cpp/header/queue",
+    "cppdoc": "cpp/library/headers/queue"
+  },
+  {
+    "cppref": "cpp/header/flat_set",
+    "cppdoc": "cpp/library/headers/flat_set"
+  },
+  {
+    "cppref": "cpp/header/cstdalign",
+    "cppdoc": "cpp/library/headers/cstdalign"
+  },
+  {
+    "cppref": "cpp/header/array",
+    "cppdoc": "cpp/library/headers/array"
+  },
+  {
+    "cppref": "cpp/header/generator",
+    "cppdoc": "cpp/library/headers/generator"
+  },
+  {
+    "cppref": "cpp/header/ctgmath",
+    "cppdoc": "cpp/library/headers/ctgmath"
+  },
+  {
+    "cppref": "cpp/header/compare",
+    "cppdoc": "cpp/library/headers/compare"
+  },
+  {
+    "cppref": "cpp/header/simd",
+    "cppdoc": "cpp/library/headers/simd"
+  },
+  {
+    "cppref": "cpp/header/stacktrace",
+    "cppdoc": "cpp/library/headers/stacktrace"
+  },
+  {
+    "cppref": "cpp/header/text_encoding",
+    "cppdoc": "cpp/library/headers/text_encoding"
+  },
+  {
+    "cppref": "cpp/header/iterator",
+    "cppdoc": "cpp/library/headers/iterator"
+  },
+  {
+    "cppref": "cpp/header/experimental",
+    "cppdoc": "cpp/library/headers/experimental"
+  },
+  {
+    "cppref": "cpp/header/stop_token",
+    "cppdoc": "cpp/library/headers/stop_token"
+  },
+  {
+    "cppref": "cpp/header/charconv",
+    "cppdoc": "cpp/library/headers/charconv"
+  },
+  {
+    "cppref": "cpp/header/strstream",
+    "cppdoc": "cpp/library/headers/strstream"
+  },
+  {
+    "cppref": "cpp/header/fstream",
+    "cppdoc": "cpp/library/headers/fstream"
+  },
+  {
+    "cppref": "cpp/header/rcu",
+    "cppdoc": "cpp/library/headers/rcu"
+  },
+  {
+    "cppref": "cpp/header/type_traits",
+    "cppdoc": "cpp/library/headers/type_traits"
+  },
+  {
+    "cppref": "cpp/header/hazard_pointer",
+    "cppdoc": "cpp/library/headers/hazard_pointer"
+  },
+  {
+    "cppref": "cpp/header/bit",
+    "cppdoc": "cpp/library/headers/bit"
+  },
+  {
+    "cppref": "cpp/header/exception",
+    "cppdoc": "cpp/library/headers/exception"
+  },
+  {
+    "cppref": "cpp/header/cstdbool",
+    "cppdoc": "cpp/library/headers/cstdbool"
+  },
+  {
+    "cppref": "cpp/header/cfloat",
+    "cppdoc": "cpp/library/headers/cfloat"
+  },
+  {
+    "cppref": "cpp/header/climits",
+    "cppdoc": "cpp/library/headers/climits"
+  },
+  {
+    "cppref": "cpp/header/print",
+    "cppdoc": "cpp/library/headers/print"
+  },
+  {
+    "cppref": "cpp/header/system_error",
+    "cppdoc": "cpp/library/headers/system_error"
+  },
+  {
+    "cppref": "cpp/header/deque",
+    "cppdoc": "cpp/library/headers/deque"
+  },
+  {
+    "cppref": "cpp/header/cstdint",
+    "cppdoc": "cpp/library/headers/cstdint"
+  },
+  {
+    "cppref": "cpp/header/csignal",
+    "cppdoc": "cpp/library/headers/csignal"
+  },
+  {
+    "cppref": "cpp/header/chrono",
+    "cppdoc": "cpp/library/headers/chrono"
+  },
+  {
+    "cppref": "cpp/header/spanstream",
+    "cppdoc": "cpp/library/headers/spanstream"
+  },
+  {
+    "cppref": "cpp/header/ctime",
+    "cppdoc": "cpp/library/headers/ctime"
+  },
+  {
+    "cppref": "cpp/header/expected",
+    "cppdoc": "cpp/library/headers/expected"
+  },
+  {
+    "cppref": "cpp/header/version",
+    "cppdoc": "cpp/library/headers/version"
+  },
+  {
+    "cppref": "cpp/header/execution",
+    "cppdoc": "cpp/library/headers/execution"
+  },
+  {
+    "cppref": "cpp/header/map",
+    "cppdoc": "cpp/library/headers/map"
+  },
+  {
+    "cppref": "cpp/header/scoped_allocator",
+    "cppdoc": "cpp/library/headers/scoped_allocator"
+  },
+  {
+    "cppref": "cpp/header/semaphore",
+    "cppdoc": "cpp/library/headers/semaphore"
+  },
+  {
+    "cppref": "cpp/header/cstdlib",
+    "cppdoc": "cpp/library/headers/cstdlib"
+  },
+  {
+    "cppref": "cpp/header/cwchar",
+    "cppdoc": "cpp/library/headers/cwchar"
+  },
+  {
+    "cppref": "cpp/header/forward_list",
+    "cppdoc": "cpp/library/headers/forward_list"
+  },
+  {
+    "cppref": "cpp/header/cctype",
+    "cppdoc": "cpp/library/headers/cctype"
+  },
+  {
+    "cppref": "cpp/header/random",
+    "cppdoc": "cpp/library/headers/random"
+  },
+  {
+    "cppref": "cpp/header/sstream",
+    "cppdoc": "cpp/library/headers/sstream"
+  },
+  {
+    "cppref": "cpp/header/locale",
+    "cppdoc": "cpp/library/headers/locale"
+  },
+  {
+    "cppref": "cpp/header/shared_mutex",
+    "cppdoc": "cpp/library/headers/shared_mutex"
+  },
+  {
+    "cppref": "cpp/header/optional",
+    "cppdoc": "cpp/library/headers/optional"
+  },
+  {
+    "cppref": "cpp/header/concepts",
+    "cppdoc": "cpp/library/headers/concepts"
+  },
+  {
+    "cppref": "cpp/header/set",
+    "cppdoc": "cpp/library/headers/set"
+  },
+  {
+    "cppref": "cpp/header/algorithm",
+    "cppdoc": "cpp/library/headers/algorithm"
+  },
+  {
+    "cppref": "cpp/header/functional",
+    "cppdoc": "cpp/library/headers/functional"
+  },
+  {
+    "cppref": "cpp/header/complex",
+    "cppdoc": "cpp/library/headers/complex"
+  },
+  {
+    "cppref": "cpp/header/utility",
+    "cppdoc": "cpp/library/headers/utility"
+  },
+  {
+    "cppref": "cpp/header/cassert",
+    "cppdoc": "cpp/library/headers/cassert"
+  },
+  {
+    "cppref": "cpp/header/numbers",
+    "cppdoc": "cpp/library/headers/numbers"
+  },
+  {
+    "cppref": "cpp/header/flat_map",
+    "cppdoc": "cpp/library/headers/flat_map"
+  },
+  {
+    "cppref": "cpp/header/ios",
+    "cppdoc": "cpp/library/headers/ios"
+  },
+  {
+    "cppref": "cpp/header/vector",
+    "cppdoc": "cpp/library/headers/vector"
+  },
+  {
+    "cppref": "cpp/header/cstddef",
+    "cppdoc": "cpp/library/headers/cstddef"
+  },
+  {
+    "cppref": "cpp/header/memory_resource",
+    "cppdoc": "cpp/library/headers/memory_resource"
+  },
+  {
+    "cppref": "cpp/header/experimental/any",
+    "cppdoc": "cpp/library/headers/experimental/any"
+  },
+  {
+    "cppref": "cpp/header/experimental/filesystem",
+    "cppdoc": "cpp/library/headers/experimental/filesystem"
+  },
+  {
+    "cppref": "cpp/header/experimental/string_view",
+    "cppdoc": "cpp/library/headers/experimental/string_view"
+  },
+  {
+    "cppref": "cpp/header/experimental/simd",
+    "cppdoc": "cpp/library/headers/experimental/simd"
+  },
+  {
+    "cppref": "cpp/header/experimental/execution",
+    "cppdoc": "cpp/library/headers/experimental/execution"
+  },
+  {
+    "cppref": "cpp/header/experimental/reflect",
+    "cppdoc": "cpp/library/headers/experimental/reflect"
+  },
+  {
+    "cppref": "cpp/header/experimental/optional",
+    "cppdoc": "cpp/library/headers/experimental/optional"
+  },
+  {
+    "cppref": "cpp/header/experimental/functional",
+    "cppdoc": "cpp/library/headers/experimental/functional"
+  },
+  {
+    "cppref": "cpp/header/experimental/net",
+    "cppdoc": "cpp/library/headers/experimental/net"
+  },
+  {
+    "cppref": "cpp/header/experimental/memory_resource",
+    "cppdoc": "cpp/library/headers/experimental/memory_resource"
+  },
+  {
+    "cppref": "cpp/header/experimental/ranges/tuple",
+    "cppdoc": "cpp/library/headers/experimental/ranges/tuple"
+  },
+  {
+    "cppref": "cpp/header/experimental/ranges/range",
+    "cppdoc": "cpp/library/headers/range"
+  },
+  {
+    "cppref": "cpp/header/experimental/ranges/iterator",
+    "cppdoc": "cpp/library/headers/experimental/ranges/iterator"
+  },
+  {
+    "cppref": "cpp/header/experimental/ranges/type_traits",
+    "cppdoc": "cpp/library/headers/experimental/ranges/type_traits"
+  },
+  {
+    "cppref": "cpp/header/experimental/ranges/random",
+    "cppdoc": "cpp/library/headers/experimental/ranges/random"
+  },
+  {
+    "cppref": "cpp/header/experimental/ranges/concepts",
+    "cppdoc": "cpp/library/headers/experimental/ranges/concepts"
+  },
+  {
+    "cppref": "cpp/header/experimental/ranges/algorithm",
+    "cppdoc": "cpp/library/headers/experimental/ranges/algorithm"
+  },
+  {
+    "cppref": "cpp/header/experimental/ranges/functional",
+    "cppdoc": "cpp/library/headers/experimental/ranges/functional"
+  },
+  {
+    "cppref": "cpp/header/experimental/ranges/utility",
+    "cppdoc": "cpp/library/headers/experimental/ranges/utility"
+  },
+  {
+    "cppref": "cpp/named_req/BidirectionalIterator",
+    "cppdoc": "cpp/library/named_req/BidirectionalIterator"
+  },
+  {
+    "cppref": "cpp/named_req/MoveInsertable",
+    "cppdoc": "cpp/library/named_req/MoveInsertable"
+  },
+  {
+    "cppref": "cpp/named_req/TrivialType",
+    "cppdoc": "cpp/library/named_req/TrivialType"
+  },
+  {
+    "cppref": "cpp/named_req/ForwardIterator",
+    "cppdoc": "cpp/library/named_req/ForwardIterator"
+  },
+  {
+    "cppref": "cpp/named_req/AccessorPolicy",
+    "cppdoc": "cpp/library/named_req/AccessorPolicy"
+  },
+  {
+    "cppref": "cpp/named_req/Compare",
+    "cppdoc": "cpp/library/named_req/Compare"
+  },
+  {
+    "cppref": "cpp/named_req/DefaultInsertable",
+    "cppdoc": "cpp/library/named_req/DefaultInsertable"
+  },
+  {
+    "cppref": "cpp/named_req/StandardLayoutType",
+    "cppdoc": "cpp/library/named_req/StandardLayoutType"
+  },
+  {
+    "cppref": "cpp/named_req/SeedSequence",
+    "cppdoc": "cpp/library/named_req/SeedSequence"
+  },
+  {
+    "cppref": "cpp/named_req/FormattedInputFunction",
+    "cppdoc": "cpp/library/named_req/FormattedInputFunction"
+  },
+  {
+    "cppref": "cpp/named_req/MoveAssignable",
+    "cppdoc": "cpp/library/named_req/MoveAssignable"
+  },
+  {
+    "cppref": "cpp/named_req/RangeAdaptorObject",
+    "cppdoc": "cpp/library/named_req/RangeAdaptorObject"
+  },
+  {
+    "cppref": "cpp/named_req/Hash",
+    "cppdoc": "cpp/library/named_req/Hash"
+  },
+  {
+    "cppref": "cpp/named_req/LiteralType",
+    "cppdoc": "cpp/library/named_req/LiteralType"
+  },
+  {
+    "cppref": "cpp/named_req/ValueSwappable",
+    "cppdoc": "cpp/library/named_req/ValueSwappable"
+  },
+  {
+    "cppref": "cpp/named_req/Container",
+    "cppdoc": "cpp/library/named_req/Container"
+  },
+  {
+    "cppref": "cpp/named_req/PODType",
+    "cppdoc": "cpp/library/named_req/PODType"
+  },
+  {
+    "cppref": "cpp/named_req/SharedTimedLockable",
+    "cppdoc": "cpp/library/named_req/SharedTimedLockable"
+  },
+  {
+    "cppref": "cpp/named_req/BinaryPredicate",
+    "cppdoc": "cpp/library/named_req/BinaryPredicate"
+  },
+  {
+    "cppref": "cpp/named_req/BooleanTestable",
+    "cppdoc": "cpp/library/named_req/BooleanTestable"
+  },
+  {
+    "cppref": "cpp/named_req/ContiguousContainer",
+    "cppdoc": "cpp/library/named_req/ContiguousContainer"
+  },
+  {
+    "cppref": "cpp/named_req/CopyConstructible",
+    "cppdoc": "cpp/library/named_req/CopyConstructible"
+  },
+  {
+    "cppref": "cpp/named_req/Allocator",
+    "cppdoc": "cpp/library/named_req/Allocator"
+  },
+  {
+    "cppref": "cpp/named_req/FormattedOutputFunction",
+    "cppdoc": "cpp/library/named_req/FormattedOutputFunction"
+  },
+  {
+    "cppref": "cpp/named_req/LayoutMapping",
+    "cppdoc": "cpp/library/named_req/LayoutMapping"
+  },
+  {
+    "cppref": "cpp/named_req/UniformRandomBitGenerator",
+    "cppdoc": "cpp/library/named_req/UniformRandomBitGenerator"
+  },
+  {
+    "cppref": "cpp/named_req/RandomAccessIterator",
+    "cppdoc": "cpp/library/named_req/RandomAccessIterator"
+  },
+  {
+    "cppref": "cpp/named_req/AllocatorAwareContainer",
+    "cppdoc": "cpp/library/named_req/AllocatorAwareContainer"
+  },
+  {
+    "cppref": "cpp/named_req/EqualityComparable",
+    "cppdoc": "cpp/library/named_req/EqualityComparable"
+  },
+  {
+    "cppref": "cpp/named_req/Destructible",
+    "cppdoc": "cpp/library/named_req/Destructible"
+  },
+  {
+    "cppref": "cpp/named_req/Erasable",
+    "cppdoc": "cpp/library/named_req/Erasable"
+  },
+  {
+    "cppref": "cpp/named_req/RandomNumberEngineAdaptor",
+    "cppdoc": "cpp/library/named_req/RandomNumberEngineAdaptor"
+  },
+  {
+    "cppref": "cpp/named_req/TransformationTrait",
+    "cppdoc": "cpp/library/named_req/TransformationTrait"
+  },
+  {
+    "cppref": "cpp/named_req/Predicate",
+    "cppdoc": "cpp/library/named_req/Predicate"
+  },
+  {
+    "cppref": "cpp/named_req/UnaryTypeTrait",
+    "cppdoc": "cpp/library/named_req/UnaryTypeTrait"
+  },
+  {
+    "cppref": "cpp/named_req/Callable",
+    "cppdoc": "cpp/library/named_req/Callable"
+  },
+  {
+    "cppref": "cpp/named_req/Lockable",
+    "cppdoc": "cpp/library/named_req/Lockable"
+  },
+  {
+    "cppref": "cpp/named_req/BitmaskType",
+    "cppdoc": "cpp/library/named_req/BitmaskType"
+  },
+  {
+    "cppref": "cpp/named_req/ScalarType",
+    "cppdoc": "cpp/library/named_req/ScalarType"
+  },
+  {
+    "cppref": "cpp/named_req/TriviallyCopyable",
+    "cppdoc": "cpp/library/named_req/TriviallyCopyable"
+  },
+  {
+    "cppref": "cpp/named_req/ReversibleContainer",
+    "cppdoc": "cpp/library/named_req/ReversibleContainer"
+  },
+  {
+    "cppref": "cpp/named_req/Formatter",
+    "cppdoc": "cpp/library/named_req/Formatter"
+  },
+  {
+    "cppref": "cpp/named_req/ConstexprIterator",
+    "cppdoc": "cpp/library/named_req/ConstexprIterator"
+  },
+  {
+    "cppref": "cpp/named_req/RandomNumberEngine",
+    "cppdoc": "cpp/library/named_req/RandomNumberEngine"
+  },
+  {
+    "cppref": "cpp/named_req/CharTraits",
+    "cppdoc": "cpp/library/named_req/CharTraits"
+  },
+  {
+    "cppref": "cpp/named_req/SequenceContainer",
+    "cppdoc": "cpp/library/named_req/SequenceContainer"
+  },
+  {
+    "cppref": "cpp/named_req/NumericType",
+    "cppdoc": "cpp/library/named_req/NumericType"
+  },
+  {
+    "cppref": "cpp/named_req/UnformattedOutputFunction",
+    "cppdoc": "cpp/library/named_req/UnformattedOutputFunction"
+  },
+  {
+    "cppref": "cpp/named_req/ContiguousIterator",
+    "cppdoc": "cpp/library/named_req/ContiguousIterator"
+  },
+  {
+    "cppref": "cpp/named_req/SharedMutex",
+    "cppdoc": "cpp/library/named_req/SharedMutex"
+  },
+  {
+    "cppref": "cpp/named_req/TimedMutex",
+    "cppdoc": "cpp/library/named_req/TimedMutex"
+  },
+  {
+    "cppref": "cpp/named_req/TimedLockable",
+    "cppdoc": "cpp/library/named_req/TimedLockable"
+  },
+  {
+    "cppref": "cpp/named_req/LessThanComparable",
+    "cppdoc": "cpp/library/named_req/LessThanComparable"
+  },
+  {
+    "cppref": "cpp/named_req/SharedLockable",
+    "cppdoc": "cpp/library/named_req/SharedLockable"
+  },
+  {
+    "cppref": "cpp/named_req/Clock",
+    "cppdoc": "cpp/library/named_req/Clock"
+  },
+  {
+    "cppref": "cpp/named_req/BasicFormatter",
+    "cppdoc": "cpp/library/named_req/BasicFormatter"
+  },
+  {
+    "cppref": "cpp/named_req/CopyAssignable",
+    "cppdoc": "cpp/library/named_req/CopyAssignable"
+  },
+  {
+    "cppref": "cpp/named_req/EmplaceConstructible",
+    "cppdoc": "cpp/library/named_req/EmplaceConstructible"
+  },
+  {
+    "cppref": "cpp/named_req/CopyInsertable",
+    "cppdoc": "cpp/library/named_req/CopyInsertable"
+  },
+  {
+    "cppref": "cpp/named_req/UnformattedInputFunction",
+    "cppdoc": "cpp/library/named_req/UnformattedInputFunction"
+  },
+  {
+    "cppref": "cpp/named_req/ImplicitLifetimeType",
+    "cppdoc": "cpp/library/named_req/ImplicitLifetimeType"
+  },
+  {
+    "cppref": "cpp/named_req/RandomNumberDistribution",
+    "cppdoc": "cpp/library/named_req/RandomNumberDistribution"
+  },
+  {
+    "cppref": "cpp/named_req/RegexTraits",
+    "cppdoc": "cpp/library/named_req/RegexTraits"
+  },
+  {
+    "cppref": "cpp/named_req/LayoutMappingPolicy",
+    "cppdoc": "cpp/library/named_req/LayoutMappingPolicy"
+  },
+  {
+    "cppref": "cpp/named_req/UnorderedAssociativeContainer",
+    "cppdoc": "cpp/library/named_req/UnorderedAssociativeContainer"
+  },
+  {
+    "cppref": "cpp/named_req/BinaryTypeTrait",
+    "cppdoc": "cpp/library/named_req/BinaryTypeTrait"
+  },
+  {
+    "cppref": "cpp/named_req/SharedTimedMutex",
+    "cppdoc": "cpp/library/named_req/SharedTimedMutex"
+  },
+  {
+    "cppref": "cpp/named_req/AssociativeContainer",
+    "cppdoc": "cpp/library/named_req/AssociativeContainer"
+  },
+  {
+    "cppref": "cpp/named_req/InputIterator",
+    "cppdoc": "cpp/library/named_req/InputIterator"
+  },
+  {
+    "cppref": "cpp/named_req/RangeAdaptorClosureObject",
+    "cppdoc": "cpp/library/named_req/RangeAdaptorClosureObject"
+  },
+  {
+    "cppref": "cpp/named_req/Swappable",
+    "cppdoc": "cpp/library/named_req/Swappable"
+  },
+  {
+    "cppref": "cpp/named_req/Mutex",
+    "cppdoc": "cpp/library/named_req/Mutex"
+  },
+  {
+    "cppref": "cpp/named_req/Iterator",
+    "cppdoc": "cpp/library/named_req/Iterator"
+  },
+  {
+    "cppref": "cpp/named_req/MoveConstructible",
+    "cppdoc": "cpp/library/named_req/MoveConstructible"
+  },
+  {
+    "cppref": "cpp/named_req/TrivialClock",
+    "cppdoc": "cpp/library/named_req/TrivialClock"
+  },
+  {
+    "cppref": "cpp/named_req/DefaultConstructible",
+    "cppdoc": "cpp/library/named_req/DefaultConstructible"
+  },
+  {
+    "cppref": "cpp/named_req/OutputIterator",
+    "cppdoc": "cpp/library/named_req/OutputIterator"
+  },
+  {
+    "cppref": "cpp/named_req/BasicLockable",
+    "cppdoc": "cpp/library/named_req/BasicLockable"
+  },
+  {
+    "cppref": "cpp/named_req/FunctionObject",
+    "cppdoc": "cpp/library/named_req/FunctionObject"
+  },
+  {
+    "cppref": "cpp/named_req/NullablePointer",
+    "cppdoc": "cpp/library/named_req/NullablePointer"
+  },
+  {
+    "cppref": "cpp/locale/time_put",
+    "cppdoc": "cpp/library/text/locale/time_put"
+  },
+  {
+    "cppref": "cpp/locale/num_put",
+    "cppdoc": "cpp/library/text/locale/num_put"
+  },
+  {
+    "cppref": "cpp/locale/ctype_byname",
+    "cppdoc": "cpp/library/text/locale/ctype_byname"
+  },
+  {
+    "cppref": "cpp/locale/islower",
+    "cppdoc": "cpp/library/text/locale/islower"
+  },
+  {
+    "cppref": "cpp/locale/iscntrl",
+    "cppdoc": "cpp/library/text/locale/iscntrl"
+  },
+  {
+    "cppref": "cpp/locale/codecvt_base",
+    "cppdoc": "cpp/library/text/locale/codecvt_base"
+  },
+  {
+    "cppref": "cpp/locale/toupper",
+    "cppdoc": "cpp/library/text/locale/toupper"
+  },
+  {
+    "cppref": "cpp/locale/isprint",
+    "cppdoc": "cpp/library/text/locale/isprint"
+  },
+  {
+    "cppref": "cpp/locale/collate_byname",
+    "cppdoc": "cpp/library/text/locale/collate_byname"
+  },
+  {
+    "cppref": "cpp/locale/LC_categories",
+    "cppdoc": "cpp/library/text/locale/LC_categories"
+  },
+  {
+    "cppref": "cpp/locale/localeconv",
+    "cppdoc": "cpp/library/text/locale/localeconv"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct",
+    "cppdoc": "cpp/library/text/locale/moneypunct"
+  },
+  {
+    "cppref": "cpp/locale/messages",
+    "cppdoc": "cpp/library/text/locale/messages"
+  },
+  {
+    "cppref": "cpp/locale/money_put",
+    "cppdoc": "cpp/library/text/locale/money_put"
+  },
+  {
+    "cppref": "cpp/locale/ctype",
+    "cppdoc": "cpp/library/text/locale/ctype"
+  },
+  {
+    "cppref": "cpp/locale/codecvt_byname",
+    "cppdoc": "cpp/library/text/locale/codecvt_byname"
+  },
+  {
+    "cppref": "cpp/locale/money_base",
+    "cppdoc": "cpp/library/text/locale/money_base"
+  },
+  {
+    "cppref": "cpp/locale/codecvt",
+    "cppdoc": "cpp/library/text/locale/codecvt"
+  },
+  {
+    "cppref": "cpp/locale/codecvt_utf8_utf16",
+    "cppdoc": "cpp/library/text/locale/codecvt_utf8_utf16"
+  },
+  {
+    "cppref": "cpp/locale/setlocale",
+    "cppdoc": "cpp/library/text/locale/setlocale"
+  },
+  {
+    "cppref": "cpp/locale/isalpha",
+    "cppdoc": "cpp/library/text/locale/isalpha"
+  },
+  {
+    "cppref": "cpp/locale/codecvt_utf16",
+    "cppdoc": "cpp/library/text/locale/codecvt_utf16"
+  },
+  {
+    "cppref": "cpp/locale/time_get_byname",
+    "cppdoc": "cpp/library/text/locale/time_get_byname"
+  },
+  {
+    "cppref": "cpp/locale/codecvt_mode",
+    "cppdoc": "cpp/library/text/locale/codecvt_mode"
+  },
+  {
+    "cppref": "cpp/locale/wstring_convert",
+    "cppdoc": "cpp/library/text/locale/wstring_convert"
+  },
+  {
+    "cppref": "cpp/locale/ispunct",
+    "cppdoc": "cpp/library/text/locale/ispunct"
+  },
+  {
+    "cppref": "cpp/locale/lconv",
+    "cppdoc": "cpp/library/text/locale/lconv"
+  },
+  {
+    "cppref": "cpp/locale/wbuffer_convert",
+    "cppdoc": "cpp/library/text/locale/wbuffer_convert"
+  },
+  {
+    "cppref": "cpp/locale/time_base",
+    "cppdoc": "cpp/library/text/locale/time_base"
+  },
+  {
+    "cppref": "cpp/locale/messages_base",
+    "cppdoc": "cpp/library/text/locale/messages_base"
+  },
+  {
+    "cppref": "cpp/locale/num_get",
+    "cppdoc": "cpp/library/text/locale/num_get"
+  },
+  {
+    "cppref": "cpp/locale/numpunct_byname",
+    "cppdoc": "cpp/library/text/locale/numpunct_byname"
+  },
+  {
+    "cppref": "cpp/locale/ctype_char",
+    "cppdoc": "cpp/library/text/locale/ctype_char"
+  },
+  {
+    "cppref": "cpp/locale/text_encoding",
+    "cppdoc": "cpp/library/text/text_encoding"
+  },
+  {
+    "cppref": "cpp/locale/isdigit",
+    "cppdoc": "cpp/library/text/locale/isdigit"
+  },
+  {
+    "cppref": "cpp/locale/isspace",
+    "cppdoc": "cpp/library/text/locale/isspace"
+  },
+  {
+    "cppref": "cpp/locale/collate",
+    "cppdoc": "cpp/library/text/locale/collate"
+  },
+  {
+    "cppref": "cpp/locale/money_get",
+    "cppdoc": "cpp/library/text/locale/money_get"
+  },
+  {
+    "cppref": "cpp/locale/ctype_base",
+    "cppdoc": "cpp/library/text/locale/ctype_base"
+  },
+  {
+    "cppref": "cpp/locale/codecvt_utf8",
+    "cppdoc": "cpp/library/text/locale/codecvt_utf8"
+  },
+  {
+    "cppref": "cpp/locale/messages_byname",
+    "cppdoc": "cpp/library/text/locale/messages_byname"
+  },
+  {
+    "cppref": "cpp/locale/time_get",
+    "cppdoc": "cpp/library/text/locale/time_get"
+  },
+  {
+    "cppref": "cpp/locale/numpunct",
+    "cppdoc": "cpp/library/text/locale/numpunct"
+  },
+  {
+    "cppref": "cpp/locale/isxdigit",
+    "cppdoc": "cpp/library/text/locale/isxdigit"
+  },
+  {
+    "cppref": "cpp/locale/has_facet",
+    "cppdoc": "cpp/library/text/locale/has_facet"
+  },
+  {
+    "cppref": "cpp/locale/locale",
+    "cppdoc": "cpp/library/text/locale/locale"
+  },
+  {
+    "cppref": "cpp/locale/use_facet",
+    "cppdoc": "cpp/library/text/locale/use_facet"
+  },
+  {
+    "cppref": "cpp/locale/isgraph",
+    "cppdoc": "cpp/library/text/locale/isgraph"
+  },
+  {
+    "cppref": "cpp/locale/time_put_byname",
+    "cppdoc": "cpp/library/text/locale/time_put_byname"
+  },
+  {
+    "cppref": "cpp/locale/tolower",
+    "cppdoc": "cpp/library/text/locale/tolower"
+  },
+  {
+    "cppref": "cpp/locale/isblank",
+    "cppdoc": "cpp/library/text/locale/isblank"
+  },
+  {
+    "cppref": "cpp/locale/isalnum",
+    "cppdoc": "cpp/library/text/locale/isalnum"
+  },
+  {
+    "cppref": "cpp/locale/isupper",
+    "cppdoc": "cpp/library/text/locale/isupper"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct_byname",
+    "cppdoc": "cpp/library/text/locale/moneypunct_byname"
+  },
+  {
+    "cppref": "cpp/locale/money_put/money_put",
+    "cppdoc": "cpp/library/text/locale/money_put/money_put"
+  },
+  {
+    "cppref": "cpp/locale/money_put/put",
+    "cppdoc": "cpp/library/text/locale/money_put/put"
+  },
+  {
+    "cppref": "cpp/locale/money_put/~money_put",
+    "cppdoc": "cpp/library/text/locale/money_put/~money_put"
+  },
+  {
+    "cppref": "cpp/locale/messages/messages",
+    "cppdoc": "cpp/library/text/locale/messages/messages"
+  },
+  {
+    "cppref": "cpp/locale/messages/get",
+    "cppdoc": "cpp/library/text/locale/messages/get"
+  },
+  {
+    "cppref": "cpp/locale/messages/close",
+    "cppdoc": "cpp/library/text/locale/messages/close"
+  },
+  {
+    "cppref": "cpp/locale/messages/~messages",
+    "cppdoc": "cpp/library/text/locale/messages/~messages"
+  },
+  {
+    "cppref": "cpp/locale/messages/open",
+    "cppdoc": "cpp/library/text/locale/messages/open"
+  },
+  {
+    "cppref": "cpp/locale/locale/global",
+    "cppdoc": "cpp/library/text/locale/locale/global"
+  },
+  {
+    "cppref": "cpp/locale/locale/~locale",
+    "cppdoc": "cpp/library/text/locale/locale/~locale"
+  },
+  {
+    "cppref": "cpp/locale/locale/combine",
+    "cppdoc": "cpp/library/text/locale/locale/combine"
+  },
+  {
+    "cppref": "cpp/locale/locale/id",
+    "cppdoc": "cpp/library/text/locale/locale/id"
+  },
+  {
+    "cppref": "cpp/locale/locale/operator()",
+    "cppdoc": "cpp/library/text/locale/locale/operator()"
+  },
+  {
+    "cppref": "cpp/locale/locale/classic",
+    "cppdoc": "cpp/library/text/locale/locale/classic"
+  },
+  {
+    "cppref": "cpp/locale/locale/name",
+    "cppdoc": "cpp/library/text/locale/locale/name"
+  },
+  {
+    "cppref": "cpp/locale/locale/operator_cmp",
+    "cppdoc": "cpp/library/text/locale/locale/operator_cmp"
+  },
+  {
+    "cppref": "cpp/locale/locale/encoding",
+    "cppdoc": "cpp/library/text/locale/locale/encoding"
+  },
+  {
+    "cppref": "cpp/locale/locale/facet",
+    "cppdoc": "cpp/library/text/locale/locale/facet"
+  },
+  {
+    "cppref": "cpp/locale/locale/operator=",
+    "cppdoc": "cpp/library/text/locale/locale/operator="
+  },
+  {
+    "cppref": "cpp/locale/locale/locale",
+    "cppdoc": "cpp/library/text/locale/locale/locale"
+  },
+  {
+    "cppref": "cpp/locale/locale/facet/facet",
+    "cppdoc": "cpp/library/text/locale/locale/facet/facet"
+  },
+  {
+    "cppref": "cpp/locale/locale/id/id",
+    "cppdoc": "cpp/library/text/locale/locale/id/id"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct/pos_format",
+    "cppdoc": "cpp/library/text/locale/moneypunct/pos_format"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct/moneypunct",
+    "cppdoc": "cpp/library/text/locale/moneypunct/moneypunct"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct/grouping",
+    "cppdoc": "cpp/library/text/locale/moneypunct/grouping"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct/~moneypunct",
+    "cppdoc": "cpp/library/text/locale/moneypunct/~moneypunct"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct/positive_sign",
+    "cppdoc": "cpp/library/text/locale/moneypunct/positive_sign"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct/thousands_sep",
+    "cppdoc": "cpp/library/text/locale/moneypunct/thousands_sep"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct/decimal_point",
+    "cppdoc": "cpp/library/text/locale/moneypunct/decimal_point"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct/frac_digits",
+    "cppdoc": "cpp/library/text/locale/moneypunct/frac_digits"
+  },
+  {
+    "cppref": "cpp/locale/moneypunct/curr_symbol",
+    "cppdoc": "cpp/library/text/locale/moneypunct/curr_symbol"
+  },
+  {
+    "cppref": "cpp/locale/numpunct/grouping",
+    "cppdoc": "cpp/library/text/locale/numpunct/grouping"
+  },
+  {
+    "cppref": "cpp/locale/numpunct/~numpunct",
+    "cppdoc": "cpp/library/text/locale/numpunct/~numpunct"
+  },
+  {
+    "cppref": "cpp/locale/numpunct/thousands_sep",
+    "cppdoc": "cpp/library/text/locale/numpunct/thousands_sep"
+  },
+  {
+    "cppref": "cpp/locale/numpunct/decimal_point",
+    "cppdoc": "cpp/library/text/locale/numpunct/decimal_point"
+  },
+  {
+    "cppref": "cpp/locale/numpunct/numpunct",
+    "cppdoc": "cpp/library/text/locale/numpunct/numpunct"
+  },
+  {
+    "cppref": "cpp/locale/numpunct/truefalsename",
+    "cppdoc": "cpp/library/text/locale/numpunct/truefalsename"
+  },
+  {
+    "cppref": "cpp/locale/ctype_char/classic_table",
+    "cppdoc": "cpp/library/text/locale/ctype/../ctype_char/classic_table"
+  },
+  {
+    "cppref": "cpp/locale/ctype_char/ctype",
+    "cppdoc": "cpp/library/text/locale/ctype/../ctype_char/ctype"
+  },
+  {
+    "cppref": "cpp/locale/ctype_char/~ctype",
+    "cppdoc": "cpp/library/text/locale/ctype/../ctype_char/~ctype"
+  },
+  {
+    "cppref": "cpp/locale/ctype_char/scan_is",
+    "cppdoc": "cpp/library/text/locale/ctype/../ctype_char/scan_is"
+  },
+  {
+    "cppref": "cpp/locale/ctype_char/is",
+    "cppdoc": "cpp/library/text/locale/ctype/../ctype_char/is"
+  },
+  {
+    "cppref": "cpp/locale/ctype_char/table",
+    "cppdoc": "cpp/library/text/locale/ctype/../ctype_char/table"
+  },
+  {
+    "cppref": "cpp/locale/ctype_char/scan_not",
+    "cppdoc": "cpp/library/text/locale/ctype/../ctype_char/scan_not"
+  },
+  {
+    "cppref": "cpp/locale/collate/hash",
+    "cppdoc": "cpp/library/text/locale/collate/hash"
+  },
+  {
+    "cppref": "cpp/locale/collate/compare",
+    "cppdoc": "cpp/library/text/locale/collate/compare"
+  },
+  {
+    "cppref": "cpp/locale/collate/collate",
+    "cppdoc": "cpp/library/text/locale/collate/collate"
+  },
+  {
+    "cppref": "cpp/locale/collate/transform",
+    "cppdoc": "cpp/library/text/locale/collate/transform"
+  },
+  {
+    "cppref": "cpp/locale/collate/~collate",
+    "cppdoc": "cpp/library/text/locale/collate/~collate"
+  },
+  {
+    "cppref": "cpp/locale/codecvt/out",
+    "cppdoc": "cpp/library/text/locale/codecvt/out"
+  },
+  {
+    "cppref": "cpp/locale/codecvt/codecvt",
+    "cppdoc": "cpp/library/text/locale/codecvt/codecvt"
+  },
+  {
+    "cppref": "cpp/locale/codecvt/~codecvt",
+    "cppdoc": "cpp/library/text/locale/codecvt/~codecvt"
+  },
+  {
+    "cppref": "cpp/locale/codecvt/in",
+    "cppdoc": "cpp/library/text/locale/codecvt/in"
+  },
+  {
+    "cppref": "cpp/locale/codecvt/unshift",
+    "cppdoc": "cpp/library/text/locale/codecvt/unshift"
+  },
+  {
+    "cppref": "cpp/locale/codecvt/max_length",
+    "cppdoc": "cpp/library/text/locale/codecvt/max_length"
+  },
+  {
+    "cppref": "cpp/locale/codecvt/always_noconv",
+    "cppdoc": "cpp/library/text/locale/codecvt/always_noconv"
+  },
+  {
+    "cppref": "cpp/locale/codecvt/length",
+    "cppdoc": "cpp/library/text/locale/codecvt/length"
+  },
+  {
+    "cppref": "cpp/locale/codecvt/encoding",
+    "cppdoc": "cpp/library/text/locale/codecvt/encoding"
+  },
+  {
+    "cppref": "cpp/locale/num_put/num_put",
+    "cppdoc": "cpp/library/text/locale/num_put/num_put"
+  },
+  {
+    "cppref": "cpp/locale/num_put/put",
+    "cppdoc": "cpp/library/text/locale/num_put/put"
+  },
+  {
+    "cppref": "cpp/locale/num_put/~num_put",
+    "cppdoc": "cpp/library/text/locale/num_put/~num_put"
+  },
+  {
+    "cppref": "cpp/locale/num_get/num_get",
+    "cppdoc": "cpp/library/text/locale/num_get/num_get"
+  },
+  {
+    "cppref": "cpp/locale/num_get/get",
+    "cppdoc": "cpp/library/text/locale/num_get/get"
+  },
+  {
+    "cppref": "cpp/locale/num_get/~num_get",
+    "cppdoc": "cpp/library/text/locale/num_get/~num_get"
+  },
+  {
+    "cppref": "cpp/locale/money_get/~money_get",
+    "cppdoc": "cpp/library/text/locale/money_get/~money_get"
+  },
+  {
+    "cppref": "cpp/locale/money_get/get",
+    "cppdoc": "cpp/library/text/locale/money_get/get"
+  },
+  {
+    "cppref": "cpp/locale/money_get/money_get",
+    "cppdoc": "cpp/library/text/locale/money_get/money_get"
+  },
+  {
+    "cppref": "cpp/locale/time_get/get_time",
+    "cppdoc": "cpp/library/text/locale/time_get/get_time"
+  },
+  {
+    "cppref": "cpp/locale/time_get/date_order",
+    "cppdoc": "cpp/library/text/locale/time_get/date_order"
+  },
+  {
+    "cppref": "cpp/locale/time_get/get_monthname",
+    "cppdoc": "cpp/library/text/locale/time_get/get_monthname"
+  },
+  {
+    "cppref": "cpp/locale/time_get/get_weekday",
+    "cppdoc": "cpp/library/text/locale/time_get/get_weekday"
+  },
+  {
+    "cppref": "cpp/locale/time_get/get_year",
+    "cppdoc": "cpp/library/text/locale/time_get/get_year"
+  },
+  {
+    "cppref": "cpp/locale/time_get/get",
+    "cppdoc": "cpp/library/text/locale/time_get/get"
+  },
+  {
+    "cppref": "cpp/locale/time_get/~time_get",
+    "cppdoc": "cpp/library/text/locale/time_get/~time_get"
+  },
+  {
+    "cppref": "cpp/locale/time_get/get_date",
+    "cppdoc": "cpp/library/text/locale/time_get/get_date"
+  },
+  {
+    "cppref": "cpp/locale/time_get/time_get",
+    "cppdoc": "cpp/library/text/locale/time_get/time_get"
+  },
+  {
+    "cppref": "cpp/locale/ctype/toupper",
+    "cppdoc": "cpp/library/text/locale/ctype/toupper"
+  },
+  {
+    "cppref": "cpp/locale/ctype/ctype",
+    "cppdoc": "cpp/library/text/locale/ctype/ctype"
+  },
+  {
+    "cppref": "cpp/locale/ctype/~ctype",
+    "cppdoc": "cpp/library/text/locale/ctype/~ctype"
+  },
+  {
+    "cppref": "cpp/locale/ctype/scan_is",
+    "cppdoc": "cpp/library/text/locale/ctype/scan_is"
+  },
+  {
+    "cppref": "cpp/locale/ctype/narrow",
+    "cppdoc": "cpp/library/text/locale/ctype/narrow"
+  },
+  {
+    "cppref": "cpp/locale/ctype/is",
+    "cppdoc": "cpp/library/text/locale/ctype/is"
+  },
+  {
+    "cppref": "cpp/locale/ctype/widen",
+    "cppdoc": "cpp/library/text/locale/ctype/widen"
+  },
+  {
+    "cppref": "cpp/locale/ctype/scan_not",
+    "cppdoc": "cpp/library/text/locale/ctype/scan_not"
+  },
+  {
+    "cppref": "cpp/locale/ctype/tolower",
+    "cppdoc": "cpp/library/text/locale/ctype/tolower"
+  },
+  {
+    "cppref": "cpp/locale/wstring_convert/from_bytes",
+    "cppdoc": "cpp/library/text/locale/wstring_convert/from_bytes"
+  },
+  {
+    "cppref": "cpp/locale/wstring_convert/wstring_convert",
+    "cppdoc": "cpp/library/text/locale/wstring_convert/wstring_convert"
+  },
+  {
+    "cppref": "cpp/locale/wstring_convert/converted",
+    "cppdoc": "cpp/library/text/locale/wstring_convert/converted"
+  },
+  {
+    "cppref": "cpp/locale/wstring_convert/~wstring_convert",
+    "cppdoc": "cpp/library/text/locale/wstring_convert/~wstring_convert"
+  },
+  {
+    "cppref": "cpp/locale/wstring_convert/to_bytes",
+    "cppdoc": "cpp/library/text/locale/wstring_convert/to_bytes"
+  },
+  {
+    "cppref": "cpp/locale/wstring_convert/state",
+    "cppdoc": "cpp/library/text/locale/wstring_convert/state"
+  },
+  {
+    "cppref": "cpp/locale/wbuffer_convert/wbuffer_convert",
+    "cppdoc": "cpp/library/text/locale/wbuffer_convert/wbuffer_convert"
+  },
+  {
+    "cppref": "cpp/locale/wbuffer_convert/~wbuffer_convert",
+    "cppdoc": "cpp/library/text/locale/wbuffer_convert/~wbuffer_convert"
+  },
+  {
+    "cppref": "cpp/locale/wbuffer_convert/rdbuf",
+    "cppdoc": "cpp/library/text/locale/wbuffer_convert/rdbuf"
+  },
+  {
+    "cppref": "cpp/locale/wbuffer_convert/state",
+    "cppdoc": "cpp/library/text/locale/wbuffer_convert/state"
+  },
+  {
+    "cppref": "cpp/locale/time_put/time_put",
+    "cppdoc": "cpp/library/text/locale/time_put/time_put"
+  },
+  {
+    "cppref": "cpp/locale/time_put/put",
+    "cppdoc": "cpp/library/text/locale/time_put/put"
+  },
+  {
+    "cppref": "cpp/locale/time_put/~time_put",
+    "cppdoc": "cpp/library/text/locale/time_put/~time_put"
+  },
+  {
+    "cppref": "cpp/text/text_encoding",
+    "cppdoc": "cpp/library/text/text_encoding"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/operator_eq",
+    "cppdoc": "cpp/library/text/text_encoding/operator_eq"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/hash",
+    "cppdoc": "cpp/library/text/text_encoding/hash"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/aliases",
+    "cppdoc": "cpp/library/text/text_encoding/aliases"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/comp-name",
+    "cppdoc": "cpp/library/text/text_encoding/comp-name"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/mib",
+    "cppdoc": "cpp/library/text/text_encoding/mib"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/id",
+    "cppdoc": "cpp/library/text/text_encoding/id"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/environment",
+    "cppdoc": "cpp/library/text/text_encoding/environment"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/name",
+    "cppdoc": "cpp/library/text/text_encoding/name"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/environment_is",
+    "cppdoc": "cpp/library/text/text_encoding/environment_is"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/literal",
+    "cppdoc": "cpp/library/text/text_encoding/literal"
+  },
+  {
+    "cppref": "cpp/text/text_encoding/aliases_view",
+    "cppdoc": "cpp/library/text/text_encoding/aliases_view"
+  },
+  {
+    "cppref": "cpp/string/byte",
+    "cppdoc": "cpp/library/text/byte"
+  },
+  {
+    "cppref": "cpp/string/basic_string",
+    "cppdoc": "cpp/library/string/basic_string"
+  },
+  {
+    "cppref": "cpp/string/multibyte",
+    "cppdoc": "cpp/library/text/multibyte"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view",
+    "cppdoc": "cpp/library/string/basic_string_view"
+  },
+  {
+    "cppref": "cpp/string/char_traits",
+    "cppdoc": "cpp/library/string/char_traits"
+  },
+  {
+    "cppref": "cpp/string/wide",
+    "cppdoc": "cpp/library/text/wide"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mbsinit",
+    "cppdoc": "cpp/library/text/multibyte/mbsinit"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mbrtoc16",
+    "cppdoc": "cpp/library/text/multibyte/mbrtoc16"
+  },
+  {
+    "cppref": "cpp/string/multibyte/wctomb",
+    "cppdoc": "cpp/library/text/multibyte/wctomb"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mbstate_t",
+    "cppdoc": "cpp/library/text/multibyte/mbstate_t"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mbtowc",
+    "cppdoc": "cpp/library/text/multibyte/mbtowc"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mbrtoc32",
+    "cppdoc": "cpp/library/text/multibyte/mbrtoc32"
+  },
+  {
+    "cppref": "cpp/string/multibyte/wcsrtombs",
+    "cppdoc": "cpp/library/text/multibyte/wcsrtombs"
+  },
+  {
+    "cppref": "cpp/string/multibyte/wcrtomb",
+    "cppdoc": "cpp/library/text/multibyte/wcrtomb"
+  },
+  {
+    "cppref": "cpp/string/multibyte/wctob",
+    "cppdoc": "cpp/library/text/multibyte/wctob"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mbrlen",
+    "cppdoc": "cpp/library/text/multibyte/mbrlen"
+  },
+  {
+    "cppref": "cpp/string/multibyte/c32rtomb",
+    "cppdoc": "cpp/library/text/multibyte/c32rtomb"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mbrtowc",
+    "cppdoc": "cpp/library/text/multibyte/mbrtowc"
+  },
+  {
+    "cppref": "cpp/string/multibyte/c16rtomb",
+    "cppdoc": "cpp/library/text/multibyte/c16rtomb"
+  },
+  {
+    "cppref": "cpp/string/multibyte/btowc",
+    "cppdoc": "cpp/library/text/multibyte/btowc"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mbstowcs",
+    "cppdoc": "cpp/library/text/multibyte/mbstowcs"
+  },
+  {
+    "cppref": "cpp/string/multibyte/wcstombs",
+    "cppdoc": "cpp/library/text/multibyte/wcstombs"
+  },
+  {
+    "cppref": "cpp/string/multibyte/c8rtomb",
+    "cppdoc": "cpp/library/text/multibyte/c8rtomb"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mbsrtowcs",
+    "cppdoc": "cpp/library/text/multibyte/mbsrtowcs"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mblen",
+    "cppdoc": "cpp/library/text/multibyte/mblen"
+  },
+  {
+    "cppref": "cpp/string/multibyte/mbrtoc8",
+    "cppdoc": "cpp/library/text/multibyte/mbrtoc8"
+  },
+  {
+    "cppref": "cpp/string/basic_string/stoul",
+    "cppdoc": "cpp/library/string/basic_string/stoul"
+  },
+  {
+    "cppref": "cpp/string/basic_string/operator_at",
+    "cppdoc": "cpp/library/string/basic_string/operator_at"
+  },
+  {
+    "cppref": "cpp/string/basic_string/replace",
+    "cppdoc": "cpp/library/string/basic_string/replace"
+  },
+  {
+    "cppref": "cpp/string/basic_string/at",
+    "cppdoc": "cpp/library/string/basic_string/at"
+  },
+  {
+    "cppref": "cpp/string/basic_string/operator_q__q_s",
+    "cppdoc": "cpp/library/string/basic_string/operator_q__q_s"
+  },
+  {
+    "cppref": "cpp/string/basic_string/back",
+    "cppdoc": "cpp/library/string/basic_string/back"
+  },
+  {
+    "cppref": "cpp/string/basic_string/npos",
+    "cppdoc": "cpp/library/string/basic_string/npos"
+  },
+  {
+    "cppref": "cpp/string/basic_string/assign",
+    "cppdoc": "cpp/library/string/basic_string/assign"
+  },
+  {
+    "cppref": "cpp/string/basic_string/insert",
+    "cppdoc": "cpp/library/string/basic_string/insert"
+  },
+  {
+    "cppref": "cpp/string/basic_string/empty",
+    "cppdoc": "cpp/library/string/basic_string/empty"
+  },
+  {
+    "cppref": "cpp/string/basic_string/find",
+    "cppdoc": "cpp/library/string/basic_string/find"
+  },
+  {
+    "cppref": "cpp/string/basic_string/hash",
+    "cppdoc": "cpp/library/string/basic_string/hash"
+  },
+  {
+    "cppref": "cpp/string/basic_string/max_size",
+    "cppdoc": "cpp/library/string/basic_string/max_size"
+  },
+  {
+    "cppref": "cpp/string/basic_string/resize_and_overwrite",
+    "cppdoc": "cpp/library/string/basic_string/resize_and_overwrite"
+  },
+  {
+    "cppref": "cpp/string/basic_string/size",
+    "cppdoc": "cpp/library/string/basic_string/size"
+  },
+  {
+    "cppref": "cpp/string/basic_string/operator+=",
+    "cppdoc": "cpp/library/string/basic_string/operator+="
+  },
+  {
+    "cppref": "cpp/string/basic_string/copy",
+    "cppdoc": "cpp/library/string/basic_string/copy"
+  },
+  {
+    "cppref": "cpp/string/basic_string/ends_with",
+    "cppdoc": "cpp/library/string/basic_string/ends_with"
+  },
+  {
+    "cppref": "cpp/string/basic_string/find_first_not_of",
+    "cppdoc": "cpp/library/string/basic_string/find_first_not_of"
+  },
+  {
+    "cppref": "cpp/string/basic_string/to_string",
+    "cppdoc": "cpp/library/string/basic_string/to_string"
+  },
+  {
+    "cppref": "cpp/string/basic_string/to_wstring",
+    "cppdoc": "cpp/library/string/basic_string/to_wstring"
+  },
+  {
+    "cppref": "cpp/string/basic_string/operator_ltltgtgt",
+    "cppdoc": "cpp/library/string/basic_string/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/string/basic_string/swap2",
+    "cppdoc": "cpp/library/string/basic_string/swap2"
+  },
+  {
+    "cppref": "cpp/string/basic_string/end",
+    "cppdoc": "cpp/library/string/basic_string/end"
+  },
+  {
+    "cppref": "cpp/string/basic_string/rend",
+    "cppdoc": "cpp/library/string/basic_string/rend"
+  },
+  {
+    "cppref": "cpp/string/basic_string/~basic_string",
+    "cppdoc": "cpp/library/string/basic_string/~basic_string"
+  },
+  {
+    "cppref": "cpp/string/basic_string/begin",
+    "cppdoc": "cpp/library/string/basic_string/begin"
+  },
+  {
+    "cppref": "cpp/string/basic_string/substr",
+    "cppdoc": "cpp/library/string/basic_string/substr"
+  },
+  {
+    "cppref": "cpp/string/basic_string/stol",
+    "cppdoc": "cpp/library/string/basic_string/stol"
+  },
+  {
+    "cppref": "cpp/string/basic_string/deduction_guides",
+    "cppdoc": "cpp/library/string/basic_string/deduction_guides"
+  },
+  {
+    "cppref": "cpp/string/basic_string/pop_back",
+    "cppdoc": "cpp/library/string/basic_string/pop_back"
+  },
+  {
+    "cppref": "cpp/string/basic_string/find_last_not_of",
+    "cppdoc": "cpp/library/string/basic_string/find_last_not_of"
+  },
+  {
+    "cppref": "cpp/string/basic_string/assign_range",
+    "cppdoc": "cpp/library/string/basic_string/assign_range"
+  },
+  {
+    "cppref": "cpp/string/basic_string/getline",
+    "cppdoc": "cpp/library/string/basic_string/getline"
+  },
+  {
+    "cppref": "cpp/string/basic_string/swap",
+    "cppdoc": "cpp/library/string/basic_string/swap"
+  },
+  {
+    "cppref": "cpp/string/basic_string/stof",
+    "cppdoc": "cpp/library/string/basic_string/stof"
+  },
+  {
+    "cppref": "cpp/string/basic_string/front",
+    "cppdoc": "cpp/library/string/basic_string/front"
+  },
+  {
+    "cppref": "cpp/string/basic_string/rfind",
+    "cppdoc": "cpp/library/string/basic_string/rfind"
+  },
+  {
+    "cppref": "cpp/string/basic_string/operator+",
+    "cppdoc": "cpp/library/string/basic_string/operator+"
+  },
+  {
+    "cppref": "cpp/string/basic_string/resize",
+    "cppdoc": "cpp/library/string/basic_string/resize"
+  },
+  {
+    "cppref": "cpp/string/basic_string/rbegin",
+    "cppdoc": "cpp/library/string/basic_string/rbegin"
+  },
+  {
+    "cppref": "cpp/string/basic_string/compare",
+    "cppdoc": "cpp/library/string/basic_string/compare"
+  },
+  {
+    "cppref": "cpp/string/basic_string/basic_string",
+    "cppdoc": "cpp/library/string/basic_string/basic_string"
+  },
+  {
+    "cppref": "cpp/string/basic_string/reserve",
+    "cppdoc": "cpp/library/string/basic_string/reserve"
+  },
+  {
+    "cppref": "cpp/string/basic_string/append",
+    "cppdoc": "cpp/library/string/basic_string/append"
+  },
+  {
+    "cppref": "cpp/string/basic_string/erase",
+    "cppdoc": "cpp/library/string/basic_string/erase"
+  },
+  {
+    "cppref": "cpp/string/basic_string/operator_cmp",
+    "cppdoc": "cpp/library/string/basic_string/operator_cmp"
+  },
+  {
+    "cppref": "cpp/string/basic_string/get_allocator",
+    "cppdoc": "cpp/library/string/basic_string/get_allocator"
+  },
+  {
+    "cppref": "cpp/string/basic_string/contains",
+    "cppdoc": "cpp/library/string/basic_string/contains"
+  },
+  {
+    "cppref": "cpp/string/basic_string/find_last_of",
+    "cppdoc": "cpp/library/string/basic_string/find_last_of"
+  },
+  {
+    "cppref": "cpp/string/basic_string/c_str",
+    "cppdoc": "cpp/library/string/basic_string/c_str"
+  },
+  {
+    "cppref": "cpp/string/basic_string/insert_range",
+    "cppdoc": "cpp/library/string/basic_string/insert_range"
+  },
+  {
+    "cppref": "cpp/string/basic_string/erase2",
+    "cppdoc": "cpp/library/string/basic_string/erase2"
+  },
+  {
+    "cppref": "cpp/string/basic_string/find_first_of",
+    "cppdoc": "cpp/library/string/basic_string/find_first_of"
+  },
+  {
+    "cppref": "cpp/string/basic_string/operator_basic_string_view",
+    "cppdoc": "cpp/library/string/basic_string/operator_basic_string_view"
+  },
+  {
+    "cppref": "cpp/string/basic_string/capacity",
+    "cppdoc": "cpp/library/string/basic_string/capacity"
+  },
+  {
+    "cppref": "cpp/string/basic_string/operator=",
+    "cppdoc": "cpp/library/string/basic_string/operator="
+  },
+  {
+    "cppref": "cpp/string/basic_string/data",
+    "cppdoc": "cpp/library/string/basic_string/data"
+  },
+  {
+    "cppref": "cpp/string/basic_string/push_back",
+    "cppdoc": "cpp/library/string/basic_string/push_back"
+  },
+  {
+    "cppref": "cpp/string/basic_string/starts_with",
+    "cppdoc": "cpp/library/string/basic_string/starts_with"
+  },
+  {
+    "cppref": "cpp/string/basic_string/shrink_to_fit",
+    "cppdoc": "cpp/library/string/basic_string/shrink_to_fit"
+  },
+  {
+    "cppref": "cpp/string/basic_string/append_range",
+    "cppdoc": "cpp/library/string/basic_string/append_range"
+  },
+  {
+    "cppref": "cpp/string/basic_string/clear",
+    "cppdoc": "cpp/library/string/basic_string/clear"
+  },
+  {
+    "cppref": "cpp/string/basic_string/replace_with_range",
+    "cppdoc": "cpp/library/string/basic_string/replace_with_range"
+  },
+  {
+    "cppref": "cpp/string/byte/islower",
+    "cppdoc": "cpp/library/text/byte/islower"
+  },
+  {
+    "cppref": "cpp/string/byte/memmove",
+    "cppdoc": "cpp/library/text/byte/memmove"
+  },
+  {
+    "cppref": "cpp/string/byte/strpbrk",
+    "cppdoc": "cpp/library/text/byte/strpbrk"
+  },
+  {
+    "cppref": "cpp/string/byte/iscntrl",
+    "cppdoc": "cpp/library/text/byte/iscntrl"
+  },
+  {
+    "cppref": "cpp/string/byte/strspn",
+    "cppdoc": "cpp/library/text/byte/strspn"
+  },
+  {
+    "cppref": "cpp/string/byte/strlen",
+    "cppdoc": "cpp/library/text/byte/strlen"
+  },
+  {
+    "cppref": "cpp/string/byte/toupper",
+    "cppdoc": "cpp/library/text/byte/toupper"
+  },
+  {
+    "cppref": "cpp/string/byte/isprint",
+    "cppdoc": "cpp/library/text/byte/isprint"
+  },
+  {
+    "cppref": "cpp/string/byte/strchr",
+    "cppdoc": "cpp/library/text/byte/strchr"
+  },
+  {
+    "cppref": "cpp/string/byte/strtoimax",
+    "cppdoc": "cpp/library/text/byte/strtoimax"
+  },
+  {
+    "cppref": "cpp/string/byte/strrchr",
+    "cppdoc": "cpp/library/text/byte/strrchr"
+  },
+  {
+    "cppref": "cpp/string/byte/memcpy",
+    "cppdoc": "cpp/library/text/byte/memcpy"
+  },
+  {
+    "cppref": "cpp/string/byte/strcat",
+    "cppdoc": "cpp/library/text/byte/strcat"
+  },
+  {
+    "cppref": "cpp/string/byte/strncpy",
+    "cppdoc": "cpp/library/text/byte/strncpy"
+  },
+  {
+    "cppref": "cpp/string/byte/isalpha",
+    "cppdoc": "cpp/library/text/byte/isalpha"
+  },
+  {
+    "cppref": "cpp/string/byte/strtol",
+    "cppdoc": "cpp/library/text/byte/strtol"
+  },
+  {
+    "cppref": "cpp/string/byte/memset",
+    "cppdoc": "cpp/library/text/byte/memset"
+  },
+  {
+    "cppref": "cpp/string/byte/strtoul",
+    "cppdoc": "cpp/library/text/byte/strtoul"
+  },
+  {
+    "cppref": "cpp/string/byte/strtok",
+    "cppdoc": "cpp/library/text/byte/strtok"
+  },
+  {
+    "cppref": "cpp/string/byte/ispunct",
+    "cppdoc": "cpp/library/text/byte/ispunct"
+  },
+  {
+    "cppref": "cpp/string/byte/atoi",
+    "cppdoc": "cpp/library/text/byte/atoi"
+  },
+  {
+    "cppref": "cpp/string/byte/strcoll",
+    "cppdoc": "cpp/library/text/byte/strcoll"
+  },
+  {
+    "cppref": "cpp/string/byte/isdigit",
+    "cppdoc": "cpp/library/text/byte/isdigit"
+  },
+  {
+    "cppref": "cpp/string/byte/memcmp",
+    "cppdoc": "cpp/library/text/byte/memcmp"
+  },
+  {
+    "cppref": "cpp/string/byte/strerror",
+    "cppdoc": "cpp/library/text/byte/strerror"
+  },
+  {
+    "cppref": "cpp/string/byte/isspace",
+    "cppdoc": "cpp/library/text/byte/isspace"
+  },
+  {
+    "cppref": "cpp/string/byte/strcspn",
+    "cppdoc": "cpp/library/text/byte/strcspn"
+  },
+  {
+    "cppref": "cpp/string/byte/strxfrm",
+    "cppdoc": "cpp/library/text/byte/strxfrm"
+  },
+  {
+    "cppref": "cpp/string/byte/strncat",
+    "cppdoc": "cpp/library/text/byte/strncat"
+  },
+  {
+    "cppref": "cpp/string/byte/isxdigit",
+    "cppdoc": "cpp/library/text/byte/isxdigit"
+  },
+  {
+    "cppref": "cpp/string/byte/atof",
+    "cppdoc": "cpp/library/text/byte/atof"
+  },
+  {
+    "cppref": "cpp/string/byte/strcmp",
+    "cppdoc": "cpp/library/text/byte/strcmp"
+  },
+  {
+    "cppref": "cpp/string/byte/strstr",
+    "cppdoc": "cpp/library/text/byte/strstr"
+  },
+  {
+    "cppref": "cpp/string/byte/isgraph",
+    "cppdoc": "cpp/library/text/byte/isgraph"
+  },
+  {
+    "cppref": "cpp/string/byte/tolower",
+    "cppdoc": "cpp/library/text/byte/tolower"
+  },
+  {
+    "cppref": "cpp/string/byte/isblank",
+    "cppdoc": "cpp/library/text/byte/isblank"
+  },
+  {
+    "cppref": "cpp/string/byte/strtof",
+    "cppdoc": "cpp/library/text/byte/strtof"
+  },
+  {
+    "cppref": "cpp/string/byte/isalnum",
+    "cppdoc": "cpp/library/text/byte/isalnum"
+  },
+  {
+    "cppref": "cpp/string/byte/strcpy",
+    "cppdoc": "cpp/library/text/byte/strcpy"
+  },
+  {
+    "cppref": "cpp/string/byte/strncmp",
+    "cppdoc": "cpp/library/text/byte/strncmp"
+  },
+  {
+    "cppref": "cpp/string/byte/memchr",
+    "cppdoc": "cpp/library/text/byte/memchr"
+  },
+  {
+    "cppref": "cpp/string/byte/isupper",
+    "cppdoc": "cpp/library/text/byte/isupper"
+  },
+  {
+    "cppref": "cpp/string/wide/towupper",
+    "cppdoc": "cpp/library/text/wide/towupper"
+  },
+  {
+    "cppref": "cpp/string/wide/wcsncat",
+    "cppdoc": "cpp/library/text/wide/wcsncat"
+  },
+  {
+    "cppref": "cpp/string/wide/wcscpy",
+    "cppdoc": "cpp/library/text/wide/wcscpy"
+  },
+  {
+    "cppref": "cpp/string/wide/wcscmp",
+    "cppdoc": "cpp/library/text/wide/wcscmp"
+  },
+  {
+    "cppref": "cpp/string/wide/wcsstr",
+    "cppdoc": "cpp/library/text/wide/wcsstr"
+  },
+  {
+    "cppref": "cpp/string/wide/wcstok",
+    "cppdoc": "cpp/library/text/wide/wcstok"
+  },
+  {
+    "cppref": "cpp/string/wide/wmemcpy",
+    "cppdoc": "cpp/library/text/wide/wmemcpy"
+  },
+  {
+    "cppref": "cpp/string/wide/wmemset",
+    "cppdoc": "cpp/library/text/wide/wmemset"
+  },
+  {
+    "cppref": "cpp/string/wide/wcstol",
+    "cppdoc": "cpp/library/text/wide/wcstol"
+  },
+  {
+    "cppref": "cpp/string/wide/towctrans",
+    "cppdoc": "cpp/library/text/wide/towctrans"
+  },
+  {
+    "cppref": "cpp/string/wide/wcspbrk",
+    "cppdoc": "cpp/library/text/wide/wcspbrk"
+  },
+  {
+    "cppref": "cpp/string/wide/wcschr",
+    "cppdoc": "cpp/library/text/wide/wcschr"
+  },
+  {
+    "cppref": "cpp/string/wide/wmemcmp",
+    "cppdoc": "cpp/library/text/wide/wmemcmp"
+  },
+  {
+    "cppref": "cpp/string/wide/iswdigit",
+    "cppdoc": "cpp/library/text/wide/iswdigit"
+  },
+  {
+    "cppref": "cpp/string/wide/wcscat",
+    "cppdoc": "cpp/library/text/wide/wcscat"
+  },
+  {
+    "cppref": "cpp/string/wide/wmemmove",
+    "cppdoc": "cpp/library/text/wide/wmemmove"
+  },
+  {
+    "cppref": "cpp/string/wide/iswupper",
+    "cppdoc": "cpp/library/text/wide/iswupper"
+  },
+  {
+    "cppref": "cpp/string/wide/iswblank",
+    "cppdoc": "cpp/library/text/wide/iswblank"
+  },
+  {
+    "cppref": "cpp/string/wide/iswpunct",
+    "cppdoc": "cpp/library/text/wide/iswpunct"
+  },
+  {
+    "cppref": "cpp/string/wide/iswlower",
+    "cppdoc": "cpp/library/text/wide/iswlower"
+  },
+  {
+    "cppref": "cpp/string/wide/wctype",
+    "cppdoc": "cpp/library/text/wide/wctype"
+  },
+  {
+    "cppref": "cpp/string/wide/wcsrchr",
+    "cppdoc": "cpp/library/text/wide/wcsrchr"
+  },
+  {
+    "cppref": "cpp/string/wide/wcscspn",
+    "cppdoc": "cpp/library/text/wide/wcscspn"
+  },
+  {
+    "cppref": "cpp/string/wide/iswcntrl",
+    "cppdoc": "cpp/library/text/wide/iswcntrl"
+  },
+  {
+    "cppref": "cpp/string/wide/wcstoul",
+    "cppdoc": "cpp/library/text/wide/wcstoul"
+  },
+  {
+    "cppref": "cpp/string/wide/wcstoimax",
+    "cppdoc": "cpp/library/text/wide/wcstoimax"
+  },
+  {
+    "cppref": "cpp/string/wide/iswalnum",
+    "cppdoc": "cpp/library/text/wide/iswalnum"
+  },
+  {
+    "cppref": "cpp/string/wide/iswctype",
+    "cppdoc": "cpp/library/text/wide/iswctype"
+  },
+  {
+    "cppref": "cpp/string/wide/towlower",
+    "cppdoc": "cpp/library/text/wide/towlower"
+  },
+  {
+    "cppref": "cpp/string/wide/iswalpha",
+    "cppdoc": "cpp/library/text/wide/iswalpha"
+  },
+  {
+    "cppref": "cpp/string/wide/wcsncmp",
+    "cppdoc": "cpp/library/text/wide/wcsncmp"
+  },
+  {
+    "cppref": "cpp/string/wide/iswprint",
+    "cppdoc": "cpp/library/text/wide/iswprint"
+  },
+  {
+    "cppref": "cpp/string/wide/iswxdigit",
+    "cppdoc": "cpp/library/text/wide/iswxdigit"
+  },
+  {
+    "cppref": "cpp/string/wide/wcsxfrm",
+    "cppdoc": "cpp/library/text/wide/wcsxfrm"
+  },
+  {
+    "cppref": "cpp/string/wide/wcsspn",
+    "cppdoc": "cpp/library/text/wide/wcsspn"
+  },
+  {
+    "cppref": "cpp/string/wide/wcstof",
+    "cppdoc": "cpp/library/text/wide/wcstof"
+  },
+  {
+    "cppref": "cpp/string/wide/wmemchr",
+    "cppdoc": "cpp/library/text/wide/wmemchr"
+  },
+  {
+    "cppref": "cpp/string/wide/wcsncpy",
+    "cppdoc": "cpp/library/text/wide/wcsncpy"
+  },
+  {
+    "cppref": "cpp/string/wide/wctrans",
+    "cppdoc": "cpp/library/text/wide/wctrans"
+  },
+  {
+    "cppref": "cpp/string/wide/iswgraph",
+    "cppdoc": "cpp/library/text/wide/iswgraph"
+  },
+  {
+    "cppref": "cpp/string/wide/iswspace",
+    "cppdoc": "cpp/library/text/wide/iswspace"
+  },
+  {
+    "cppref": "cpp/string/wide/wcscoll",
+    "cppdoc": "cpp/library/text/wide/wcscoll"
+  },
+  {
+    "cppref": "cpp/string/wide/wcslen",
+    "cppdoc": "cpp/library/text/wide/wcslen"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/remove_prefix",
+    "cppdoc": "cpp/library/string/basic_string_view/remove_prefix"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/operator_q__q_sv",
+    "cppdoc": "cpp/library/string/basic_string_view/operator_q__q_sv"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/operator_at",
+    "cppdoc": "cpp/library/string/basic_string_view/operator_at"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/at",
+    "cppdoc": "cpp/library/string/basic_string_view/at"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/back",
+    "cppdoc": "cpp/library/string/basic_string_view/back"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/npos",
+    "cppdoc": "cpp/library/string/basic_string_view/npos"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/empty",
+    "cppdoc": "cpp/library/string/basic_string_view/empty"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/find",
+    "cppdoc": "cpp/library/string/basic_string_view/find"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/hash",
+    "cppdoc": "cpp/library/string/basic_string_view/hash"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/max_size",
+    "cppdoc": "cpp/library/string/basic_string_view/max_size"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/size",
+    "cppdoc": "cpp/library/string/basic_string_view/size"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/copy",
+    "cppdoc": "cpp/library/string/basic_string_view/copy"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/ends_with",
+    "cppdoc": "cpp/library/string/basic_string_view/ends_with"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/find_first_not_of",
+    "cppdoc": "cpp/library/string/basic_string_view/find_first_not_of"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/end",
+    "cppdoc": "cpp/library/string/basic_string_view/end"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/rend",
+    "cppdoc": "cpp/library/string/basic_string_view/rend"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/begin",
+    "cppdoc": "cpp/library/string/basic_string_view/begin"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/substr",
+    "cppdoc": "cpp/library/string/basic_string_view/substr"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/deduction_guides",
+    "cppdoc": "cpp/library/string/basic_string_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/find_last_not_of",
+    "cppdoc": "cpp/library/string/basic_string_view/find_last_not_of"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/swap",
+    "cppdoc": "cpp/library/string/basic_string_view/swap"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/front",
+    "cppdoc": "cpp/library/string/basic_string_view/front"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/rfind",
+    "cppdoc": "cpp/library/string/basic_string_view/rfind"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/rbegin",
+    "cppdoc": "cpp/library/string/basic_string_view/rbegin"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/compare",
+    "cppdoc": "cpp/library/string/basic_string_view/compare"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/basic_string_view",
+    "cppdoc": "cpp/library/string/basic_string_view/basic_string_view"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/operator_cmp",
+    "cppdoc": "cpp/library/string/basic_string_view/operator_cmp"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/contains",
+    "cppdoc": "cpp/library/string/basic_string_view/contains"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/find_last_of",
+    "cppdoc": "cpp/library/string/basic_string_view/find_last_of"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/find_first_of",
+    "cppdoc": "cpp/library/string/basic_string_view/find_first_of"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/operator=",
+    "cppdoc": "cpp/library/string/basic_string_view/operator="
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/data",
+    "cppdoc": "cpp/library/string/basic_string_view/data"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/operator_ltlt",
+    "cppdoc": "cpp/library/string/basic_string_view/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/starts_with",
+    "cppdoc": "cpp/library/string/basic_string_view/starts_with"
+  },
+  {
+    "cppref": "cpp/string/basic_string_view/remove_suffix",
+    "cppdoc": "cpp/library/string/basic_string_view/remove_suffix"
+  },
+  {
+    "cppref": "cpp/string/char_traits/assign",
+    "cppdoc": "cpp/library/string/char_traits/assign"
+  },
+  {
+    "cppref": "cpp/string/char_traits/find",
+    "cppdoc": "cpp/library/string/char_traits/find"
+  },
+  {
+    "cppref": "cpp/string/char_traits/move",
+    "cppdoc": "cpp/library/string/char_traits/move"
+  },
+  {
+    "cppref": "cpp/string/char_traits/copy",
+    "cppdoc": "cpp/library/string/char_traits/copy"
+  },
+  {
+    "cppref": "cpp/string/char_traits/to_char_type",
+    "cppdoc": "cpp/library/string/char_traits/to_char_type"
+  },
+  {
+    "cppref": "cpp/string/char_traits/eof",
+    "cppdoc": "cpp/library/string/char_traits/eof"
+  },
+  {
+    "cppref": "cpp/string/char_traits/to_int_type",
+    "cppdoc": "cpp/library/string/char_traits/to_int_type"
+  },
+  {
+    "cppref": "cpp/string/char_traits/cmp",
+    "cppdoc": "cpp/library/string/char_traits/cmp"
+  },
+  {
+    "cppref": "cpp/string/char_traits/compare",
+    "cppdoc": "cpp/library/string/char_traits/compare"
+  },
+  {
+    "cppref": "cpp/string/char_traits/not_eof",
+    "cppdoc": "cpp/library/string/char_traits/not_eof"
+  },
+  {
+    "cppref": "cpp/string/char_traits/length",
+    "cppdoc": "cpp/library/string/char_traits/length"
+  },
+  {
+    "cppref": "cpp/string/char_traits/eq_int_type",
+    "cppdoc": "cpp/library/string/char_traits/eq_int_type"
+  },
+  {
+    "cppref": "cpp/algorithm/rotate",
+    "cppdoc": "cpp/library/algorithm/rotate"
+  },
+  {
+    "cppref": "cpp/algorithm/adjacent_find",
+    "cppdoc": "cpp/library/algorithm/adjacent_find"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges",
+    "cppdoc": "cpp/library/algorithm/ranges"
+  },
+  {
+    "cppref": "cpp/algorithm/replace",
+    "cppdoc": "cpp/library/algorithm/replace"
+  },
+  {
+    "cppref": "cpp/algorithm/transform_reduce",
+    "cppdoc": "cpp/library/numeric/transform_reduce"
+  },
+  {
+    "cppref": "cpp/algorithm/includes",
+    "cppdoc": "cpp/library/algorithm/includes"
+  },
+  {
+    "cppref": "cpp/algorithm/remove",
+    "cppdoc": "cpp/library/algorithm/remove"
+  },
+  {
+    "cppref": "cpp/algorithm/transform_exclusive_scan",
+    "cppdoc": "cpp/library/numeric/transform_exclusive_scan"
+  },
+  {
+    "cppref": "cpp/algorithm/prev_permutation",
+    "cppdoc": "cpp/library/algorithm/prev_permutation"
+  },
+  {
+    "cppref": "cpp/algorithm/is_heap",
+    "cppdoc": "cpp/library/algorithm/is_heap"
+  },
+  {
+    "cppref": "cpp/algorithm/sample",
+    "cppdoc": "cpp/library/algorithm/sample"
+  },
+  {
+    "cppref": "cpp/algorithm/partition_copy",
+    "cppdoc": "cpp/library/algorithm/partition_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/clamp",
+    "cppdoc": "cpp/library/algorithm/clamp"
+  },
+  {
+    "cppref": "cpp/algorithm/set_symmetric_difference",
+    "cppdoc": "cpp/library/algorithm/set_symmetric_difference"
+  },
+  {
+    "cppref": "cpp/algorithm/random_shuffle",
+    "cppdoc": "cpp/library/algorithm/random_shuffle"
+  },
+  {
+    "cppref": "cpp/algorithm/find",
+    "cppdoc": "cpp/library/algorithm/find"
+  },
+  {
+    "cppref": "cpp/algorithm/search",
+    "cppdoc": "cpp/library/algorithm/search"
+  },
+  {
+    "cppref": "cpp/algorithm/equal_range",
+    "cppdoc": "cpp/library/algorithm/equal_range"
+  },
+  {
+    "cppref": "cpp/algorithm/stable_sort",
+    "cppdoc": "cpp/library/algorithm/stable_sort"
+  },
+  {
+    "cppref": "cpp/algorithm/move",
+    "cppdoc": "cpp/library/algorithm/move"
+  },
+  {
+    "cppref": "cpp/algorithm/all_any_none_of",
+    "cppdoc": "cpp/library/algorithm/all_any_none_of"
+  },
+  {
+    "cppref": "cpp/algorithm/shift",
+    "cppdoc": "cpp/library/algorithm/shift"
+  },
+  {
+    "cppref": "cpp/algorithm/copy",
+    "cppdoc": "cpp/library/algorithm/copy"
+  },
+  {
+    "cppref": "cpp/algorithm/min",
+    "cppdoc": "cpp/library/algorithm/min"
+  },
+  {
+    "cppref": "cpp/algorithm/max_element",
+    "cppdoc": "cpp/library/algorithm/max_element"
+  },
+  {
+    "cppref": "cpp/algorithm/qsort",
+    "cppdoc": "cpp/library/algorithm/qsort"
+  },
+  {
+    "cppref": "cpp/algorithm/minmax",
+    "cppdoc": "cpp/library/algorithm/minmax"
+  },
+  {
+    "cppref": "cpp/algorithm/partition",
+    "cppdoc": "cpp/library/algorithm/partition"
+  },
+  {
+    "cppref": "cpp/algorithm/partial_sum",
+    "cppdoc": "cpp/library/numeric/partial_sum"
+  },
+  {
+    "cppref": "cpp/algorithm/copy_backward",
+    "cppdoc": "cpp/library/algorithm/copy_backward"
+  },
+  {
+    "cppref": "cpp/algorithm/push_heap",
+    "cppdoc": "cpp/library/algorithm/push_heap"
+  },
+  {
+    "cppref": "cpp/algorithm/copy_n",
+    "cppdoc": "cpp/library/algorithm/copy_n"
+  },
+  {
+    "cppref": "cpp/algorithm/transform_inclusive_scan",
+    "cppdoc": "cpp/library/numeric/transform_inclusive_scan"
+  },
+  {
+    "cppref": "cpp/algorithm/pop_heap",
+    "cppdoc": "cpp/library/algorithm/pop_heap"
+  },
+  {
+    "cppref": "cpp/algorithm/execution_policy_tag",
+    "cppdoc": "cpp/library/algorithm/execution_policy_tag"
+  },
+  {
+    "cppref": "cpp/algorithm/is_sorted",
+    "cppdoc": "cpp/library/algorithm/is_sorted"
+  },
+  {
+    "cppref": "cpp/algorithm/bsearch",
+    "cppdoc": "cpp/library/algorithm/bsearch"
+  },
+  {
+    "cppref": "cpp/algorithm/rotate_copy",
+    "cppdoc": "cpp/library/algorithm/rotate_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/iota",
+    "cppdoc": "cpp/library/numeric/iota"
+  },
+  {
+    "cppref": "cpp/algorithm/set_difference",
+    "cppdoc": "cpp/library/algorithm/set_difference"
+  },
+  {
+    "cppref": "cpp/algorithm/execution_policy_tag_t",
+    "cppdoc": "cpp/library/algorithm/execution_policy_tag_t"
+  },
+  {
+    "cppref": "cpp/algorithm/is_partitioned",
+    "cppdoc": "cpp/library/algorithm/is_partitioned"
+  },
+  {
+    "cppref": "cpp/algorithm/for_each",
+    "cppdoc": "cpp/library/algorithm/for_each"
+  },
+  {
+    "cppref": "cpp/algorithm/find_end",
+    "cppdoc": "cpp/library/algorithm/find_end"
+  },
+  {
+    "cppref": "cpp/algorithm/lexicographical_compare_three_way",
+    "cppdoc": "cpp/library/algorithm/lexicographical_compare_three_way"
+  },
+  {
+    "cppref": "cpp/algorithm/swap",
+    "cppdoc": "cpp/library/algorithm/swap"
+  },
+  {
+    "cppref": "cpp/algorithm/sort_heap",
+    "cppdoc": "cpp/library/algorithm/sort_heap"
+  },
+  {
+    "cppref": "cpp/algorithm/accumulate",
+    "cppdoc": "cpp/library/numeric/accumulate"
+  },
+  {
+    "cppref": "cpp/algorithm/swap_ranges",
+    "cppdoc": "cpp/library/algorithm/swap_ranges"
+  },
+  {
+    "cppref": "cpp/algorithm/min_element",
+    "cppdoc": "cpp/library/algorithm/min_element"
+  },
+  {
+    "cppref": "cpp/algorithm/exclusive_scan",
+    "cppdoc": "cpp/library/numeric/exclusive_scan"
+  },
+  {
+    "cppref": "cpp/algorithm/max",
+    "cppdoc": "cpp/library/algorithm/max"
+  },
+  {
+    "cppref": "cpp/algorithm/upper_bound",
+    "cppdoc": "cpp/library/algorithm/upper_bound"
+  },
+  {
+    "cppref": "cpp/algorithm/next_permutation",
+    "cppdoc": "cpp/library/algorithm/next_permutation"
+  },
+  {
+    "cppref": "cpp/algorithm/partial_sort_copy",
+    "cppdoc": "cpp/library/algorithm/partial_sort_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/inclusive_scan",
+    "cppdoc": "cpp/library/numeric/inclusive_scan"
+  },
+  {
+    "cppref": "cpp/algorithm/search_n",
+    "cppdoc": "cpp/library/algorithm/search_n"
+  },
+  {
+    "cppref": "cpp/algorithm/lower_bound",
+    "cppdoc": "cpp/library/algorithm/lower_bound"
+  },
+  {
+    "cppref": "cpp/algorithm/is_execution_policy",
+    "cppdoc": "cpp/library/algorithm/is_execution_policy"
+  },
+  {
+    "cppref": "cpp/algorithm/mismatch",
+    "cppdoc": "cpp/library/algorithm/mismatch"
+  },
+  {
+    "cppref": "cpp/algorithm/reduce",
+    "cppdoc": "cpp/library/numeric/reduce"
+  },
+  {
+    "cppref": "cpp/algorithm/count",
+    "cppdoc": "cpp/library/algorithm/count"
+  },
+  {
+    "cppref": "cpp/algorithm/equal",
+    "cppdoc": "cpp/library/algorithm/equal"
+  },
+  {
+    "cppref": "cpp/algorithm/replace_copy",
+    "cppdoc": "cpp/library/algorithm/replace_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/inplace_merge",
+    "cppdoc": "cpp/library/algorithm/inplace_merge"
+  },
+  {
+    "cppref": "cpp/algorithm/generate_n",
+    "cppdoc": "cpp/library/algorithm/generate_n"
+  },
+  {
+    "cppref": "cpp/algorithm/inner_product",
+    "cppdoc": "cpp/library/numeric/inner_product"
+  },
+  {
+    "cppref": "cpp/algorithm/set_union",
+    "cppdoc": "cpp/library/algorithm/set_union"
+  },
+  {
+    "cppref": "cpp/algorithm/merge",
+    "cppdoc": "cpp/library/algorithm/merge"
+  },
+  {
+    "cppref": "cpp/algorithm/fill_n",
+    "cppdoc": "cpp/library/algorithm/fill_n"
+  },
+  {
+    "cppref": "cpp/algorithm/set_intersection",
+    "cppdoc": "cpp/library/algorithm/set_intersection"
+  },
+  {
+    "cppref": "cpp/algorithm/make_heap",
+    "cppdoc": "cpp/library/algorithm/make_heap"
+  },
+  {
+    "cppref": "cpp/algorithm/iter_swap",
+    "cppdoc": "cpp/library/algorithm/iter_swap"
+  },
+  {
+    "cppref": "cpp/algorithm/binary_search",
+    "cppdoc": "cpp/library/algorithm/binary_search"
+  },
+  {
+    "cppref": "cpp/algorithm/unique",
+    "cppdoc": "cpp/library/algorithm/unique"
+  },
+  {
+    "cppref": "cpp/algorithm/is_heap_until",
+    "cppdoc": "cpp/library/algorithm/is_heap_until"
+  },
+  {
+    "cppref": "cpp/algorithm/is_sorted_until",
+    "cppdoc": "cpp/library/algorithm/is_sorted_until"
+  },
+  {
+    "cppref": "cpp/algorithm/fill",
+    "cppdoc": "cpp/library/algorithm/fill"
+  },
+  {
+    "cppref": "cpp/algorithm/move_backward",
+    "cppdoc": "cpp/library/algorithm/move_backward"
+  },
+  {
+    "cppref": "cpp/algorithm/partition_point",
+    "cppdoc": "cpp/library/algorithm/partition_point"
+  },
+  {
+    "cppref": "cpp/algorithm/minmax_element",
+    "cppdoc": "cpp/library/algorithm/minmax_element"
+  },
+  {
+    "cppref": "cpp/algorithm/adjacent_difference",
+    "cppdoc": "cpp/library/numeric/adjacent_difference"
+  },
+  {
+    "cppref": "cpp/algorithm/sort",
+    "cppdoc": "cpp/library/algorithm/sort"
+  },
+  {
+    "cppref": "cpp/algorithm/for_each_n",
+    "cppdoc": "cpp/library/algorithm/for_each_n"
+  },
+  {
+    "cppref": "cpp/algorithm/nth_element",
+    "cppdoc": "cpp/library/algorithm/nth_element"
+  },
+  {
+    "cppref": "cpp/algorithm/find_first_of",
+    "cppdoc": "cpp/library/algorithm/find_first_of"
+  },
+  {
+    "cppref": "cpp/algorithm/stable_partition",
+    "cppdoc": "cpp/library/algorithm/stable_partition"
+  },
+  {
+    "cppref": "cpp/algorithm/remove_copy",
+    "cppdoc": "cpp/library/algorithm/remove_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/unique_copy",
+    "cppdoc": "cpp/library/algorithm/unique_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/transform",
+    "cppdoc": "cpp/library/algorithm/transform"
+  },
+  {
+    "cppref": "cpp/algorithm/reverse_copy",
+    "cppdoc": "cpp/library/algorithm/reverse_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/lexicographical_compare",
+    "cppdoc": "cpp/library/algorithm/lexicographical_compare"
+  },
+  {
+    "cppref": "cpp/algorithm/generate",
+    "cppdoc": "cpp/library/algorithm/generate"
+  },
+  {
+    "cppref": "cpp/algorithm/partial_sort",
+    "cppdoc": "cpp/library/algorithm/partial_sort"
+  },
+  {
+    "cppref": "cpp/algorithm/is_permutation",
+    "cppdoc": "cpp/library/algorithm/is_permutation"
+  },
+  {
+    "cppref": "cpp/algorithm/reverse",
+    "cppdoc": "cpp/library/algorithm/reverse"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/fold_left_first_with_iter",
+    "cppdoc": "cpp/library/algorithm/ranges/fold_left_first_with_iter"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/rotate",
+    "cppdoc": "cpp/library/algorithm/ranges/rotate"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/adjacent_find",
+    "cppdoc": "cpp/library/algorithm/ranges/adjacent_find"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/replace",
+    "cppdoc": "cpp/library/algorithm/ranges/replace"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/includes",
+    "cppdoc": "cpp/library/algorithm/ranges/includes"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/remove",
+    "cppdoc": "cpp/library/algorithm/ranges/remove"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/fold_left_first",
+    "cppdoc": "cpp/library/algorithm/ranges/fold_left_first"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/prev_permutation",
+    "cppdoc": "cpp/library/algorithm/ranges/prev_permutation"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/is_heap",
+    "cppdoc": "cpp/library/algorithm/ranges/is_heap"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/sample",
+    "cppdoc": "cpp/library/algorithm/ranges/sample"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/partition_copy",
+    "cppdoc": "cpp/library/algorithm/ranges/partition_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/clamp",
+    "cppdoc": "cpp/library/algorithm/ranges/clamp"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/set_symmetric_difference",
+    "cppdoc": "cpp/library/algorithm/ranges/set_symmetric_difference"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/find",
+    "cppdoc": "cpp/library/algorithm/ranges/find"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/search",
+    "cppdoc": "cpp/library/algorithm/ranges/search"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/equal_range",
+    "cppdoc": "cpp/library/algorithm/ranges/equal_range"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/stable_sort",
+    "cppdoc": "cpp/library/algorithm/ranges/stable_sort"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/move",
+    "cppdoc": "cpp/library/algorithm/ranges/move"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/all_any_none_of",
+    "cppdoc": "cpp/library/algorithm/ranges/all_any_none_of"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/shift",
+    "cppdoc": "cpp/library/algorithm/ranges/shift"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/copy",
+    "cppdoc": "cpp/library/algorithm/ranges/copy"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/min",
+    "cppdoc": "cpp/library/algorithm/ranges/min"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/ends_with",
+    "cppdoc": "cpp/library/algorithm/ranges/ends_with"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/max_element",
+    "cppdoc": "cpp/library/algorithm/ranges/max_element"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/minmax",
+    "cppdoc": "cpp/library/algorithm/ranges/minmax"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/partition",
+    "cppdoc": "cpp/library/algorithm/ranges/partition"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/copy_backward",
+    "cppdoc": "cpp/library/algorithm/ranges/copy_backward"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/find_last",
+    "cppdoc": "cpp/library/algorithm/ranges/find_last"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/push_heap",
+    "cppdoc": "cpp/library/algorithm/ranges/push_heap"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/copy_n",
+    "cppdoc": "cpp/library/algorithm/ranges/copy_n"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/pop_heap",
+    "cppdoc": "cpp/library/algorithm/ranges/pop_heap"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/is_sorted",
+    "cppdoc": "cpp/library/algorithm/ranges/is_sorted"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/rotate_copy",
+    "cppdoc": "cpp/library/algorithm/ranges/rotate_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/iota",
+    "cppdoc": "cpp/library/numeric/ranges/iota"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/fold_right",
+    "cppdoc": "cpp/library/algorithm/ranges/fold_right"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/generate_random",
+    "cppdoc": "cpp/library/algorithm/ranges/generate_random"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/set_difference",
+    "cppdoc": "cpp/library/algorithm/ranges/set_difference"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/is_partitioned",
+    "cppdoc": "cpp/library/algorithm/ranges/is_partitioned"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/for_each",
+    "cppdoc": "cpp/library/algorithm/ranges/for_each"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/find_end",
+    "cppdoc": "cpp/library/algorithm/ranges/find_end"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/sort_heap",
+    "cppdoc": "cpp/library/algorithm/ranges/sort_heap"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/swap_ranges",
+    "cppdoc": "cpp/library/algorithm/ranges/swap_ranges"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/min_element",
+    "cppdoc": "cpp/library/algorithm/ranges/min_element"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/max",
+    "cppdoc": "cpp/library/algorithm/ranges/max"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/upper_bound",
+    "cppdoc": "cpp/library/algorithm/ranges/upper_bound"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/next_permutation",
+    "cppdoc": "cpp/library/algorithm/ranges/next_permutation"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/partial_sort_copy",
+    "cppdoc": "cpp/library/algorithm/ranges/partial_sort_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/search_n",
+    "cppdoc": "cpp/library/algorithm/ranges/search_n"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/lower_bound",
+    "cppdoc": "cpp/library/algorithm/ranges/lower_bound"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/mismatch",
+    "cppdoc": "cpp/library/algorithm/ranges/mismatch"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/count",
+    "cppdoc": "cpp/library/algorithm/ranges/count"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/shuffle",
+    "cppdoc": "cpp/library/algorithm/ranges/shuffle"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/equal",
+    "cppdoc": "cpp/library/algorithm/ranges/equal"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/replace_copy",
+    "cppdoc": "cpp/library/algorithm/ranges/replace_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/inplace_merge",
+    "cppdoc": "cpp/library/algorithm/ranges/inplace_merge"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/generate_n",
+    "cppdoc": "cpp/library/algorithm/ranges/generate_n"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/set_union",
+    "cppdoc": "cpp/library/algorithm/ranges/set_union"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/contains",
+    "cppdoc": "cpp/library/algorithm/ranges/contains"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/merge",
+    "cppdoc": "cpp/library/algorithm/ranges/merge"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/fill_n",
+    "cppdoc": "cpp/library/algorithm/ranges/fill_n"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/set_intersection",
+    "cppdoc": "cpp/library/algorithm/ranges/set_intersection"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/make_heap",
+    "cppdoc": "cpp/library/algorithm/ranges/make_heap"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/binary_search",
+    "cppdoc": "cpp/library/algorithm/ranges/binary_search"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/unique",
+    "cppdoc": "cpp/library/algorithm/ranges/unique"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/is_heap_until",
+    "cppdoc": "cpp/library/algorithm/ranges/is_heap_until"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/is_sorted_until",
+    "cppdoc": "cpp/library/algorithm/ranges/is_sorted_until"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/fill",
+    "cppdoc": "cpp/library/algorithm/ranges/fill"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/move_backward",
+    "cppdoc": "cpp/library/algorithm/ranges/move_backward"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/partition_point",
+    "cppdoc": "cpp/library/algorithm/ranges/partition_point"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/minmax_element",
+    "cppdoc": "cpp/library/algorithm/ranges/minmax_element"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/sort",
+    "cppdoc": "cpp/library/algorithm/ranges/sort"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/for_each_n",
+    "cppdoc": "cpp/library/algorithm/ranges/for_each_n"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/nth_element",
+    "cppdoc": "cpp/library/algorithm/ranges/nth_element"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/find_first_of",
+    "cppdoc": "cpp/library/algorithm/ranges/find_first_of"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/stable_partition",
+    "cppdoc": "cpp/library/algorithm/ranges/stable_partition"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/remove_copy",
+    "cppdoc": "cpp/library/algorithm/ranges/remove_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/unique_copy",
+    "cppdoc": "cpp/library/algorithm/ranges/unique_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/fold_left",
+    "cppdoc": "cpp/library/algorithm/ranges/fold_left"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/transform",
+    "cppdoc": "cpp/library/algorithm/ranges/transform"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/reverse_copy",
+    "cppdoc": "cpp/library/algorithm/ranges/reverse_copy"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/lexicographical_compare",
+    "cppdoc": "cpp/library/algorithm/ranges/lexicographical_compare"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/starts_with",
+    "cppdoc": "cpp/library/algorithm/ranges/starts_with"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/fold_right_last",
+    "cppdoc": "cpp/library/algorithm/ranges/fold_right_last"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/generate",
+    "cppdoc": "cpp/library/algorithm/ranges/generate"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/partial_sort",
+    "cppdoc": "cpp/library/algorithm/ranges/partial_sort"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/is_permutation",
+    "cppdoc": "cpp/library/algorithm/ranges/is_permutation"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/reverse",
+    "cppdoc": "cpp/library/algorithm/ranges/reverse"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/fold_left_with_iter",
+    "cppdoc": "cpp/library/algorithm/ranges/fold_left_with_iter"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/return_types/in_out_out_result",
+    "cppdoc": "cpp/library/algorithm/ranges/return_types/in_out_out_result"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/return_types/in_found_result",
+    "cppdoc": "cpp/library/algorithm/ranges/return_types/in_found_result"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/return_types/in_fun_result",
+    "cppdoc": "cpp/library/algorithm/ranges/return_types/in_fun_result"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/return_types/in_in_result",
+    "cppdoc": "cpp/library/algorithm/ranges/return_types/in_in_result"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/return_types/in_out_result",
+    "cppdoc": "cpp/library/algorithm/ranges/return_types/in_out_result"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/return_types/out_value_result",
+    "cppdoc": "cpp/library/algorithm/ranges/return_types/out_value_result"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/return_types/in_value_result",
+    "cppdoc": "cpp/library/algorithm/ranges/return_types/in_value_result"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/return_types/in_in_out_result",
+    "cppdoc": "cpp/library/algorithm/ranges/return_types/in_in_out_result"
+  },
+  {
+    "cppref": "cpp/algorithm/ranges/return_types/min_max_result",
+    "cppdoc": "cpp/library/algorithm/ranges/return_types/min_max_result"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions",
+    "cppdoc": "cpp/library/numeric/special_functions"
+  },
+  {
+    "cppref": "cpp/numeric/fenv",
+    "cppdoc": "cpp/library/numeric/fenv"
+  },
+  {
+    "cppref": "cpp/numeric/lcm",
+    "cppdoc": "cpp/library/numeric/lcm"
+  },
+  {
+    "cppref": "cpp/numeric/valarray",
+    "cppdoc": "cpp/library/numeric/valarray"
+  },
+  {
+    "cppref": "cpp/numeric/ratio",
+    "cppdoc": "cpp/library/meta/ratio"
+  },
+  {
+    "cppref": "cpp/numeric/constants",
+    "cppdoc": "cpp/library/numeric/constants"
+  },
+  {
+    "cppref": "cpp/numeric/linalg",
+    "cppdoc": "cpp/library/numeric/linalg"
+  },
+  {
+    "cppref": "cpp/numeric/lerp",
+    "cppdoc": "cpp/library/numeric/lerp"
+  },
+  {
+    "cppref": "cpp/numeric/saturate_cast",
+    "cppdoc": "cpp/library/numeric/saturate_cast"
+  },
+  {
+    "cppref": "cpp/numeric/add_sat",
+    "cppdoc": "cpp/library/numeric/add_sat"
+  },
+  {
+    "cppref": "cpp/numeric/midpoint",
+    "cppdoc": "cpp/library/numeric/midpoint"
+  },
+  {
+    "cppref": "cpp/numeric/simd",
+    "cppdoc": "cpp/library/numeric/simd"
+  },
+  {
+    "cppref": "cpp/numeric/div_sat",
+    "cppdoc": "cpp/library/numeric/div_sat"
+  },
+  {
+    "cppref": "cpp/numeric/gcd",
+    "cppdoc": "cpp/library/numeric/gcd"
+  },
+  {
+    "cppref": "cpp/numeric/math",
+    "cppdoc": "cpp/library/numeric/math"
+  },
+  {
+    "cppref": "cpp/numeric/mul_sat",
+    "cppdoc": "cpp/library/numeric/mul_sat"
+  },
+  {
+    "cppref": "cpp/numeric/random",
+    "cppdoc": "cpp/library/numeric/random"
+  },
+  {
+    "cppref": "cpp/numeric/sub_sat",
+    "cppdoc": "cpp/library/numeric/sub_sat"
+  },
+  {
+    "cppref": "cpp/numeric/complex",
+    "cppdoc": "cpp/library/numeric/complex"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/operator_at",
+    "cppdoc": "cpp/library/numeric/valarray/operator_at"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/end2",
+    "cppdoc": "cpp/library/numeric/valarray/end2"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/asin",
+    "cppdoc": "cpp/library/numeric/valarray/asin"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/sin",
+    "cppdoc": "cpp/library/numeric/valarray/sin"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/slice",
+    "cppdoc": "cpp/library/numeric/valarray/slice"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/acos",
+    "cppdoc": "cpp/library/numeric/valarray/acos"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/shift",
+    "cppdoc": "cpp/library/numeric/valarray/shift"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/tan",
+    "cppdoc": "cpp/library/numeric/valarray/tan"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/size",
+    "cppdoc": "cpp/library/numeric/valarray/size"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/min",
+    "cppdoc": "cpp/library/numeric/valarray/min"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/~valarray",
+    "cppdoc": "cpp/library/numeric/valarray/~valarray"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/valarray",
+    "cppdoc": "cpp/library/numeric/valarray/valarray"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/swap2",
+    "cppdoc": "cpp/library/numeric/valarray/swap2"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/begin2",
+    "cppdoc": "cpp/library/numeric/valarray/begin2"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/exp",
+    "cppdoc": "cpp/library/numeric/valarray/exp"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/sqrt",
+    "cppdoc": "cpp/library/numeric/valarray/sqrt"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/deduction_guides",
+    "cppdoc": "cpp/library/numeric/valarray/deduction_guides"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/swap",
+    "cppdoc": "cpp/library/numeric/valarray/swap"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/operator_arith",
+    "cppdoc": "cpp/library/numeric/valarray/operator_arith"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/operator_arith3",
+    "cppdoc": "cpp/library/numeric/valarray/operator_arith3"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/resize",
+    "cppdoc": "cpp/library/numeric/valarray/resize"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/max",
+    "cppdoc": "cpp/library/numeric/valarray/max"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/mask_array",
+    "cppdoc": "cpp/library/numeric/valarray/mask_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/indirect_array",
+    "cppdoc": "cpp/library/numeric/valarray/indirect_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/gslice_array",
+    "cppdoc": "cpp/library/numeric/valarray/gslice_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/cosh",
+    "cppdoc": "cpp/library/numeric/valarray/cosh"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/pow",
+    "cppdoc": "cpp/library/numeric/valarray/pow"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/slice_array",
+    "cppdoc": "cpp/library/numeric/valarray/slice_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/cshift",
+    "cppdoc": "cpp/library/numeric/valarray/cshift"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/operator_cmp",
+    "cppdoc": "cpp/library/numeric/valarray/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/sum",
+    "cppdoc": "cpp/library/numeric/valarray/sum"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/tanh",
+    "cppdoc": "cpp/library/numeric/valarray/tanh"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/apply",
+    "cppdoc": "cpp/library/numeric/valarray/apply"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/gslice",
+    "cppdoc": "cpp/library/numeric/valarray/gslice"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/cos",
+    "cppdoc": "cpp/library/numeric/valarray/cos"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/operator_arith2",
+    "cppdoc": "cpp/library/numeric/valarray/operator_arith2"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/sinh",
+    "cppdoc": "cpp/library/numeric/valarray/sinh"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/atan",
+    "cppdoc": "cpp/library/numeric/valarray/atan"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/operator=",
+    "cppdoc": "cpp/library/numeric/valarray/operator="
+  },
+  {
+    "cppref": "cpp/numeric/valarray/atan2",
+    "cppdoc": "cpp/library/numeric/valarray/atan2"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/log10",
+    "cppdoc": "cpp/library/numeric/valarray/log10"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/abs",
+    "cppdoc": "cpp/library/numeric/valarray/abs"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/log",
+    "cppdoc": "cpp/library/numeric/valarray/log"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/gslice_array/operator_arith",
+    "cppdoc": "cpp/library/numeric/valarray/gslice_array/operator_arith"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/gslice_array/gslice_array",
+    "cppdoc": "cpp/library/numeric/valarray/gslice_array/gslice_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/gslice_array/~gslice_array",
+    "cppdoc": "cpp/library/numeric/valarray/gslice_array/~gslice_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/gslice_array/operator=",
+    "cppdoc": "cpp/library/numeric/valarray/gslice_array/operator="
+  },
+  {
+    "cppref": "cpp/numeric/valarray/mask_array/operator_arith",
+    "cppdoc": "cpp/library/numeric/valarray/mask_array/operator_arith"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/mask_array/mask_array",
+    "cppdoc": "cpp/library/numeric/valarray/mask_array/mask_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/mask_array/~mask_array",
+    "cppdoc": "cpp/library/numeric/valarray/mask_array/~mask_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/mask_array/operator=",
+    "cppdoc": "cpp/library/numeric/valarray/mask_array/operator="
+  },
+  {
+    "cppref": "cpp/numeric/valarray/slice_array/operator_arith",
+    "cppdoc": "cpp/library/numeric/valarray/slice_array/operator_arith"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/slice_array/~slice_array",
+    "cppdoc": "cpp/library/numeric/valarray/slice_array/~slice_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/slice_array/slice_array",
+    "cppdoc": "cpp/library/numeric/valarray/slice_array/slice_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/slice_array/operator=",
+    "cppdoc": "cpp/library/numeric/valarray/slice_array/operator="
+  },
+  {
+    "cppref": "cpp/numeric/valarray/indirect_array/operator_arith",
+    "cppdoc": "cpp/library/numeric/valarray/indirect_array/operator_arith"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/indirect_array/indirect_array",
+    "cppdoc": "cpp/library/numeric/valarray/indirect_array/indirect_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/indirect_array/~indirect_array",
+    "cppdoc": "cpp/library/numeric/valarray/indirect_array/~indirect_array"
+  },
+  {
+    "cppref": "cpp/numeric/valarray/indirect_array/operator=",
+    "cppdoc": "cpp/library/numeric/valarray/indirect_array/operator="
+  },
+  {
+    "cppref": "cpp/numeric/complex/asin",
+    "cppdoc": "cpp/library/numeric/complex/asin"
+  },
+  {
+    "cppref": "cpp/numeric/complex/sin",
+    "cppdoc": "cpp/library/numeric/complex/sin"
+  },
+  {
+    "cppref": "cpp/numeric/complex/imag2",
+    "cppdoc": "cpp/library/numeric/complex/imag2"
+  },
+  {
+    "cppref": "cpp/numeric/complex/acos",
+    "cppdoc": "cpp/library/numeric/complex/acos"
+  },
+  {
+    "cppref": "cpp/numeric/complex/operator_q__q_i",
+    "cppdoc": "cpp/library/numeric/complex/operator_q__q_i"
+  },
+  {
+    "cppref": "cpp/numeric/complex/tan",
+    "cppdoc": "cpp/library/numeric/complex/tan"
+  },
+  {
+    "cppref": "cpp/numeric/complex/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/complex/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/complex/exp",
+    "cppdoc": "cpp/library/numeric/complex/exp"
+  },
+  {
+    "cppref": "cpp/numeric/complex/proj",
+    "cppdoc": "cpp/library/numeric/complex/proj"
+  },
+  {
+    "cppref": "cpp/numeric/complex/conj",
+    "cppdoc": "cpp/library/numeric/complex/conj"
+  },
+  {
+    "cppref": "cpp/numeric/complex/sqrt",
+    "cppdoc": "cpp/library/numeric/complex/sqrt"
+  },
+  {
+    "cppref": "cpp/numeric/complex/operator_arith",
+    "cppdoc": "cpp/library/numeric/complex/operator_arith"
+  },
+  {
+    "cppref": "cpp/numeric/complex/operator_arith3",
+    "cppdoc": "cpp/library/numeric/complex/operator_arith3"
+  },
+  {
+    "cppref": "cpp/numeric/complex/norm",
+    "cppdoc": "cpp/library/numeric/complex/norm"
+  },
+  {
+    "cppref": "cpp/numeric/complex/imag",
+    "cppdoc": "cpp/library/numeric/complex/imag"
+  },
+  {
+    "cppref": "cpp/numeric/complex/tuple_size",
+    "cppdoc": "cpp/library/numeric/complex/tuple_size"
+  },
+  {
+    "cppref": "cpp/numeric/complex/cosh",
+    "cppdoc": "cpp/library/numeric/complex/cosh"
+  },
+  {
+    "cppref": "cpp/numeric/complex/pow",
+    "cppdoc": "cpp/library/numeric/complex/pow"
+  },
+  {
+    "cppref": "cpp/numeric/complex/get",
+    "cppdoc": "cpp/library/numeric/complex/get"
+  },
+  {
+    "cppref": "cpp/numeric/complex/asinh",
+    "cppdoc": "cpp/library/numeric/complex/asinh"
+  },
+  {
+    "cppref": "cpp/numeric/complex/operator_cmp",
+    "cppdoc": "cpp/library/numeric/complex/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/complex/real2",
+    "cppdoc": "cpp/library/numeric/complex/real2"
+  },
+  {
+    "cppref": "cpp/numeric/complex/tanh",
+    "cppdoc": "cpp/library/numeric/complex/tanh"
+  },
+  {
+    "cppref": "cpp/numeric/complex/cos",
+    "cppdoc": "cpp/library/numeric/complex/cos"
+  },
+  {
+    "cppref": "cpp/numeric/complex/tuple_element",
+    "cppdoc": "cpp/library/numeric/complex/tuple_element"
+  },
+  {
+    "cppref": "cpp/numeric/complex/operator_arith2",
+    "cppdoc": "cpp/library/numeric/complex/operator_arith2"
+  },
+  {
+    "cppref": "cpp/numeric/complex/sinh",
+    "cppdoc": "cpp/library/numeric/complex/sinh"
+  },
+  {
+    "cppref": "cpp/numeric/complex/atan",
+    "cppdoc": "cpp/library/numeric/complex/atan"
+  },
+  {
+    "cppref": "cpp/numeric/complex/operator=",
+    "cppdoc": "cpp/library/numeric/complex/operator="
+  },
+  {
+    "cppref": "cpp/numeric/complex/log10",
+    "cppdoc": "cpp/library/numeric/complex/log10"
+  },
+  {
+    "cppref": "cpp/numeric/complex/arg",
+    "cppdoc": "cpp/library/numeric/complex/arg"
+  },
+  {
+    "cppref": "cpp/numeric/complex/acosh",
+    "cppdoc": "cpp/library/numeric/complex/acosh"
+  },
+  {
+    "cppref": "cpp/numeric/complex/complex",
+    "cppdoc": "cpp/library/numeric/complex/complex"
+  },
+  {
+    "cppref": "cpp/numeric/complex/real",
+    "cppdoc": "cpp/library/numeric/complex/real"
+  },
+  {
+    "cppref": "cpp/numeric/complex/polar",
+    "cppdoc": "cpp/library/numeric/complex/polar"
+  },
+  {
+    "cppref": "cpp/numeric/complex/abs",
+    "cppdoc": "cpp/library/numeric/complex/abs"
+  },
+  {
+    "cppref": "cpp/numeric/complex/log",
+    "cppdoc": "cpp/library/numeric/complex/log"
+  },
+  {
+    "cppref": "cpp/numeric/complex/atanh",
+    "cppdoc": "cpp/library/numeric/complex/atanh"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/cyl_bessel_j",
+    "cppdoc": "cpp/library/numeric/special_functions/cyl_bessel_j"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/hermite",
+    "cppdoc": "cpp/library/numeric/special_functions/hermite"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/cyl_bessel_i",
+    "cppdoc": "cpp/library/numeric/special_functions/cyl_bessel_i"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/sph_neumann",
+    "cppdoc": "cpp/library/numeric/special_functions/sph_neumann"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/cyl_bessel_k",
+    "cppdoc": "cpp/library/numeric/special_functions/cyl_bessel_k"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/comp_ellint_2",
+    "cppdoc": "cpp/library/numeric/special_functions/comp_ellint_2"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/assoc_legendre",
+    "cppdoc": "cpp/library/numeric/special_functions/assoc_legendre"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/sph_bessel",
+    "cppdoc": "cpp/library/numeric/special_functions/sph_bessel"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/beta",
+    "cppdoc": "cpp/library/numeric/special_functions/beta"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/sph_legendre",
+    "cppdoc": "cpp/library/numeric/special_functions/sph_legendre"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/ellint_1",
+    "cppdoc": "cpp/library/numeric/special_functions/ellint_1"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/assoc_laguerre",
+    "cppdoc": "cpp/library/numeric/special_functions/assoc_laguerre"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/riemann_zeta",
+    "cppdoc": "cpp/library/numeric/special_functions/riemann_zeta"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/comp_ellint_1",
+    "cppdoc": "cpp/library/numeric/special_functions/comp_ellint_1"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/legendre",
+    "cppdoc": "cpp/library/numeric/special_functions/legendre"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/laguerre",
+    "cppdoc": "cpp/library/numeric/special_functions/laguerre"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/comp_ellint_3",
+    "cppdoc": "cpp/library/numeric/special_functions/comp_ellint_3"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/expint",
+    "cppdoc": "cpp/library/numeric/special_functions/expint"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/cyl_neumann",
+    "cppdoc": "cpp/library/numeric/special_functions/cyl_neumann"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/ellint_3",
+    "cppdoc": "cpp/library/numeric/special_functions/ellint_3"
+  },
+  {
+    "cppref": "cpp/numeric/special_functions/ellint_2",
+    "cppdoc": "cpp/library/numeric/special_functions/ellint_2"
+  },
+  {
+    "cppref": "cpp/numeric/random/random_device",
+    "cppdoc": "cpp/library/numeric/random/random_device"
+  },
+  {
+    "cppref": "cpp/numeric/random/discard_block_engine",
+    "cppdoc": "cpp/library/numeric/random/discard_block_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/normal_distribution",
+    "cppdoc": "cpp/library/numeric/random/normal_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/negative_binomial_distribution",
+    "cppdoc": "cpp/library/numeric/random/negative_binomial_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/subtract_with_carry_engine",
+    "cppdoc": "cpp/library/numeric/random/subtract_with_carry_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/extreme_value_distribution",
+    "cppdoc": "cpp/library/numeric/random/extreme_value_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/RAND_MAX",
+    "cppdoc": "cpp/library/numeric/random/RAND_MAX"
+  },
+  {
+    "cppref": "cpp/numeric/random/fisher_f_distribution",
+    "cppdoc": "cpp/library/numeric/random/fisher_f_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/geometric_distribution",
+    "cppdoc": "cpp/library/numeric/random/geometric_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/linear_congruential_engine",
+    "cppdoc": "cpp/library/numeric/random/linear_congruential_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/bernoulli_distribution",
+    "cppdoc": "cpp/library/numeric/random/bernoulli_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/gamma_distribution",
+    "cppdoc": "cpp/library/numeric/random/gamma_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_random_bit_generator",
+    "cppdoc": "cpp/library/numeric/random/uniform_random_bit_generator"
+  },
+  {
+    "cppref": "cpp/numeric/random/mersenne_twister_engine",
+    "cppdoc": "cpp/library/numeric/random/mersenne_twister_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/shuffle_order_engine",
+    "cppdoc": "cpp/library/numeric/random/shuffle_order_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/cauchy_distribution",
+    "cppdoc": "cpp/library/numeric/random/cauchy_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/rand",
+    "cppdoc": "cpp/library/numeric/random/rand"
+  },
+  {
+    "cppref": "cpp/numeric/random/lognormal_distribution",
+    "cppdoc": "cpp/library/numeric/random/lognormal_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/UniformRandomBitGenerator",
+    "cppdoc": "cpp/library/numeric/random/UniformRandomBitGenerator"
+  },
+  {
+    "cppref": "cpp/numeric/random/seed_seq",
+    "cppdoc": "cpp/library/numeric/random/seed_seq"
+  },
+  {
+    "cppref": "cpp/numeric/random/chi_squared_distribution",
+    "cppdoc": "cpp/library/numeric/random/chi_squared_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/srand",
+    "cppdoc": "cpp/library/numeric/random/srand"
+  },
+  {
+    "cppref": "cpp/numeric/random/student_t_distribution",
+    "cppdoc": "cpp/library/numeric/random/student_t_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/discrete_distribution",
+    "cppdoc": "cpp/library/numeric/random/discrete_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/generate_canonical",
+    "cppdoc": "cpp/library/numeric/random/generate_canonical"
+  },
+  {
+    "cppref": "cpp/numeric/random/binomial_distribution",
+    "cppdoc": "cpp/library/numeric/random/binomial_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_linear_distribution",
+    "cppdoc": "cpp/library/numeric/random/piecewise_linear_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_real_distribution",
+    "cppdoc": "cpp/library/numeric/random/uniform_real_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/philox_engine",
+    "cppdoc": "cpp/library/numeric/random/philox_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/weibull_distribution",
+    "cppdoc": "cpp/library/numeric/random/weibull_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/poisson_distribution",
+    "cppdoc": "cpp/library/numeric/random/poisson_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_constant_distribution",
+    "cppdoc": "cpp/library/numeric/random/piecewise_constant_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/exponential_distribution",
+    "cppdoc": "cpp/library/numeric/random/exponential_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_int_distribution",
+    "cppdoc": "cpp/library/numeric/random/uniform_int_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/independent_bits_engine",
+    "cppdoc": "cpp/library/numeric/random/independent_bits_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/negative_binomial_distribution/negative_binomial_distribution",
+    "cppdoc": "cpp/library/numeric/random/negative_binomial_distribution/negative_binomial_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/negative_binomial_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/negative_binomial_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/negative_binomial_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/negative_binomial_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/negative_binomial_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/negative_binomial_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/negative_binomial_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/negative_binomial_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/negative_binomial_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/negative_binomial_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/negative_binomial_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/negative_binomial_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/negative_binomial_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/negative_binomial_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/negative_binomial_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/negative_binomial_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/gamma_distribution/gamma_distribution",
+    "cppdoc": "cpp/library/numeric/random/gamma_distribution/gamma_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/gamma_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/gamma_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/gamma_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/gamma_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/gamma_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/gamma_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/gamma_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/gamma_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/gamma_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/gamma_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/gamma_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/gamma_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/gamma_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/gamma_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/gamma_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/gamma_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/shuffle_order_engine/discard",
+    "cppdoc": "cpp/library/numeric/random/shuffle_order_engine/discard"
+  },
+  {
+    "cppref": "cpp/numeric/random/shuffle_order_engine/min",
+    "cppdoc": "cpp/library/numeric/random/shuffle_order_engine/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/shuffle_order_engine/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/shuffle_order_engine/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/shuffle_order_engine/shuffle_order_engine",
+    "cppdoc": "cpp/library/numeric/random/shuffle_order_engine/shuffle_order_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/shuffle_order_engine/max",
+    "cppdoc": "cpp/library/numeric/random/shuffle_order_engine/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/shuffle_order_engine/operator()",
+    "cppdoc": "cpp/library/numeric/random/shuffle_order_engine/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/shuffle_order_engine/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/shuffle_order_engine/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/shuffle_order_engine/seed",
+    "cppdoc": "cpp/library/numeric/random/shuffle_order_engine/seed"
+  },
+  {
+    "cppref": "cpp/numeric/random/shuffle_order_engine/base",
+    "cppdoc": "cpp/library/numeric/random/shuffle_order_engine/base"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_int_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/uniform_int_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_int_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/uniform_int_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_int_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/uniform_int_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_int_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/uniform_int_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_int_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/uniform_int_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_int_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/uniform_int_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_int_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/uniform_int_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_int_distribution/uniform_int_distribution",
+    "cppdoc": "cpp/library/numeric/random/uniform_int_distribution/uniform_int_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_int_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/uniform_int_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/discard_block_engine/discard_block_engine",
+    "cppdoc": "cpp/library/numeric/random/discard_block_engine/discard_block_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/discard_block_engine/discard",
+    "cppdoc": "cpp/library/numeric/random/discard_block_engine/discard"
+  },
+  {
+    "cppref": "cpp/numeric/random/discard_block_engine/min",
+    "cppdoc": "cpp/library/numeric/random/discard_block_engine/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/discard_block_engine/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/discard_block_engine/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/discard_block_engine/max",
+    "cppdoc": "cpp/library/numeric/random/discard_block_engine/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/discard_block_engine/operator()",
+    "cppdoc": "cpp/library/numeric/random/discard_block_engine/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/discard_block_engine/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/discard_block_engine/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/discard_block_engine/seed",
+    "cppdoc": "cpp/library/numeric/random/discard_block_engine/seed"
+  },
+  {
+    "cppref": "cpp/numeric/random/discard_block_engine/base",
+    "cppdoc": "cpp/library/numeric/random/discard_block_engine/base"
+  },
+  {
+    "cppref": "cpp/numeric/random/bernoulli_distribution/bernoulli_distribution",
+    "cppdoc": "cpp/library/numeric/random/bernoulli_distribution/bernoulli_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/bernoulli_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/bernoulli_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/bernoulli_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/bernoulli_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/bernoulli_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/bernoulli_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/bernoulli_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/bernoulli_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/bernoulli_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/bernoulli_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/bernoulli_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/bernoulli_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/bernoulli_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/bernoulli_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/bernoulli_distribution/p",
+    "cppdoc": "cpp/library/numeric/random/bernoulli_distribution/p"
+  },
+  {
+    "cppref": "cpp/numeric/random/student_t_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/student_t_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/student_t_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/student_t_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/student_t_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/student_t_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/student_t_distribution/student_t_distribution",
+    "cppdoc": "cpp/library/numeric/random/student_t_distribution/student_t_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/student_t_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/student_t_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/student_t_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/student_t_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/student_t_distribution/n",
+    "cppdoc": "cpp/library/numeric/random/student_t_distribution/n"
+  },
+  {
+    "cppref": "cpp/numeric/random/student_t_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/student_t_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/student_t_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/student_t_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/binomial_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/binomial_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/binomial_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/binomial_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/binomial_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/binomial_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/binomial_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/binomial_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/binomial_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/binomial_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/binomial_distribution/binomial_distribution",
+    "cppdoc": "cpp/library/numeric/random/binomial_distribution/binomial_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/binomial_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/binomial_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/binomial_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/binomial_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/binomial_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/binomial_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_constant_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/piecewise_constant_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_constant_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/piecewise_constant_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_constant_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/piecewise_constant_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_constant_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/piecewise_constant_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_constant_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/piecewise_constant_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_constant_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/piecewise_constant_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_constant_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/piecewise_constant_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_constant_distribution/piecewise_constant_distribution",
+    "cppdoc": "cpp/library/numeric/random/piecewise_constant_distribution/piecewise_constant_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_constant_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/piecewise_constant_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/independent_bits_engine/discard",
+    "cppdoc": "cpp/library/numeric/random/independent_bits_engine/discard"
+  },
+  {
+    "cppref": "cpp/numeric/random/independent_bits_engine/min",
+    "cppdoc": "cpp/library/numeric/random/independent_bits_engine/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/independent_bits_engine/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/independent_bits_engine/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/independent_bits_engine/max",
+    "cppdoc": "cpp/library/numeric/random/independent_bits_engine/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/independent_bits_engine/operator()",
+    "cppdoc": "cpp/library/numeric/random/independent_bits_engine/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/independent_bits_engine/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/independent_bits_engine/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/independent_bits_engine/seed",
+    "cppdoc": "cpp/library/numeric/random/independent_bits_engine/seed"
+  },
+  {
+    "cppref": "cpp/numeric/random/independent_bits_engine/base",
+    "cppdoc": "cpp/library/numeric/random/independent_bits_engine/base"
+  },
+  {
+    "cppref": "cpp/numeric/random/independent_bits_engine/independent_bits_engine",
+    "cppdoc": "cpp/library/numeric/random/independent_bits_engine/independent_bits_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/cauchy_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/cauchy_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/cauchy_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/cauchy_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/cauchy_distribution/cauchy_distribution",
+    "cppdoc": "cpp/library/numeric/random/cauchy_distribution/cauchy_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/cauchy_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/cauchy_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/cauchy_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/cauchy_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/cauchy_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/cauchy_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/cauchy_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/cauchy_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/cauchy_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/cauchy_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/cauchy_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/cauchy_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/normal_distribution/normal_distribution",
+    "cppdoc": "cpp/library/numeric/random/normal_distribution/normal_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/normal_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/normal_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/normal_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/normal_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/normal_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/normal_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/normal_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/normal_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/normal_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/normal_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/normal_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/normal_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/normal_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/normal_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/normal_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/normal_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/linear_congruential_engine/discard",
+    "cppdoc": "cpp/library/numeric/random/linear_congruential_engine/discard"
+  },
+  {
+    "cppref": "cpp/numeric/random/linear_congruential_engine/linear_congruential_engine",
+    "cppdoc": "cpp/library/numeric/random/linear_congruential_engine/linear_congruential_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/linear_congruential_engine/min",
+    "cppdoc": "cpp/library/numeric/random/linear_congruential_engine/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/linear_congruential_engine/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/linear_congruential_engine/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/linear_congruential_engine/max",
+    "cppdoc": "cpp/library/numeric/random/linear_congruential_engine/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/linear_congruential_engine/operator()",
+    "cppdoc": "cpp/library/numeric/random/linear_congruential_engine/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/linear_congruential_engine/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/linear_congruential_engine/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/linear_congruential_engine/seed",
+    "cppdoc": "cpp/library/numeric/random/linear_congruential_engine/seed"
+  },
+  {
+    "cppref": "cpp/numeric/random/extreme_value_distribution/extreme_value_distribution",
+    "cppdoc": "cpp/library/numeric/random/extreme_value_distribution/extreme_value_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/extreme_value_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/extreme_value_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/extreme_value_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/extreme_value_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/extreme_value_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/extreme_value_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/extreme_value_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/extreme_value_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/extreme_value_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/extreme_value_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/extreme_value_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/extreme_value_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/extreme_value_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/extreme_value_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/extreme_value_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/extreme_value_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/weibull_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/weibull_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/weibull_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/weibull_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/weibull_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/weibull_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/weibull_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/weibull_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/weibull_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/weibull_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/weibull_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/weibull_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/weibull_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/weibull_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/weibull_distribution/weibull_distribution",
+    "cppdoc": "cpp/library/numeric/random/weibull_distribution/weibull_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/weibull_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/weibull_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/discrete_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/discrete_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/discrete_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/discrete_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/discrete_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/discrete_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/discrete_distribution/probabilities",
+    "cppdoc": "cpp/library/numeric/random/discrete_distribution/probabilities"
+  },
+  {
+    "cppref": "cpp/numeric/random/discrete_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/discrete_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/discrete_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/discrete_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/discrete_distribution/discrete_distribution",
+    "cppdoc": "cpp/library/numeric/random/discrete_distribution/discrete_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/discrete_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/discrete_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/discrete_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/discrete_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/chi_squared_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/chi_squared_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/chi_squared_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/chi_squared_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/chi_squared_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/chi_squared_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/chi_squared_distribution/chi_squared_distribution",
+    "cppdoc": "cpp/library/numeric/random/chi_squared_distribution/chi_squared_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/chi_squared_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/chi_squared_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/chi_squared_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/chi_squared_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/chi_squared_distribution/n",
+    "cppdoc": "cpp/library/numeric/random/chi_squared_distribution/n"
+  },
+  {
+    "cppref": "cpp/numeric/random/chi_squared_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/chi_squared_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/chi_squared_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/chi_squared_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/poisson_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/poisson_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/poisson_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/poisson_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/poisson_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/poisson_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/poisson_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/poisson_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/poisson_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/poisson_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/poisson_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/poisson_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/poisson_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/poisson_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/poisson_distribution/poisson_distribution",
+    "cppdoc": "cpp/library/numeric/random/poisson_distribution/poisson_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/poisson_distribution/mean",
+    "cppdoc": "cpp/library/numeric/random/poisson_distribution/mean"
+  },
+  {
+    "cppref": "cpp/numeric/random/philox_engine/discard",
+    "cppdoc": "cpp/library/numeric/random/philox_engine/discard"
+  },
+  {
+    "cppref": "cpp/numeric/random/philox_engine/min",
+    "cppdoc": "cpp/library/numeric/random/philox_engine/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/philox_engine/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/philox_engine/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/philox_engine/max",
+    "cppdoc": "cpp/library/numeric/random/philox_engine/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/philox_engine/operator()",
+    "cppdoc": "cpp/library/numeric/random/philox_engine/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/philox_engine/set_counter",
+    "cppdoc": "cpp/library/numeric/random/philox_engine/set_counter"
+  },
+  {
+    "cppref": "cpp/numeric/random/philox_engine/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/philox_engine/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/philox_engine/philox_engine",
+    "cppdoc": "cpp/library/numeric/random/philox_engine/philox_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/philox_engine/seed",
+    "cppdoc": "cpp/library/numeric/random/philox_engine/seed"
+  },
+  {
+    "cppref": "cpp/numeric/random/exponential_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/exponential_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/exponential_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/exponential_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/exponential_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/exponential_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/exponential_distribution/lambda",
+    "cppdoc": "cpp/library/numeric/random/exponential_distribution/lambda"
+  },
+  {
+    "cppref": "cpp/numeric/random/exponential_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/exponential_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/exponential_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/exponential_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/exponential_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/exponential_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/exponential_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/exponential_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/exponential_distribution/exponential_distribution",
+    "cppdoc": "cpp/library/numeric/random/exponential_distribution/exponential_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/mersenne_twister_engine/discard",
+    "cppdoc": "cpp/library/numeric/random/mersenne_twister_engine/discard"
+  },
+  {
+    "cppref": "cpp/numeric/random/mersenne_twister_engine/mersenne_twister_engine",
+    "cppdoc": "cpp/library/numeric/random/mersenne_twister_engine/mersenne_twister_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/mersenne_twister_engine/min",
+    "cppdoc": "cpp/library/numeric/random/mersenne_twister_engine/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/mersenne_twister_engine/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/mersenne_twister_engine/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/mersenne_twister_engine/max",
+    "cppdoc": "cpp/library/numeric/random/mersenne_twister_engine/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/mersenne_twister_engine/operator()",
+    "cppdoc": "cpp/library/numeric/random/mersenne_twister_engine/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/mersenne_twister_engine/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/mersenne_twister_engine/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/mersenne_twister_engine/seed",
+    "cppdoc": "cpp/library/numeric/random/mersenne_twister_engine/seed"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_linear_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/piecewise_linear_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_linear_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/piecewise_linear_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_linear_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/piecewise_linear_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_linear_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/piecewise_linear_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_linear_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/piecewise_linear_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_linear_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/piecewise_linear_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_linear_distribution/piecewise_linear_distribution",
+    "cppdoc": "cpp/library/numeric/random/piecewise_linear_distribution/piecewise_linear_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_linear_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/piecewise_linear_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/piecewise_linear_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/piecewise_linear_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/subtract_with_carry_engine/subtract_with_carry_engine",
+    "cppdoc": "cpp/library/numeric/random/subtract_with_carry_engine/subtract_with_carry_engine"
+  },
+  {
+    "cppref": "cpp/numeric/random/subtract_with_carry_engine/discard",
+    "cppdoc": "cpp/library/numeric/random/subtract_with_carry_engine/discard"
+  },
+  {
+    "cppref": "cpp/numeric/random/subtract_with_carry_engine/min",
+    "cppdoc": "cpp/library/numeric/random/subtract_with_carry_engine/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/subtract_with_carry_engine/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/subtract_with_carry_engine/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/subtract_with_carry_engine/max",
+    "cppdoc": "cpp/library/numeric/random/subtract_with_carry_engine/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/subtract_with_carry_engine/operator()",
+    "cppdoc": "cpp/library/numeric/random/subtract_with_carry_engine/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/subtract_with_carry_engine/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/subtract_with_carry_engine/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/subtract_with_carry_engine/seed",
+    "cppdoc": "cpp/library/numeric/random/subtract_with_carry_engine/seed"
+  },
+  {
+    "cppref": "cpp/numeric/random/lognormal_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/lognormal_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/lognormal_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/lognormal_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/lognormal_distribution/lognormal_distribution",
+    "cppdoc": "cpp/library/numeric/random/lognormal_distribution/lognormal_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/lognormal_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/lognormal_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/lognormal_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/lognormal_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/lognormal_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/lognormal_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/lognormal_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/lognormal_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/lognormal_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/lognormal_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/lognormal_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/lognormal_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/geometric_distribution/geometric_distribution",
+    "cppdoc": "cpp/library/numeric/random/geometric_distribution/geometric_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/geometric_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/geometric_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/geometric_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/geometric_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/geometric_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/geometric_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/geometric_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/geometric_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/geometric_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/geometric_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/geometric_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/geometric_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/geometric_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/geometric_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/geometric_distribution/p",
+    "cppdoc": "cpp/library/numeric/random/geometric_distribution/p"
+  },
+  {
+    "cppref": "cpp/numeric/random/random_device/random_device",
+    "cppdoc": "cpp/library/numeric/random/random_device/random_device"
+  },
+  {
+    "cppref": "cpp/numeric/random/random_device/min",
+    "cppdoc": "cpp/library/numeric/random/random_device/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/random_device/max",
+    "cppdoc": "cpp/library/numeric/random/random_device/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/random_device/operator()",
+    "cppdoc": "cpp/library/numeric/random/random_device/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/random_device/entropy",
+    "cppdoc": "cpp/library/numeric/random/random_device/entropy"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_real_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/uniform_real_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_real_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/uniform_real_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_real_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/uniform_real_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_real_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/uniform_real_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_real_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/uniform_real_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_real_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/uniform_real_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_real_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/uniform_real_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_real_distribution/uniform_real_distribution",
+    "cppdoc": "cpp/library/numeric/random/uniform_real_distribution/uniform_real_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/uniform_real_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/uniform_real_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/fisher_f_distribution/fisher_f_distribution",
+    "cppdoc": "cpp/library/numeric/random/fisher_f_distribution/fisher_f_distribution"
+  },
+  {
+    "cppref": "cpp/numeric/random/fisher_f_distribution/min",
+    "cppdoc": "cpp/library/numeric/random/fisher_f_distribution/min"
+  },
+  {
+    "cppref": "cpp/numeric/random/fisher_f_distribution/operator_ltltgtgt",
+    "cppdoc": "cpp/library/numeric/random/fisher_f_distribution/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/numeric/random/fisher_f_distribution/reset",
+    "cppdoc": "cpp/library/numeric/random/fisher_f_distribution/reset"
+  },
+  {
+    "cppref": "cpp/numeric/random/fisher_f_distribution/param",
+    "cppdoc": "cpp/library/numeric/random/fisher_f_distribution/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/fisher_f_distribution/max",
+    "cppdoc": "cpp/library/numeric/random/fisher_f_distribution/max"
+  },
+  {
+    "cppref": "cpp/numeric/random/fisher_f_distribution/operator()",
+    "cppdoc": "cpp/library/numeric/random/fisher_f_distribution/operator()"
+  },
+  {
+    "cppref": "cpp/numeric/random/fisher_f_distribution/operator_cmp",
+    "cppdoc": "cpp/library/numeric/random/fisher_f_distribution/operator_cmp"
+  },
+  {
+    "cppref": "cpp/numeric/random/fisher_f_distribution/params",
+    "cppdoc": "cpp/library/numeric/random/fisher_f_distribution/params"
+  },
+  {
+    "cppref": "cpp/numeric/random/seed_seq/size",
+    "cppdoc": "cpp/library/numeric/random/seed_seq/size"
+  },
+  {
+    "cppref": "cpp/numeric/random/seed_seq/seed_seq",
+    "cppdoc": "cpp/library/numeric/random/seed_seq/seed_seq"
+  },
+  {
+    "cppref": "cpp/numeric/random/seed_seq/param",
+    "cppdoc": "cpp/library/numeric/random/seed_seq/param"
+  },
+  {
+    "cppref": "cpp/numeric/random/seed_seq/generate",
+    "cppdoc": "cpp/library/numeric/random/seed_seq/generate"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/feupdateenv",
+    "cppdoc": "cpp/library/numeric/fenv/feupdateenv"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/FE_exceptions",
+    "cppdoc": "cpp/library/numeric/fenv/FE_exceptions"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/feexceptflag",
+    "cppdoc": "cpp/library/numeric/fenv/feexceptflag"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/feholdexcept",
+    "cppdoc": "cpp/library/numeric/fenv/feholdexcept"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/feraiseexcept",
+    "cppdoc": "cpp/library/numeric/fenv/feraiseexcept"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/feround",
+    "cppdoc": "cpp/library/numeric/fenv/feround"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/FE_round",
+    "cppdoc": "cpp/library/numeric/fenv/FE_round"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/feenv",
+    "cppdoc": "cpp/library/numeric/fenv/feenv"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/fetestexcept",
+    "cppdoc": "cpp/library/numeric/fenv/fetestexcept"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/FE_DFL_ENV",
+    "cppdoc": "cpp/library/numeric/fenv/FE_DFL_ENV"
+  },
+  {
+    "cppref": "cpp/numeric/fenv/feclearexcept",
+    "cppdoc": "cpp/library/numeric/fenv/feclearexcept"
+  },
+  {
+    "cppref": "cpp/numeric/math/fma",
+    "cppdoc": "cpp/library/numeric/math/fma"
+  },
+  {
+    "cppref": "cpp/numeric/math/asin",
+    "cppdoc": "cpp/library/numeric/math/asin"
+  },
+  {
+    "cppref": "cpp/numeric/math/isnormal",
+    "cppdoc": "cpp/library/numeric/math/isnormal"
+  },
+  {
+    "cppref": "cpp/numeric/math/sin",
+    "cppdoc": "cpp/library/numeric/math/sin"
+  },
+  {
+    "cppref": "cpp/numeric/math/scalbn",
+    "cppdoc": "cpp/library/numeric/math/scalbn"
+  },
+  {
+    "cppref": "cpp/numeric/math/acos",
+    "cppdoc": "cpp/library/numeric/math/acos"
+  },
+  {
+    "cppref": "cpp/numeric/math/modf",
+    "cppdoc": "cpp/library/numeric/math/modf"
+  },
+  {
+    "cppref": "cpp/numeric/math/tan",
+    "cppdoc": "cpp/library/numeric/math/tan"
+  },
+  {
+    "cppref": "cpp/numeric/math/fmin",
+    "cppdoc": "cpp/library/numeric/math/fmin"
+  },
+  {
+    "cppref": "cpp/numeric/math/frexp",
+    "cppdoc": "cpp/library/numeric/math/frexp"
+  },
+  {
+    "cppref": "cpp/numeric/math/fabs",
+    "cppdoc": "cpp/library/numeric/math/fabs"
+  },
+  {
+    "cppref": "cpp/numeric/math/floor",
+    "cppdoc": "cpp/library/numeric/math/floor"
+  },
+  {
+    "cppref": "cpp/numeric/math/fdim",
+    "cppdoc": "cpp/library/numeric/math/fdim"
+  },
+  {
+    "cppref": "cpp/numeric/math/ldexp",
+    "cppdoc": "cpp/library/numeric/math/ldexp"
+  },
+  {
+    "cppref": "cpp/numeric/math/log2",
+    "cppdoc": "cpp/library/numeric/math/log2"
+  },
+  {
+    "cppref": "cpp/numeric/math/ceil",
+    "cppdoc": "cpp/library/numeric/math/ceil"
+  },
+  {
+    "cppref": "cpp/numeric/math/erfc",
+    "cppdoc": "cpp/library/numeric/math/erfc"
+  },
+  {
+    "cppref": "cpp/numeric/math/isless",
+    "cppdoc": "cpp/library/numeric/math/isless"
+  },
+  {
+    "cppref": "cpp/numeric/math/exp",
+    "cppdoc": "cpp/library/numeric/math/exp"
+  },
+  {
+    "cppref": "cpp/numeric/math/sqrt",
+    "cppdoc": "cpp/library/numeric/math/sqrt"
+  },
+  {
+    "cppref": "cpp/numeric/math/tgamma",
+    "cppdoc": "cpp/library/numeric/math/tgamma"
+  },
+  {
+    "cppref": "cpp/numeric/math/math_errhandling",
+    "cppdoc": "cpp/library/numeric/math/math_errhandling"
+  },
+  {
+    "cppref": "cpp/numeric/math/erf",
+    "cppdoc": "cpp/library/numeric/math/erf"
+  },
+  {
+    "cppref": "cpp/numeric/math/log1p",
+    "cppdoc": "cpp/library/numeric/math/log1p"
+  },
+  {
+    "cppref": "cpp/numeric/math/exp2",
+    "cppdoc": "cpp/library/numeric/math/exp2"
+  },
+  {
+    "cppref": "cpp/numeric/math/remainder",
+    "cppdoc": "cpp/library/numeric/math/remainder"
+  },
+  {
+    "cppref": "cpp/numeric/math/islessgreater",
+    "cppdoc": "cpp/library/numeric/math/islessgreater"
+  },
+  {
+    "cppref": "cpp/numeric/math/isunordered",
+    "cppdoc": "cpp/library/numeric/math/isunordered"
+  },
+  {
+    "cppref": "cpp/numeric/math/isnan",
+    "cppdoc": "cpp/library/numeric/math/isnan"
+  },
+  {
+    "cppref": "cpp/numeric/math/isfinite",
+    "cppdoc": "cpp/library/numeric/math/isfinite"
+  },
+  {
+    "cppref": "cpp/numeric/math/ilogb",
+    "cppdoc": "cpp/library/numeric/math/ilogb"
+  },
+  {
+    "cppref": "cpp/numeric/math/trunc",
+    "cppdoc": "cpp/library/numeric/math/trunc"
+  },
+  {
+    "cppref": "cpp/numeric/math/isinf",
+    "cppdoc": "cpp/library/numeric/math/isinf"
+  },
+  {
+    "cppref": "cpp/numeric/math/signbit",
+    "cppdoc": "cpp/library/numeric/math/signbit"
+  },
+  {
+    "cppref": "cpp/numeric/math/HUGE_VAL",
+    "cppdoc": "cpp/library/numeric/math/HUGE_VAL"
+  },
+  {
+    "cppref": "cpp/numeric/math/cosh",
+    "cppdoc": "cpp/library/numeric/math/cosh"
+  },
+  {
+    "cppref": "cpp/numeric/math/pow",
+    "cppdoc": "cpp/library/numeric/math/pow"
+  },
+  {
+    "cppref": "cpp/numeric/math/isgreaterequal",
+    "cppdoc": "cpp/library/numeric/math/isgreaterequal"
+  },
+  {
+    "cppref": "cpp/numeric/math/INFINITY",
+    "cppdoc": "cpp/library/numeric/math/INFINITY"
+  },
+  {
+    "cppref": "cpp/numeric/math/logb",
+    "cppdoc": "cpp/library/numeric/math/logb"
+  },
+  {
+    "cppref": "cpp/numeric/math/NAN",
+    "cppdoc": "cpp/library/numeric/math/NAN"
+  },
+  {
+    "cppref": "cpp/numeric/math/asinh",
+    "cppdoc": "cpp/library/numeric/math/asinh"
+  },
+  {
+    "cppref": "cpp/numeric/math/lgamma",
+    "cppdoc": "cpp/library/numeric/math/lgamma"
+  },
+  {
+    "cppref": "cpp/numeric/math/FP_categories",
+    "cppdoc": "cpp/library/numeric/math/FP_categories"
+  },
+  {
+    "cppref": "cpp/numeric/math/tanh",
+    "cppdoc": "cpp/library/numeric/math/tanh"
+  },
+  {
+    "cppref": "cpp/numeric/math/copysign",
+    "cppdoc": "cpp/library/numeric/math/copysign"
+  },
+  {
+    "cppref": "cpp/numeric/math/cbrt",
+    "cppdoc": "cpp/library/numeric/math/cbrt"
+  },
+  {
+    "cppref": "cpp/numeric/math/hypot",
+    "cppdoc": "cpp/library/numeric/math/hypot"
+  },
+  {
+    "cppref": "cpp/numeric/math/cos",
+    "cppdoc": "cpp/library/numeric/math/cos"
+  },
+  {
+    "cppref": "cpp/numeric/math/rint",
+    "cppdoc": "cpp/library/numeric/math/rint"
+  },
+  {
+    "cppref": "cpp/numeric/math/nextafter",
+    "cppdoc": "cpp/library/numeric/math/nextafter"
+  },
+  {
+    "cppref": "cpp/numeric/math/sinh",
+    "cppdoc": "cpp/library/numeric/math/sinh"
+  },
+  {
+    "cppref": "cpp/numeric/math/isgreater",
+    "cppdoc": "cpp/library/numeric/math/isgreater"
+  },
+  {
+    "cppref": "cpp/numeric/math/nearbyint",
+    "cppdoc": "cpp/library/numeric/math/nearbyint"
+  },
+  {
+    "cppref": "cpp/numeric/math/atan",
+    "cppdoc": "cpp/library/numeric/math/atan"
+  },
+  {
+    "cppref": "cpp/numeric/math/atan2",
+    "cppdoc": "cpp/library/numeric/math/atan2"
+  },
+  {
+    "cppref": "cpp/numeric/math/log10",
+    "cppdoc": "cpp/library/numeric/math/log10"
+  },
+  {
+    "cppref": "cpp/numeric/math/round",
+    "cppdoc": "cpp/library/numeric/math/round"
+  },
+  {
+    "cppref": "cpp/numeric/math/nan.2",
+    "cppdoc": "cpp/library/numeric/math/nan.2"
+  },
+  {
+    "cppref": "cpp/numeric/math/fmax",
+    "cppdoc": "cpp/library/numeric/math/fmax"
+  },
+  {
+    "cppref": "cpp/numeric/math/remquo",
+    "cppdoc": "cpp/library/numeric/math/remquo"
+  },
+  {
+    "cppref": "cpp/numeric/math/acosh",
+    "cppdoc": "cpp/library/numeric/math/acosh"
+  },
+  {
+    "cppref": "cpp/numeric/math/islessequal",
+    "cppdoc": "cpp/library/numeric/math/islessequal"
+  },
+  {
+    "cppref": "cpp/numeric/math/abs",
+    "cppdoc": "cpp/library/numeric/math/abs"
+  },
+  {
+    "cppref": "cpp/numeric/math/div",
+    "cppdoc": "cpp/library/numeric/math/div"
+  },
+  {
+    "cppref": "cpp/numeric/math/log",
+    "cppdoc": "cpp/library/numeric/math/log"
+  },
+  {
+    "cppref": "cpp/numeric/math/fpclassify",
+    "cppdoc": "cpp/library/numeric/math/fpclassify"
+  },
+  {
+    "cppref": "cpp/numeric/math/fmod",
+    "cppdoc": "cpp/library/numeric/math/fmod"
+  },
+  {
+    "cppref": "cpp/numeric/math/expm1",
+    "cppdoc": "cpp/library/numeric/math/expm1"
+  },
+  {
+    "cppref": "cpp/numeric/math/atanh",
+    "cppdoc": "cpp/library/numeric/math/atanh"
+  },
+  {
+    "cppref": "cpp/numeric/simd/basic_simd",
+    "cppdoc": "cpp/library/numeric/simd/basic_simd"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio_less",
+    "cppdoc": "cpp/library/meta/ratio/ratio_less"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio_equal",
+    "cppdoc": "cpp/library/meta/ratio/ratio_equal"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio",
+    "cppdoc": "cpp/library/meta/ratio/ratio"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio_add",
+    "cppdoc": "cpp/library/meta/ratio/ratio_add"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio_not_equal",
+    "cppdoc": "cpp/library/meta/ratio/ratio_not_equal"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio_greater_equal",
+    "cppdoc": "cpp/library/meta/ratio/ratio_greater_equal"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio_divide",
+    "cppdoc": "cpp/library/meta/ratio/ratio_divide"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio_greater",
+    "cppdoc": "cpp/library/meta/ratio/ratio_greater"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio_multiply",
+    "cppdoc": "cpp/library/meta/ratio/ratio_multiply"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio_less_equal",
+    "cppdoc": "cpp/library/meta/ratio/ratio_less_equal"
+  },
+  {
+    "cppref": "cpp/numeric/ratio/ratio_subtract",
+    "cppdoc": "cpp/library/meta/ratio/ratio_subtract"
+  },
+  {
+    "cppref": "cpp/language/classes",
+    "cppdoc": "cpp/language/classes"
+  },
+  {
+    "cppref": "cpp/language/static",
+    "cppdoc": "cpp/language/classes/static"
+  },
+  {
+    "cppref": "cpp/language/declarations",
+    "cppdoc": "cpp/language/declarations"
+  },
+  {
+    "cppref": "cpp/language/consteval",
+    "cppdoc": "cpp/language/declarations/consteval"
+  },
+  {
+    "cppref": "cpp/language/structured_binding",
+    "cppdoc": "cpp/language/declarations/structured_binding"
+  },
+  {
+    "cppref": "cpp/language/namespace_alias",
+    "cppdoc": "cpp/language/declarations/namespace_alias"
+  },
+  {
+    "cppref": "cpp/language/expressions",
+    "cppdoc": "cpp/language/expressions"
+  },
+  {
+    "cppref": "cpp/language/operator_alternative",
+    "cppdoc": "cpp/language/expressions/operator_alternative"
+  },
+  {
+    "cppref": "cpp/language/templates",
+    "cppdoc": "cpp/language/templates"
+  },
+  {
+    "cppref": "cpp/language/partial_specialization",
+    "cppdoc": "cpp/language/templates/partial_specialization"
+  },
+  {
+    "cppref": "cpp/language/default_constructor",
+    "cppdoc": "cpp/language/classes/default_constructor"
+  },
+  {
+    "cppref": "cpp/language/attributes",
+    "cppdoc": "cpp/language/declarations/attributes"
+  },
+  {
+    "cppref": "cpp/language/pack_indexing",
+    "cppdoc": "cpp/language/templates/pack_indexing"
+  },
+  {
+    "cppref": "cpp/language/initializer_list",
+    "cppdoc": "cpp/language/classes/initializer_list"
+  },
+  {
+    "cppref": "cpp/language/using_declaration",
+    "cppdoc": "cpp/language/classes/using_declaration"
+  },
+  {
+    "cppref": "cpp/language/delete",
+    "cppdoc": "cpp/language/expressions/delete"
+  },
+  {
+    "cppref": "cpp/language/variable_template",
+    "cppdoc": "cpp/language/templates/variable_template"
+  },
+  {
+    "cppref": "cpp/language/class",
+    "cppdoc": "cpp/language/classes/class"
+  },
+  {
+    "cppref": "cpp/language/elaborated_type_specifier",
+    "cppdoc": "cpp/language/declarations/elaborated_type_specifier"
+  },
+  {
+    "cppref": "cpp/language/cv",
+    "cppdoc": "cpp/language/declarations/cv"
+  },
+  {
+    "cppref": "cpp/language/parameter_pack",
+    "cppdoc": "cpp/language/templates/parameter_pack"
+  },
+  {
+    "cppref": "cpp/language/default_comparisons",
+    "cppdoc": "cpp/language/expressions/default_comparisons"
+  },
+  {
+    "cppref": "cpp/language/operator_logical",
+    "cppdoc": "cpp/language/expressions/operator_logical"
+  },
+  {
+    "cppref": "cpp/language/requires",
+    "cppdoc": "cpp/language/templates/requires"
+  },
+  {
+    "cppref": "cpp/language/operator_incdec",
+    "cppdoc": "cpp/language/expressions/operator_incdec"
+  },
+  {
+    "cppref": "cpp/language/ndr",
+    "cppdoc": "cpp/language/ndr"
+  },
+  {
+    "cppref": "cpp/language/alignof",
+    "cppdoc": "cpp/language/expressions/alignof"
+  },
+  {
+    "cppref": "cpp/language/namespace",
+    "cppdoc": "cpp/language/declarations/namespace"
+  },
+  {
+    "cppref": "cpp/language/ascii",
+    "cppdoc": "cpp/language/ascii"
+  },
+  {
+    "cppref": "cpp/language/template_parameters",
+    "cppdoc": "cpp/language/templates/template_parameters"
+  },
+  {
+    "cppref": "cpp/language/rule_of_three",
+    "cppdoc": "cpp/language/rule_of_three"
+  },
+  {
+    "cppref": "cpp/language/operator_other",
+    "cppdoc": "cpp/language/expressions/operator_other"
+  },
+  {
+    "cppref": "cpp/language/destructor",
+    "cppdoc": "cpp/language/classes/destructor"
+  },
+  {
+    "cppref": "cpp/language/escape",
+    "cppdoc": "cpp/language/expressions/escape"
+  },
+  {
+    "cppref": "cpp/language/statements",
+    "cppdoc": "cpp/language/statements"
+  },
+  {
+    "cppref": "cpp/language/explicit_cast",
+    "cppdoc": "cpp/language/expressions/explicit_cast"
+  },
+  {
+    "cppref": "cpp/language/bool_literal",
+    "cppdoc": "cpp/language/expressions/bool_literal"
+  },
+  {
+    "cppref": "cpp/language/move_constructor",
+    "cppdoc": "cpp/language/classes/move_constructor"
+  },
+  {
+    "cppref": "cpp/language/this",
+    "cppdoc": "cpp/language/classes/this"
+  },
+  {
+    "cppref": "cpp/language/explicit",
+    "cppdoc": "cpp/language/classes/explicit"
+  },
+  {
+    "cppref": "cpp/language/member_functions",
+    "cppdoc": "cpp/language/classes/member_functions"
+  },
+  {
+    "cppref": "cpp/language/operator_precedence",
+    "cppdoc": "cpp/language/expressions/operator_precedence"
+  },
+  {
+    "cppref": "cpp/language/floating_literal",
+    "cppdoc": "cpp/language/expressions/floating_literal"
+  },
+  {
+    "cppref": "cpp/language/constant_expression",
+    "cppdoc": "cpp/language/expressions/constant_expression"
+  },
+  {
+    "cppref": "cpp/language/switch",
+    "cppdoc": "cpp/language/statements/switch"
+  },
+  {
+    "cppref": "cpp/language/language_linkage",
+    "cppdoc": "cpp/language/declarations/language_linkage"
+  },
+  {
+    "cppref": "cpp/language/abstract_class",
+    "cppdoc": "cpp/language/classes/abstract_class"
+  },
+  {
+    "cppref": "cpp/language/constraints",
+    "cppdoc": "cpp/language/templates/constraints"
+  },
+  {
+    "cppref": "cpp/language/new",
+    "cppdoc": "cpp/language/expressions/new"
+  },
+  {
+    "cppref": "cpp/language/fold",
+    "cppdoc": "cpp/language/templates/fold"
+  },
+  {
+    "cppref": "cpp/language/raii",
+    "cppdoc": "cpp/language/raii"
+  },
+  {
+    "cppref": "cpp/language/crtp",
+    "cppdoc": "cpp/language/crtp"
+  },
+  {
+    "cppref": "cpp/language/sizeof",
+    "cppdoc": "cpp/language/expressions/sizeof"
+  },
+  {
+    "cppref": "cpp/language/move_assignment",
+    "cppdoc": "cpp/language/classes/move_assignment"
+  },
+  {
+    "cppref": "cpp/language/template_specialization",
+    "cppdoc": "cpp/language/templates/template_specialization"
+  },
+  {
+    "cppref": "cpp/language/deduction_guide",
+    "cppdoc": "cpp/language/templates/deduction_guide"
+  },
+  {
+    "cppref": "cpp/language/for",
+    "cppdoc": "cpp/language/statements/for"
+  },
+  {
+    "cppref": "cpp/language/eval_order",
+    "cppdoc": "cpp/language/expressions/eval_order"
+  },
+  {
+    "cppref": "cpp/language/exceptions",
+    "cppdoc": "cpp/language/exceptions"
+  },
+  {
+    "cppref": "cpp/language/operators",
+    "cppdoc": "cpp/language/expressions/operators"
+  },
+  {
+    "cppref": "cpp/language/continue",
+    "cppdoc": "cpp/language/statements/continue"
+  },
+  {
+    "cppref": "cpp/language/tu_local",
+    "cppdoc": "cpp/language/declarations/tu_local"
+  },
+  {
+    "cppref": "cpp/language/type_alias",
+    "cppdoc": "cpp/language/declarations/type_alias"
+  },
+  {
+    "cppref": "cpp/language/function_template",
+    "cppdoc": "cpp/language/templates/function_template"
+  },
+  {
+    "cppref": "cpp/language/character_literal",
+    "cppdoc": "cpp/language/expressions/character_literal"
+  },
+  {
+    "cppref": "cpp/language/derived_class",
+    "cppdoc": "cpp/language/classes/derived_class"
+  },
+  {
+    "cppref": "cpp/language/if",
+    "cppdoc": "cpp/language/statements/if"
+  },
+  {
+    "cppref": "cpp/language/integer_literal",
+    "cppdoc": "cpp/language/expressions/integer_literal"
+  },
+  {
+    "cppref": "cpp/language/extending_std",
+    "cppdoc": "cpp/language/extending_std"
+  },
+  {
+    "cppref": "cpp/language/array",
+    "cppdoc": "cpp/language/declarations/array"
+  },
+  {
+    "cppref": "cpp/language/operator_arithmetic",
+    "cppdoc": "cpp/language/expressions/operator_arithmetic"
+  },
+  {
+    "cppref": "cpp/language/reinterpret_cast",
+    "cppdoc": "cpp/language/expressions/reinterpret_cast"
+  },
+  {
+    "cppref": "cpp/language/static_cast",
+    "cppdoc": "cpp/language/expressions/static_cast"
+  },
+  {
+    "cppref": "cpp/language/value_category",
+    "cppdoc": "cpp/language/expressions/value_category"
+  },
+  {
+    "cppref": "cpp/language/typedef",
+    "cppdoc": "cpp/language/declarations/typedef"
+  },
+  {
+    "cppref": "cpp/language/Zero-overhead_principle",
+    "cppdoc": "cpp/language/Zero-overhead_principle"
+  },
+  {
+    "cppref": "cpp/language/injected-class-name",
+    "cppdoc": "cpp/language/classes/injected-class-name"
+  },
+  {
+    "cppref": "cpp/language/nullptr",
+    "cppdoc": "cpp/language/expressions/nullptr"
+  },
+  {
+    "cppref": "cpp/language/throw",
+    "cppdoc": "cpp/language/exceptions/throw"
+  },
+  {
+    "cppref": "cpp/language/friend",
+    "cppdoc": "cpp/language/classes/friend"
+  },
+  {
+    "cppref": "cpp/language/pimpl",
+    "cppdoc": "cpp/language/pimpl"
+  },
+  {
+    "cppref": "cpp/language/conflicting_declarations",
+    "cppdoc": "cpp/language/declarations/conflicting_declarations"
+  },
+  {
+    "cppref": "cpp/language/data_members",
+    "cppdoc": "cpp/language/classes/data_members"
+  },
+  {
+    "cppref": "cpp/language/ebo",
+    "cppdoc": "cpp/language/classes/ebo"
+  },
+  {
+    "cppref": "cpp/language/nested_types",
+    "cppdoc": "cpp/language/classes/nested_types"
+  },
+  {
+    "cppref": "cpp/language/user_literal",
+    "cppdoc": "cpp/language/expressions/user_literal"
+  },
+  {
+    "cppref": "cpp/language/static_assert",
+    "cppdoc": "cpp/language/declarations/static_assert"
+  },
+  {
+    "cppref": "cpp/language/string_literal",
+    "cppdoc": "cpp/language/expressions/string_literal"
+  },
+  {
+    "cppref": "cpp/language/transactional_memory",
+    "cppdoc": "cpp/language/statements/transactional_memory"
+  },
+  {
+    "cppref": "cpp/language/class_template",
+    "cppdoc": "cpp/language/templates/class_template"
+  },
+  {
+    "cppref": "cpp/language/template_argument_deduction",
+    "cppdoc": "cpp/language/templates/template_argument_deduction"
+  },
+  {
+    "cppref": "cpp/language/pointer",
+    "cppdoc": "cpp/language/declarations/pointer"
+  },
+  {
+    "cppref": "cpp/language/operator_assignment",
+    "cppdoc": "cpp/language/expressions/operator_assignment"
+  },
+  {
+    "cppref": "cpp/language/enum",
+    "cppdoc": "cpp/language/declarations/enum"
+  },
+  {
+    "cppref": "cpp/language/as_operator",
+    "cppdoc": "cpp/language/classes/as_operator"
+  },
+  {
+    "cppref": "cpp/language/storage_duration",
+    "cppdoc": "cpp/language/declarations/storage_duration"
+  },
+  {
+    "cppref": "cpp/language/noexcept",
+    "cppdoc": "cpp/language/exceptions/noexcept"
+  },
+  {
+    "cppref": "cpp/language/asm",
+    "cppdoc": "cpp/language/declarations/asm"
+  },
+  {
+    "cppref": "cpp/language/final",
+    "cppdoc": "cpp/language/classes/final"
+  },
+  {
+    "cppref": "cpp/language/while",
+    "cppdoc": "cpp/language/statements/while"
+  },
+  {
+    "cppref": "cpp/language/union",
+    "cppdoc": "cpp/language/classes/union"
+  },
+  {
+    "cppref": "cpp/language/implicit_cast",
+    "cppdoc": "cpp/language/expressions/implicit_cast"
+  },
+  {
+    "cppref": "cpp/language/move_operator",
+    "cppdoc": "cpp/language/classes/move_operator"
+  },
+  {
+    "cppref": "cpp/language/dynamic_cast",
+    "cppdoc": "cpp/language/expressions/dynamic_cast"
+  },
+  {
+    "cppref": "cpp/language/template_metaprogramming",
+    "cppdoc": "cpp/language/template_metaprogramming"
+  },
+  {
+    "cppref": "cpp/language/copy_constructor",
+    "cppdoc": "cpp/language/classes/copy_constructor"
+  },
+  {
+    "cppref": "cpp/language/nested_classes",
+    "cppdoc": "cpp/language/classes/nested_classes"
+  },
+  {
+    "cppref": "cpp/language/break",
+    "cppdoc": "cpp/language/statements/break"
+  },
+  {
+    "cppref": "cpp/language/sizeof...",
+    "cppdoc": "cpp/language/templates/sizeof..."
+  },
+  {
+    "cppref": "cpp/language/functions",
+    "cppdoc": "cpp/language/functions"
+  },
+  {
+    "cppref": "cpp/language/access",
+    "cppdoc": "cpp/language/classes/access"
+  },
+  {
+    "cppref": "cpp/language/ctad",
+    "cppdoc": "cpp/language/templates/ctad"
+  },
+  {
+    "cppref": "cpp/language/override",
+    "cppdoc": "cpp/language/classes/override"
+  },
+  {
+    "cppref": "cpp/language/constexpr",
+    "cppdoc": "cpp/language/declarations/constexpr"
+  },
+  {
+    "cppref": "cpp/language/reference",
+    "cppdoc": "cpp/language/declarations/reference"
+  },
+  {
+    "cppref": "cpp/language/operator_member_access",
+    "cppdoc": "cpp/language/expressions/operator_member_access"
+  },
+  {
+    "cppref": "cpp/language/converting_constructor",
+    "cppdoc": "cpp/language/classes/converting_constructor"
+  },
+  {
+    "cppref": "cpp/language/class_template_argument_deduction",
+    "cppdoc": "cpp/language/templates/class_template_argument_deduction"
+  },
+  {
+    "cppref": "cpp/language/range-for",
+    "cppdoc": "cpp/language/statements/range-for"
+  },
+  {
+    "cppref": "cpp/language/inline",
+    "cppdoc": "cpp/language/declarations/inline"
+  },
+  {
+    "cppref": "cpp/language/decltype",
+    "cppdoc": "cpp/language/declarations/decltype"
+  },
+  {
+    "cppref": "cpp/language/history",
+    "cppdoc": "cpp/language/history"
+  },
+  {
+    "cppref": "cpp/language/initialization",
+    "cppdoc": "cpp/language/initialization"
+  },
+  {
+    "cppref": "cpp/language/usual_arithmetic_conversions",
+    "cppdoc": "cpp/language/expressions/usual_arithmetic_conversions"
+  },
+  {
+    "cppref": "cpp/language/dependent_name",
+    "cppdoc": "cpp/language/templates/dependent_name"
+  },
+  {
+    "cppref": "cpp/language/typeid",
+    "cppdoc": "cpp/language/expressions/typeid"
+  },
+  {
+    "cppref": "cpp/language/bit_field",
+    "cppdoc": "cpp/language/classes/bit_field"
+  },
+  {
+    "cppref": "cpp/language/cast_operator",
+    "cppdoc": "cpp/language/expressions/cast_operator"
+  },
+  {
+    "cppref": "cpp/language/acronyms",
+    "cppdoc": "cpp/language/acronyms"
+  },
+  {
+    "cppref": "cpp/language/basic_concepts",
+    "cppdoc": "cpp/language/basic_concepts"
+  },
+  {
+    "cppref": "cpp/language/goto",
+    "cppdoc": "cpp/language/statements/goto"
+  },
+  {
+    "cppref": "cpp/language/const_cast",
+    "cppdoc": "cpp/language/expressions/const_cast"
+  },
+  {
+    "cppref": "cpp/language/reference_initialization",
+    "cppdoc": "cpp/language/initialization/reference_initialization"
+  },
+  {
+    "cppref": "cpp/language/operator_comparison",
+    "cppdoc": "cpp/language/expressions/operator_comparison"
+  },
+  {
+    "cppref": "cpp/language/virtual",
+    "cppdoc": "cpp/language/classes/virtual"
+  },
+  {
+    "cppref": "cpp/language/constinit",
+    "cppdoc": "cpp/language/declarations/constinit"
+  },
+  {
+    "cppref": "cpp/language/auto",
+    "cppdoc": "cpp/language/declarations/auto"
+  },
+  {
+    "cppref": "cpp/language/attributes/fallthrough",
+    "cppdoc": "cpp/language/declarations/attributes/fallthrough"
+  },
+  {
+    "cppref": "cpp/language/attributes/indeterminate",
+    "cppdoc": "cpp/language/declarations/attributes/indeterminate"
+  },
+  {
+    "cppref": "cpp/language/attributes/deprecated",
+    "cppdoc": "cpp/language/declarations/attributes/deprecated"
+  },
+  {
+    "cppref": "cpp/language/attributes/assume",
+    "cppdoc": "cpp/language/declarations/attributes/assume"
+  },
+  {
+    "cppref": "cpp/language/attributes/optimize_for_synchronized",
+    "cppdoc": "cpp/language/declarations/attributes/optimize_for_synchronized"
+  },
+  {
+    "cppref": "cpp/language/attributes/maybe_unused",
+    "cppdoc": "cpp/language/declarations/attributes/maybe_unused"
+  },
+  {
+    "cppref": "cpp/language/attributes/likely",
+    "cppdoc": "cpp/language/declarations/attributes/likely"
+  },
+  {
+    "cppref": "cpp/language/attributes/noreturn",
+    "cppdoc": "cpp/language/declarations/attributes/noreturn"
+  },
+  {
+    "cppref": "cpp/language/attributes/nodiscard",
+    "cppdoc": "cpp/language/declarations/attributes/nodiscard"
+  },
+  {
+    "cppref": "cpp/language/attributes/no_unique_address",
+    "cppdoc": "cpp/language/declarations/attributes/no_unique_address"
+  },
+  {
+    "cppref": "cpp/language/attributes/carries_dependency",
+    "cppdoc": "cpp/language/declarations/attributes/carries_dependency"
+  },
+  {
+    "cppref": "cpp/ranges/lazy_split_view",
+    "cppdoc": "cpp/library/ranges/lazy_split_view"
+  },
+  {
+    "cppref": "cpp/ranges/ref_view",
+    "cppdoc": "cpp/library/ranges/ref_view"
+  },
+  {
+    "cppref": "cpp/ranges/common_view",
+    "cppdoc": "cpp/library/ranges/common_view"
+  },
+  {
+    "cppref": "cpp/ranges/subrange",
+    "cppdoc": "cpp/library/ranges/subrange"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view",
+    "cppdoc": "cpp/library/ranges/chunk_view"
+  },
+  {
+    "cppref": "cpp/ranges/range_size_t",
+    "cppdoc": "cpp/library/ranges/range_size_t"
+  },
+  {
+    "cppref": "cpp/ranges/range_reference_t",
+    "cppdoc": "cpp/library/ranges/range_reference_t"
+  },
+  {
+    "cppref": "cpp/ranges/keys_view",
+    "cppdoc": "cpp/library/ranges/keys_view"
+  },
+  {
+    "cppref": "cpp/ranges/cdata",
+    "cppdoc": "cpp/library/ranges/cdata"
+  },
+  {
+    "cppref": "cpp/ranges/drop_while_view",
+    "cppdoc": "cpp/library/ranges/drop_while_view"
+  },
+  {
+    "cppref": "cpp/ranges/bidirectional_range",
+    "cppdoc": "cpp/library/ranges/bidirectional_range"
+  },
+  {
+    "cppref": "cpp/ranges/view_counted",
+    "cppdoc": "cpp/library/ranges/view_counted"
+  },
+  {
+    "cppref": "cpp/ranges/cend",
+    "cppdoc": "cpp/library/ranges/cend"
+  },
+  {
+    "cppref": "cpp/ranges/empty",
+    "cppdoc": "cpp/library/ranges/empty"
+  },
+  {
+    "cppref": "cpp/ranges/values_view",
+    "cppdoc": "cpp/library/ranges/values_view"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view",
+    "cppdoc": "cpp/library/ranges/join_with_view"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view",
+    "cppdoc": "cpp/library/ranges/slide_view"
+  },
+  {
+    "cppref": "cpp/ranges/empty_view",
+    "cppdoc": "cpp/library/ranges/empty_view"
+  },
+  {
+    "cppref": "cpp/ranges/range_adaptor_closure",
+    "cppdoc": "cpp/library/ranges/range_adaptor_closure"
+  },
+  {
+    "cppref": "cpp/ranges/view",
+    "cppdoc": "cpp/library/ranges/view"
+  },
+  {
+    "cppref": "cpp/ranges/size",
+    "cppdoc": "cpp/library/ranges/size"
+  },
+  {
+    "cppref": "cpp/ranges/common_range",
+    "cppdoc": "cpp/library/ranges/common_range"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view",
+    "cppdoc": "cpp/library/ranges/chunk_by_view"
+  },
+  {
+    "cppref": "cpp/ranges/to",
+    "cppdoc": "cpp/library/ranges/to"
+  },
+  {
+    "cppref": "cpp/ranges/non-propagating-cache",
+    "cppdoc": "cpp/library/ranges/non-propagating-cache"
+  },
+  {
+    "cppref": "cpp/ranges/drop_view",
+    "cppdoc": "cpp/library/ranges/drop_view"
+  },
+  {
+    "cppref": "cpp/ranges/take_view",
+    "cppdoc": "cpp/library/ranges/take_view"
+  },
+  {
+    "cppref": "cpp/ranges/end",
+    "cppdoc": "cpp/library/ranges/end"
+  },
+  {
+    "cppref": "cpp/ranges/single_view",
+    "cppdoc": "cpp/library/ranges/single_view"
+  },
+  {
+    "cppref": "cpp/ranges/crbegin",
+    "cppdoc": "cpp/library/ranges/crbegin"
+  },
+  {
+    "cppref": "cpp/ranges/rend",
+    "cppdoc": "cpp/library/ranges/rend"
+  },
+  {
+    "cppref": "cpp/ranges/subrange_kind",
+    "cppdoc": "cpp/library/ranges/subrange/../subrange_kind"
+  },
+  {
+    "cppref": "cpp/ranges/begin",
+    "cppdoc": "cpp/library/ranges/begin"
+  },
+  {
+    "cppref": "cpp/ranges/borrowed_range",
+    "cppdoc": "cpp/library/ranges/borrowed_range"
+  },
+  {
+    "cppref": "cpp/ranges/cbegin",
+    "cppdoc": "cpp/library/ranges/cbegin"
+  },
+  {
+    "cppref": "cpp/ranges/constant_range",
+    "cppdoc": "cpp/library/ranges/constant_range"
+  },
+  {
+    "cppref": "cpp/ranges/forward_range",
+    "cppdoc": "cpp/library/ranges/forward_range"
+  },
+  {
+    "cppref": "cpp/ranges/output_range",
+    "cppdoc": "cpp/library/ranges/output_range"
+  },
+  {
+    "cppref": "cpp/ranges/iterator_t",
+    "cppdoc": "cpp/library/ranges/iterator_t"
+  },
+  {
+    "cppref": "cpp/ranges/range",
+    "cppdoc": "cpp/library/ranges/range"
+  },
+  {
+    "cppref": "cpp/ranges/as_const_view",
+    "cppdoc": "cpp/library/ranges/as_const_view"
+  },
+  {
+    "cppref": "cpp/ranges/cpo",
+    "cppdoc": "cpp/library/standard_library/cpo"
+  },
+  {
+    "cppref": "cpp/ranges/join_view",
+    "cppdoc": "cpp/library/ranges/join_view"
+  },
+  {
+    "cppref": "cpp/ranges/rbegin",
+    "cppdoc": "cpp/library/ranges/rbegin"
+  },
+  {
+    "cppref": "cpp/ranges/ssize",
+    "cppdoc": "cpp/library/ranges/ssize"
+  },
+  {
+    "cppref": "cpp/ranges/counted_view",
+    "cppdoc": "cpp/library/ranges/counted_view"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view",
+    "cppdoc": "cpp/library/ranges/concat_view"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view",
+    "cppdoc": "cpp/library/ranges/elements_view"
+  },
+  {
+    "cppref": "cpp/ranges/split_view",
+    "cppdoc": "cpp/library/ranges/split_view"
+  },
+  {
+    "cppref": "cpp/ranges/view_interface",
+    "cppdoc": "cpp/library/ranges/view_interface"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view",
+    "cppdoc": "cpp/library/ranges/adjacent_view"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view"
+  },
+  {
+    "cppref": "cpp/ranges/copyable_wrapper",
+    "cppdoc": "cpp/library/ranges/copyable_wrapper"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view",
+    "cppdoc": "cpp/library/ranges/enumerate_view"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view",
+    "cppdoc": "cpp/library/ranges/transform_view"
+  },
+  {
+    "cppref": "cpp/ranges/input_range",
+    "cppdoc": "cpp/library/ranges/input_range"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view",
+    "cppdoc": "cpp/library/ranges/stride_view"
+  },
+  {
+    "cppref": "cpp/ranges/crend",
+    "cppdoc": "cpp/library/ranges/crend"
+  },
+  {
+    "cppref": "cpp/ranges/filter_view",
+    "cppdoc": "cpp/library/ranges/filter_view"
+  },
+  {
+    "cppref": "cpp/ranges/repeat_view",
+    "cppdoc": "cpp/library/ranges/repeat_view"
+  },
+  {
+    "cppref": "cpp/ranges/viewable_range",
+    "cppdoc": "cpp/library/ranges/viewable_range"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view",
+    "cppdoc": "cpp/library/ranges/zip_view"
+  },
+  {
+    "cppref": "cpp/ranges/contiguous_range",
+    "cppdoc": "cpp/library/ranges/contiguous_range"
+  },
+  {
+    "cppref": "cpp/ranges/all_view",
+    "cppdoc": "cpp/library/ranges/all_view"
+  },
+  {
+    "cppref": "cpp/ranges/data",
+    "cppdoc": "cpp/library/ranges/data"
+  },
+  {
+    "cppref": "cpp/ranges/reverse_view",
+    "cppdoc": "cpp/library/ranges/reverse_view"
+  },
+  {
+    "cppref": "cpp/ranges/random_access_range",
+    "cppdoc": "cpp/library/ranges/random_access_range"
+  },
+  {
+    "cppref": "cpp/ranges/elements_of",
+    "cppdoc": "cpp/library/ranges/elements_of"
+  },
+  {
+    "cppref": "cpp/ranges/from_range",
+    "cppdoc": "cpp/library/ranges/from_range"
+  },
+  {
+    "cppref": "cpp/ranges/iota_view",
+    "cppdoc": "cpp/library/ranges/iota_view"
+  },
+  {
+    "cppref": "cpp/ranges/dangling",
+    "cppdoc": "cpp/library/ranges/dangling"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view",
+    "cppdoc": "cpp/library/ranges/zip_transform_view"
+  },
+  {
+    "cppref": "cpp/ranges/sized_range",
+    "cppdoc": "cpp/library/ranges/sized_range"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view",
+    "cppdoc": "cpp/library/ranges/take_while_view"
+  },
+  {
+    "cppref": "cpp/ranges/owning_view",
+    "cppdoc": "cpp/library/ranges/owning_view"
+  },
+  {
+    "cppref": "cpp/ranges/as_rvalue_view",
+    "cppdoc": "cpp/library/ranges/as_rvalue_view"
+  },
+  {
+    "cppref": "cpp/ranges/borrowed_iterator_t",
+    "cppdoc": "cpp/library/ranges/borrowed_iterator_t"
+  },
+  {
+    "cppref": "cpp/ranges/basic_istream_view",
+    "cppdoc": "cpp/library/ranges/basic_istream_view"
+  },
+  {
+    "cppref": "cpp/ranges/take_view/sentinel",
+    "cppdoc": "cpp/library/ranges/take_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/take_view/size",
+    "cppdoc": "cpp/library/ranges/take_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/take_view/take_view",
+    "cppdoc": "cpp/library/ranges/take_view/take_view"
+  },
+  {
+    "cppref": "cpp/ranges/take_view/end",
+    "cppdoc": "cpp/library/ranges/take_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/take_view/begin",
+    "cppdoc": "cpp/library/ranges/take_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/take_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/take_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/take_view/base",
+    "cppdoc": "cpp/library/ranges/take_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/take_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/take_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/take_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/take_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/take_view/sentinel/base",
+    "cppdoc": "cpp/library/ranges/take_view/sentinel/base"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/sentinel",
+    "cppdoc": "cpp/library/ranges/zip_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/size",
+    "cppdoc": "cpp/library/ranges/zip_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/end",
+    "cppdoc": "cpp/library/ranges/zip_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/begin",
+    "cppdoc": "cpp/library/ranges/zip_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/zip_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/iterator",
+    "cppdoc": "cpp/library/ranges/zip_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/zip_view",
+    "cppdoc": "cpp/library/ranges/zip_view/zip_view"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/zip_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/zip_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/sentinel/operator-",
+    "cppdoc": "cpp/library/ranges/zip_view/sentinel/operator-"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/zip_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/iterator/iter_move",
+    "cppdoc": "cpp/library/ranges/zip_view/iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/zip_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/zip_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/zip_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/zip_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/iterator/iter_swap",
+    "cppdoc": "cpp/library/ranges/zip_view/iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/ranges/zip_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/zip_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/sentinel",
+    "cppdoc": "cpp/library/ranges/elements_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/size",
+    "cppdoc": "cpp/library/ranges/elements_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/end",
+    "cppdoc": "cpp/library/ranges/elements_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/begin",
+    "cppdoc": "cpp/library/ranges/elements_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/iterator",
+    "cppdoc": "cpp/library/ranges/elements_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/elements_view",
+    "cppdoc": "cpp/library/ranges/elements_view/elements_view"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/base",
+    "cppdoc": "cpp/library/ranges/elements_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/elements_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/elements_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/sentinel/operator-",
+    "cppdoc": "cpp/library/ranges/elements_view/sentinel/operator-"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/sentinel/base",
+    "cppdoc": "cpp/library/ranges/elements_view/sentinel/base"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/elements_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/elements_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/elements_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/elements_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/elements_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/elements_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/elements_view/iterator/base",
+    "cppdoc": "cpp/library/ranges/elements_view/iterator/base"
+  },
+  {
+    "cppref": "cpp/ranges/basic_istream_view/iterator",
+    "cppdoc": "cpp/library/ranges/basic_istream_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/sentinel",
+    "cppdoc": "cpp/library/ranges/adjacent_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/size",
+    "cppdoc": "cpp/library/ranges/adjacent_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/end",
+    "cppdoc": "cpp/library/ranges/adjacent_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/begin",
+    "cppdoc": "cpp/library/ranges/adjacent_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/iterator",
+    "cppdoc": "cpp/library/ranges/adjacent_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/adjacent_view",
+    "cppdoc": "cpp/library/ranges/adjacent_view/adjacent_view"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/adjacent_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/adjacent_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/sentinel/operator-",
+    "cppdoc": "cpp/library/ranges/adjacent_view/sentinel/operator-"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/adjacent_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/iterator/iter_move",
+    "cppdoc": "cpp/library/ranges/adjacent_view/iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/adjacent_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/adjacent_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/adjacent_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/adjacent_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/iterator/iter_swap",
+    "cppdoc": "cpp/library/ranges/adjacent_view/iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/adjacent_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/sentinel",
+    "cppdoc": "cpp/library/ranges/join_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/end",
+    "cppdoc": "cpp/library/ranges/join_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/begin",
+    "cppdoc": "cpp/library/ranges/join_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/join_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/join_view",
+    "cppdoc": "cpp/library/ranges/join_view/join_view"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/iterator",
+    "cppdoc": "cpp/library/ranges/join_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/base",
+    "cppdoc": "cpp/library/ranges/join_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/join_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/join_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/iterator/satisfy",
+    "cppdoc": "cpp/library/ranges/join_view/iterator/satisfy"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/iterator/iter_move",
+    "cppdoc": "cpp/library/ranges/join_view/iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/join_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/join_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/join_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/join_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/join_view/iterator/iter_swap",
+    "cppdoc": "cpp/library/ranges/join_view/iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/sentinel",
+    "cppdoc": "cpp/library/ranges/slide_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/slide_view",
+    "cppdoc": "cpp/library/ranges/slide_view/slide_view"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/size",
+    "cppdoc": "cpp/library/ranges/slide_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/end",
+    "cppdoc": "cpp/library/ranges/slide_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/begin",
+    "cppdoc": "cpp/library/ranges/slide_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/slide_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/iterator",
+    "cppdoc": "cpp/library/ranges/slide_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/slide_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/slide_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/sentinel/operator-",
+    "cppdoc": "cpp/library/ranges/slide_view/sentinel/operator-"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/slide_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/slide_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/slide_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/slide_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/slide_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/slide_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/slide_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/sentinel",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/size",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/adjacent_transform_view",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/adjacent_transform_view"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/end",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/begin",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/iterator",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/sentinel/operator-",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/sentinel/operator-"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/adjacent_transform_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/adjacent_transform_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/size",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/end",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/begin",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/iterator",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/cartesian_product_view",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/cartesian_product_view"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/iterator/helpers",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/iterator/helpers"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/iterator/iter_move",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/iterator/iter_swap",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/ranges/cartesian_product_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/cartesian_product_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/size",
+    "cppdoc": "cpp/library/ranges/concat_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/end",
+    "cppdoc": "cpp/library/ranges/concat_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/begin",
+    "cppdoc": "cpp/library/ranges/concat_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/concat_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/iterator",
+    "cppdoc": "cpp/library/ranges/concat_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/concat_view",
+    "cppdoc": "cpp/library/ranges/concat_view/concat_view"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/concat_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/iterator/helpers",
+    "cppdoc": "cpp/library/ranges/concat_view/iterator/helpers"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/iterator/iter_move",
+    "cppdoc": "cpp/library/ranges/concat_view/iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/concat_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/concat_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/concat_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/concat_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/iterator/iter_swap",
+    "cppdoc": "cpp/library/ranges/concat_view/iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/ranges/concat_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/concat_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/subrange",
+    "cppdoc": "cpp/library/ranges/subrange/subrange"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/prev",
+    "cppdoc": "cpp/library/ranges/subrange/prev"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/next",
+    "cppdoc": "cpp/library/ranges/subrange/next"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/empty",
+    "cppdoc": "cpp/library/ranges/subrange/empty"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/size",
+    "cppdoc": "cpp/library/ranges/subrange/size"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/end",
+    "cppdoc": "cpp/library/ranges/subrange/end"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/begin",
+    "cppdoc": "cpp/library/ranges/subrange/begin"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/deduction_guides",
+    "cppdoc": "cpp/library/ranges/subrange/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/tuple_size",
+    "cppdoc": "cpp/library/ranges/subrange/tuple_size"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/get",
+    "cppdoc": "cpp/library/ranges/subrange/get"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/operator_PairLike",
+    "cppdoc": "cpp/library/ranges/subrange/operator_PairLike"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/tuple_element",
+    "cppdoc": "cpp/library/ranges/subrange/tuple_element"
+  },
+  {
+    "cppref": "cpp/ranges/subrange/advance",
+    "cppdoc": "cpp/library/ranges/subrange/advance"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/sentinel",
+    "cppdoc": "cpp/library/ranges/transform_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/size",
+    "cppdoc": "cpp/library/ranges/transform_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/end",
+    "cppdoc": "cpp/library/ranges/transform_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/begin",
+    "cppdoc": "cpp/library/ranges/transform_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/transform_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/iterator",
+    "cppdoc": "cpp/library/ranges/transform_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/transform_view",
+    "cppdoc": "cpp/library/ranges/transform_view/transform_view"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/base",
+    "cppdoc": "cpp/library/ranges/transform_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/transform_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/transform_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/sentinel/operator-",
+    "cppdoc": "cpp/library/ranges/transform_view/sentinel/operator-"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/sentinel/base",
+    "cppdoc": "cpp/library/ranges/transform_view/sentinel/base"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/transform_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/iterator/iter_move",
+    "cppdoc": "cpp/library/ranges/transform_view/iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/transform_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/transform_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/transform_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/transform_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/transform_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/transform_view/iterator/base",
+    "cppdoc": "cpp/library/ranges/transform_view/iterator/base"
+  },
+  {
+    "cppref": "cpp/ranges/drop_view/size",
+    "cppdoc": "cpp/library/ranges/drop_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/drop_view/drop_view",
+    "cppdoc": "cpp/library/ranges/drop_view/drop_view"
+  },
+  {
+    "cppref": "cpp/ranges/drop_view/end",
+    "cppdoc": "cpp/library/ranges/drop_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/drop_view/begin",
+    "cppdoc": "cpp/library/ranges/drop_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/drop_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/drop_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/drop_view/base",
+    "cppdoc": "cpp/library/ranges/drop_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/drop_while_view/drop_while_view",
+    "cppdoc": "cpp/library/ranges/drop_while_view/drop_while_view"
+  },
+  {
+    "cppref": "cpp/ranges/drop_while_view/end",
+    "cppdoc": "cpp/library/ranges/drop_while_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/drop_while_view/begin",
+    "cppdoc": "cpp/library/ranges/drop_while_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/drop_while_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/drop_while_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/drop_while_view/pred",
+    "cppdoc": "cpp/library/ranges/drop_while_view/pred"
+  },
+  {
+    "cppref": "cpp/ranges/drop_while_view/base",
+    "cppdoc": "cpp/library/ranges/drop_while_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/chunk_view",
+    "cppdoc": "cpp/library/ranges/chunk_view/chunk_view"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/size",
+    "cppdoc": "cpp/library/ranges/chunk_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/inner_iterator",
+    "cppdoc": "cpp/library/ranges/chunk_view/inner_iterator"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/end",
+    "cppdoc": "cpp/library/ranges/chunk_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/begin",
+    "cppdoc": "cpp/library/ranges/chunk_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/chunk_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/iterator",
+    "cppdoc": "cpp/library/ranges/chunk_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/outer_iterator",
+    "cppdoc": "cpp/library/ranges/chunk_view/outer_iterator"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/base",
+    "cppdoc": "cpp/library/ranges/chunk_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/outer_iterator/value_type",
+    "cppdoc": "cpp/library/ranges/chunk_view/outer_iterator/value_type"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/outer_iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/chunk_view/outer_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/outer_iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/chunk_view/outer_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/outer_iterator/outer_iterator",
+    "cppdoc": "cpp/library/ranges/chunk_view/outer_iterator/outer_iterator"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/outer_iterator/operator-",
+    "cppdoc": "cpp/library/ranges/chunk_view/outer_iterator/operator-"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/outer_iterator/operator=",
+    "cppdoc": "cpp/library/ranges/chunk_view/outer_iterator/operator="
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/outer_iterator/operator_inc",
+    "cppdoc": "cpp/library/ranges/chunk_view/outer_iterator/operator_inc"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/chunk_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/chunk_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/chunk_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/chunk_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/chunk_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/chunk_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/iterator/base",
+    "cppdoc": "cpp/library/ranges/chunk_view/iterator/base"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/inner_iterator/inner_iterator",
+    "cppdoc": "cpp/library/ranges/chunk_view/inner_iterator/inner_iterator"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/inner_iterator/iter_move",
+    "cppdoc": "cpp/library/ranges/chunk_view/inner_iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/inner_iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/chunk_view/inner_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/inner_iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/chunk_view/inner_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/inner_iterator/iter_swap",
+    "cppdoc": "cpp/library/ranges/chunk_view/inner_iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/inner_iterator/operator-",
+    "cppdoc": "cpp/library/ranges/chunk_view/inner_iterator/operator-"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/inner_iterator/operator=",
+    "cppdoc": "cpp/library/ranges/chunk_view/inner_iterator/operator="
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/inner_iterator/base",
+    "cppdoc": "cpp/library/ranges/chunk_view/inner_iterator/base"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_view/inner_iterator/operator_inc",
+    "cppdoc": "cpp/library/ranges/chunk_view/inner_iterator/operator_inc"
+  },
+  {
+    "cppref": "cpp/ranges/view_interface/operator_at",
+    "cppdoc": "cpp/library/ranges/view_interface/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/view_interface/back",
+    "cppdoc": "cpp/library/ranges/view_interface/back"
+  },
+  {
+    "cppref": "cpp/ranges/view_interface/cend",
+    "cppdoc": "cpp/library/ranges/view_interface/cend"
+  },
+  {
+    "cppref": "cpp/ranges/view_interface/empty",
+    "cppdoc": "cpp/library/ranges/view_interface/empty"
+  },
+  {
+    "cppref": "cpp/ranges/view_interface/size",
+    "cppdoc": "cpp/library/ranges/view_interface/size"
+  },
+  {
+    "cppref": "cpp/ranges/view_interface/cbegin",
+    "cppdoc": "cpp/library/ranges/view_interface/cbegin"
+  },
+  {
+    "cppref": "cpp/ranges/view_interface/front",
+    "cppdoc": "cpp/library/ranges/view_interface/front"
+  },
+  {
+    "cppref": "cpp/ranges/view_interface/operator_bool",
+    "cppdoc": "cpp/library/ranges/view_interface/operator_bool"
+  },
+  {
+    "cppref": "cpp/ranges/view_interface/data",
+    "cppdoc": "cpp/library/ranges/view_interface/data"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/sentinel",
+    "cppdoc": "cpp/library/ranges/join_with_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/join_with_view",
+    "cppdoc": "cpp/library/ranges/join_with_view/join_with_view"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/end",
+    "cppdoc": "cpp/library/ranges/join_with_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/begin",
+    "cppdoc": "cpp/library/ranges/join_with_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/join_with_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/iterator",
+    "cppdoc": "cpp/library/ranges/join_with_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/base",
+    "cppdoc": "cpp/library/ranges/join_with_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/join_with_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/join_with_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/iterator/iter_move",
+    "cppdoc": "cpp/library/ranges/join_with_view/iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/join_with_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/join_with_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/join_with_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/join_with_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/join_with_view/iterator/iter_swap",
+    "cppdoc": "cpp/library/ranges/join_with_view/iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view/sentinel",
+    "cppdoc": "cpp/library/ranges/take_while_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view/end",
+    "cppdoc": "cpp/library/ranges/take_while_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view/begin",
+    "cppdoc": "cpp/library/ranges/take_while_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/take_while_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view/pred",
+    "cppdoc": "cpp/library/ranges/take_while_view/pred"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view/base",
+    "cppdoc": "cpp/library/ranges/take_while_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view/take_while_view",
+    "cppdoc": "cpp/library/ranges/take_while_view/take_while_view"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/take_while_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/take_while_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/take_while_view/sentinel/base",
+    "cppdoc": "cpp/library/ranges/take_while_view/sentinel/base"
+  },
+  {
+    "cppref": "cpp/ranges/repeat_view/iterator",
+    "cppdoc": "cpp/library/ranges/repeat_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/iota_view/sentinel",
+    "cppdoc": "cpp/library/ranges/iota_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/iota_view/empty",
+    "cppdoc": "cpp/library/ranges/iota_view/empty"
+  },
+  {
+    "cppref": "cpp/ranges/iota_view/size",
+    "cppdoc": "cpp/library/ranges/iota_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/iota_view/end",
+    "cppdoc": "cpp/library/ranges/iota_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/iota_view/begin",
+    "cppdoc": "cpp/library/ranges/iota_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/iota_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/iota_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/iota_view/iterator",
+    "cppdoc": "cpp/library/ranges/iota_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/iota_view/iota_view",
+    "cppdoc": "cpp/library/ranges/iota_view/iota_view"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/sentinel",
+    "cppdoc": "cpp/library/ranges/enumerate_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/size",
+    "cppdoc": "cpp/library/ranges/enumerate_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/end",
+    "cppdoc": "cpp/library/ranges/enumerate_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/begin",
+    "cppdoc": "cpp/library/ranges/enumerate_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/enumerate_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/iterator",
+    "cppdoc": "cpp/library/ranges/enumerate_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/enumerate_view",
+    "cppdoc": "cpp/library/ranges/enumerate_view/enumerate_view"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/base",
+    "cppdoc": "cpp/library/ranges/enumerate_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/enumerate_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/enumerate_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/sentinel/operator-",
+    "cppdoc": "cpp/library/ranges/enumerate_view/sentinel/operator-"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/sentinel/base",
+    "cppdoc": "cpp/library/ranges/enumerate_view/sentinel/base"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/enumerate_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/iterator/index",
+    "cppdoc": "cpp/library/ranges/enumerate_view/iterator/index"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/iterator/iter_move",
+    "cppdoc": "cpp/library/ranges/enumerate_view/iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/enumerate_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/enumerate_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/enumerate_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/enumerate_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/enumerate_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/enumerate_view/iterator/base",
+    "cppdoc": "cpp/library/ranges/enumerate_view/iterator/base"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/helpers",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/helpers"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/chunk_by_view",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/chunk_by_view"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/end",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/begin",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/pred",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/pred"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/iterator",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/base",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/chunk_by_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/chunk_by_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/sentinel",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/size",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/end",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/begin",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/iterator",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/zip_transform_view",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/zip_transform_view"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/sentinel/sentinel",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/sentinel/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/sentinel/operator_cmp",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/sentinel/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/sentinel/operator-",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/sentinel/operator-"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/zip_transform_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/zip_transform_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/lazy_split_view/lazy_split_view",
+    "cppdoc": "cpp/library/ranges/lazy_split_view/lazy_split_view"
+  },
+  {
+    "cppref": "cpp/ranges/lazy_split_view/value_type",
+    "cppdoc": "cpp/library/ranges/lazy_split_view/value_type"
+  },
+  {
+    "cppref": "cpp/ranges/lazy_split_view/inner_iterator",
+    "cppdoc": "cpp/library/ranges/lazy_split_view/inner_iterator"
+  },
+  {
+    "cppref": "cpp/ranges/lazy_split_view/end",
+    "cppdoc": "cpp/library/ranges/lazy_split_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/lazy_split_view/begin",
+    "cppdoc": "cpp/library/ranges/lazy_split_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/lazy_split_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/lazy_split_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/lazy_split_view/outer_iterator",
+    "cppdoc": "cpp/library/ranges/lazy_split_view/outer_iterator"
+  },
+  {
+    "cppref": "cpp/ranges/lazy_split_view/base",
+    "cppdoc": "cpp/library/ranges/lazy_split_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/common_view/common_view",
+    "cppdoc": "cpp/library/ranges/common_view/common_view"
+  },
+  {
+    "cppref": "cpp/ranges/common_view/size",
+    "cppdoc": "cpp/library/ranges/common_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/common_view/end",
+    "cppdoc": "cpp/library/ranges/common_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/common_view/begin",
+    "cppdoc": "cpp/library/ranges/common_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/common_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/common_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/common_view/base",
+    "cppdoc": "cpp/library/ranges/common_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/stride",
+    "cppdoc": "cpp/library/ranges/stride_view/stride"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/size",
+    "cppdoc": "cpp/library/ranges/stride_view/size"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/end",
+    "cppdoc": "cpp/library/ranges/stride_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/begin",
+    "cppdoc": "cpp/library/ranges/stride_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/stride_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/iterator",
+    "cppdoc": "cpp/library/ranges/stride_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/stride_view",
+    "cppdoc": "cpp/library/ranges/stride_view/stride_view"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/base",
+    "cppdoc": "cpp/library/ranges/stride_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/iterator/operator_at",
+    "cppdoc": "cpp/library/ranges/stride_view/iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/iterator/iter_move",
+    "cppdoc": "cpp/library/ranges/stride_view/iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/iterator/operator_arith",
+    "cppdoc": "cpp/library/ranges/stride_view/iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/iterator/iterator",
+    "cppdoc": "cpp/library/ranges/stride_view/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/iterator/operator_star_",
+    "cppdoc": "cpp/library/ranges/stride_view/iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/iterator/operator_cmp",
+    "cppdoc": "cpp/library/ranges/stride_view/iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/iterator/iter_swap",
+    "cppdoc": "cpp/library/ranges/stride_view/iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/iterator/operator_arith2",
+    "cppdoc": "cpp/library/ranges/stride_view/iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/ranges/stride_view/iterator/base",
+    "cppdoc": "cpp/library/ranges/stride_view/iterator/base"
+  },
+  {
+    "cppref": "cpp/ranges/split_view/sentinel",
+    "cppdoc": "cpp/library/ranges/split_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/split_view/end",
+    "cppdoc": "cpp/library/ranges/split_view/end"
+  },
+  {
+    "cppref": "cpp/ranges/split_view/begin",
+    "cppdoc": "cpp/library/ranges/split_view/begin"
+  },
+  {
+    "cppref": "cpp/ranges/split_view/deduction_guides",
+    "cppdoc": "cpp/library/ranges/split_view/deduction_guides"
+  },
+  {
+    "cppref": "cpp/ranges/split_view/iterator",
+    "cppdoc": "cpp/library/ranges/split_view/iterator"
+  },
+  {
+    "cppref": "cpp/ranges/split_view/split_view",
+    "cppdoc": "cpp/library/ranges/split_view/split_view"
+  },
+  {
+    "cppref": "cpp/ranges/split_view/base",
+    "cppdoc": "cpp/library/ranges/split_view/base"
+  },
+  {
+    "cppref": "cpp/ranges/split_view/find_next",
+    "cppdoc": "cpp/library/ranges/split_view/find_next"
+  },
+  {
+    "cppref": "cpp/ranges/filter_view/sentinel",
+    "cppdoc": "cpp/library/ranges/filter_view/sentinel"
+  },
+  {
+    "cppref": "cpp/ranges/filter_view/iterator",
+    "cppdoc": "cpp/library/ranges/filter_view/iterator"
+  },
+  {
+    "cppref": "cpp/iterator/mergeable",
+    "cppdoc": "cpp/library/iterator/mergeable"
+  },
+  {
+    "cppref": "cpp/iterator/default_sentinel",
+    "cppdoc": "cpp/library/iterator/default_sentinel"
+  },
+  {
+    "cppref": "cpp/iterator/indirect_result_t",
+    "cppdoc": "cpp/library/iterator/indirect_result_t"
+  },
+  {
+    "cppref": "cpp/iterator/const_iterator",
+    "cppdoc": "cpp/library/iterator/const_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/ostreambuf_iterator",
+    "cppdoc": "cpp/library/iterator/ostreambuf_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/move_sentinel",
+    "cppdoc": "cpp/library/iterator/move_sentinel"
+  },
+  {
+    "cppref": "cpp/iterator/istream_iterator",
+    "cppdoc": "cpp/library/iterator/istream_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/sentinel_for",
+    "cppdoc": "cpp/library/iterator/sentinel_for"
+  },
+  {
+    "cppref": "cpp/iterator/front_insert_iterator",
+    "cppdoc": "cpp/library/iterator/front_insert_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/prev",
+    "cppdoc": "cpp/library/iterator/prev"
+  },
+  {
+    "cppref": "cpp/iterator/bidirectional_iterator",
+    "cppdoc": "cpp/library/iterator/bidirectional_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/next",
+    "cppdoc": "cpp/library/iterator/next"
+  },
+  {
+    "cppref": "cpp/iterator/default_sentinel_t",
+    "cppdoc": "cpp/library/iterator/default_sentinel_t"
+  },
+  {
+    "cppref": "cpp/iterator/empty",
+    "cppdoc": "cpp/library/iterator/empty"
+  },
+  {
+    "cppref": "cpp/iterator/back_inserter",
+    "cppdoc": "cpp/library/iterator/back_inserter"
+  },
+  {
+    "cppref": "cpp/iterator/projected",
+    "cppdoc": "cpp/library/iterator/projected"
+  },
+  {
+    "cppref": "cpp/iterator/incrementable",
+    "cppdoc": "cpp/library/iterator/incrementable"
+  },
+  {
+    "cppref": "cpp/iterator/size",
+    "cppdoc": "cpp/library/iterator/size"
+  },
+  {
+    "cppref": "cpp/iterator/indirectly_copyable_storable",
+    "cppdoc": "cpp/library/iterator/indirectly_copyable_storable"
+  },
+  {
+    "cppref": "cpp/iterator/is-integer-like",
+    "cppdoc": "cpp/library/iterator/is-integer-like"
+  },
+  {
+    "cppref": "cpp/iterator/contiguous_iterator",
+    "cppdoc": "cpp/library/iterator/contiguous_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/back_insert_iterator",
+    "cppdoc": "cpp/library/iterator/back_insert_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/indirectly_swappable",
+    "cppdoc": "cpp/library/iterator/indirectly_swappable"
+  },
+  {
+    "cppref": "cpp/iterator/const_sentinel",
+    "cppdoc": "cpp/library/iterator/const_sentinel"
+  },
+  {
+    "cppref": "cpp/iterator/indirect_unary_predicate",
+    "cppdoc": "cpp/library/iterator/indirect_unary_predicate"
+  },
+  {
+    "cppref": "cpp/iterator/output_iterator",
+    "cppdoc": "cpp/library/iterator/output_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/end",
+    "cppdoc": "cpp/library/iterator/end"
+  },
+  {
+    "cppref": "cpp/iterator/rend",
+    "cppdoc": "cpp/library/iterator/rend"
+  },
+  {
+    "cppref": "cpp/iterator/make_move_iterator",
+    "cppdoc": "cpp/library/iterator/make_move_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/begin",
+    "cppdoc": "cpp/library/iterator/begin"
+  },
+  {
+    "cppref": "cpp/iterator/indirect_equivalence_relation",
+    "cppdoc": "cpp/library/iterator/indirect_equivalence_relation"
+  },
+  {
+    "cppref": "cpp/iterator/input_or_output_iterator",
+    "cppdoc": "cpp/library/iterator/input_or_output_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator",
+    "cppdoc": "cpp/library/iterator/reverse_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/ostream_iterator",
+    "cppdoc": "cpp/library/iterator/ostream_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/unreachable_sentinel_t",
+    "cppdoc": "cpp/library/iterator/unreachable_sentinel_t"
+  },
+  {
+    "cppref": "cpp/iterator/iter_t",
+    "cppdoc": "cpp/library/iterator/iter_t"
+  },
+  {
+    "cppref": "cpp/iterator/indirectly_movable_storable",
+    "cppdoc": "cpp/library/iterator/indirectly_movable_storable"
+  },
+  {
+    "cppref": "cpp/iterator/forward_iterator",
+    "cppdoc": "cpp/library/iterator/forward_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/indirectly_readable",
+    "cppdoc": "cpp/library/iterator/indirectly_readable"
+  },
+  {
+    "cppref": "cpp/iterator/rbegin",
+    "cppdoc": "cpp/library/iterator/rbegin"
+  },
+  {
+    "cppref": "cpp/iterator/sized_sentinel_for",
+    "cppdoc": "cpp/library/iterator/sized_sentinel_for"
+  },
+  {
+    "cppref": "cpp/iterator/indirectly_writable",
+    "cppdoc": "cpp/library/iterator/indirectly_writable"
+  },
+  {
+    "cppref": "cpp/iterator/make_const_sentinel",
+    "cppdoc": "cpp/library/iterator/make_const_sentinel"
+  },
+  {
+    "cppref": "cpp/iterator/indirectly_readable_traits",
+    "cppdoc": "cpp/library/iterator/indirectly_readable_traits"
+  },
+  {
+    "cppref": "cpp/iterator/projected_value_t",
+    "cppdoc": "cpp/library/iterator/projected_value_t"
+  },
+  {
+    "cppref": "cpp/iterator/iterator",
+    "cppdoc": "cpp/library/iterator/iterator"
+  },
+  {
+    "cppref": "cpp/iterator/iterator_tags",
+    "cppdoc": "cpp/library/iterator/iterator_tags"
+  },
+  {
+    "cppref": "cpp/iterator/indirectly_unary_invocable",
+    "cppdoc": "cpp/library/iterator/indirectly_unary_invocable"
+  },
+  {
+    "cppref": "cpp/iterator/indirect_strict_weak_order",
+    "cppdoc": "cpp/library/iterator/indirect_strict_weak_order"
+  },
+  {
+    "cppref": "cpp/iterator/incrementable_traits",
+    "cppdoc": "cpp/library/iterator/incrementable_traits"
+  },
+  {
+    "cppref": "cpp/iterator/indirectly_comparable",
+    "cppdoc": "cpp/library/iterator/indirectly_comparable"
+  },
+  {
+    "cppref": "cpp/iterator/indirectly_copyable",
+    "cppdoc": "cpp/library/iterator/indirectly_copyable"
+  },
+  {
+    "cppref": "cpp/iterator/input_iterator",
+    "cppdoc": "cpp/library/iterator/input_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/indirectly_movable",
+    "cppdoc": "cpp/library/iterator/indirectly_movable"
+  },
+  {
+    "cppref": "cpp/iterator/front_inserter",
+    "cppdoc": "cpp/library/iterator/front_inserter"
+  },
+  {
+    "cppref": "cpp/iterator/insert_iterator",
+    "cppdoc": "cpp/library/iterator/insert_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/iterator_traits",
+    "cppdoc": "cpp/library/iterator/iterator_traits"
+  },
+  {
+    "cppref": "cpp/iterator/istreambuf_iterator",
+    "cppdoc": "cpp/library/iterator/istreambuf_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/distance",
+    "cppdoc": "cpp/library/iterator/distance"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator",
+    "cppdoc": "cpp/library/iterator/counted_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/make_reverse_iterator",
+    "cppdoc": "cpp/library/iterator/make_reverse_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator",
+    "cppdoc": "cpp/library/iterator/common_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/indirect_binary_predicate",
+    "cppdoc": "cpp/library/iterator/indirect_binary_predicate"
+  },
+  {
+    "cppref": "cpp/iterator/data",
+    "cppdoc": "cpp/library/iterator/data"
+  },
+  {
+    "cppref": "cpp/iterator/random_access_iterator",
+    "cppdoc": "cpp/library/iterator/random_access_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/sortable",
+    "cppdoc": "cpp/library/iterator/sortable"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator",
+    "cppdoc": "cpp/library/iterator/move_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/weakly_incrementable",
+    "cppdoc": "cpp/library/iterator/weakly_incrementable"
+  },
+  {
+    "cppref": "cpp/iterator/permutable",
+    "cppdoc": "cpp/library/iterator/permutable"
+  },
+  {
+    "cppref": "cpp/iterator/advance",
+    "cppdoc": "cpp/library/iterator/advance"
+  },
+  {
+    "cppref": "cpp/iterator/make_const_iterator",
+    "cppdoc": "cpp/library/iterator/make_const_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/inserter",
+    "cppdoc": "cpp/library/iterator/inserter"
+  },
+  {
+    "cppref": "cpp/iterator/move_sentinel/move_sentinel",
+    "cppdoc": "cpp/library/iterator/move_sentinel/move_sentinel"
+  },
+  {
+    "cppref": "cpp/iterator/move_sentinel/operator=",
+    "cppdoc": "cpp/library/iterator/move_sentinel/operator="
+  },
+  {
+    "cppref": "cpp/iterator/move_sentinel/base",
+    "cppdoc": "cpp/library/iterator/move_sentinel/base"
+  },
+  {
+    "cppref": "cpp/iterator/ostreambuf_iterator/ostreambuf_iterator",
+    "cppdoc": "cpp/library/iterator/ostreambuf_iterator/ostreambuf_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/ostreambuf_iterator/operator_arith",
+    "cppdoc": "cpp/library/iterator/ostreambuf_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/iterator/ostreambuf_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/ostreambuf_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/ostreambuf_iterator/failed",
+    "cppdoc": "cpp/library/iterator/ostreambuf_iterator/failed"
+  },
+  {
+    "cppref": "cpp/iterator/ostreambuf_iterator/operator=",
+    "cppdoc": "cpp/library/iterator/ostreambuf_iterator/operator="
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/operator_at",
+    "cppdoc": "cpp/library/iterator/counted_iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/iter_move",
+    "cppdoc": "cpp/library/iterator/counted_iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/operator_cmp2",
+    "cppdoc": "cpp/library/iterator/counted_iterator/operator_cmp2"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/operator_arith",
+    "cppdoc": "cpp/library/iterator/counted_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/operator+",
+    "cppdoc": "cpp/library/iterator/counted_iterator/operator+"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/counted_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/count",
+    "cppdoc": "cpp/library/iterator/counted_iterator/count"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/operator_cmp",
+    "cppdoc": "cpp/library/iterator/counted_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/iter_swap",
+    "cppdoc": "cpp/library/iterator/counted_iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/iterator_traits",
+    "cppdoc": "cpp/library/iterator/counted_iterator/iterator_traits"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/operator-",
+    "cppdoc": "cpp/library/iterator/counted_iterator/operator-"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/counted_iterator",
+    "cppdoc": "cpp/library/iterator/counted_iterator/counted_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/operator=",
+    "cppdoc": "cpp/library/iterator/counted_iterator/operator="
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/base",
+    "cppdoc": "cpp/library/iterator/counted_iterator/base"
+  },
+  {
+    "cppref": "cpp/iterator/counted_iterator/operator-2",
+    "cppdoc": "cpp/library/iterator/counted_iterator/operator-2"
+  },
+  {
+    "cppref": "cpp/iterator/back_insert_iterator/back_insert_iterator",
+    "cppdoc": "cpp/library/iterator/back_insert_iterator/back_insert_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/back_insert_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/back_insert_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/back_insert_iterator/operator++",
+    "cppdoc": "cpp/library/iterator/back_insert_iterator/operator++"
+  },
+  {
+    "cppref": "cpp/iterator/back_insert_iterator/operator=",
+    "cppdoc": "cpp/library/iterator/back_insert_iterator/operator="
+  },
+  {
+    "cppref": "cpp/iterator/ranges/prev",
+    "cppdoc": "cpp/library/iterator/ranges/prev"
+  },
+  {
+    "cppref": "cpp/iterator/ranges/next",
+    "cppdoc": "cpp/library/iterator/ranges/next"
+  },
+  {
+    "cppref": "cpp/iterator/ranges/iter_move",
+    "cppdoc": "cpp/library/iterator/ranges/iter_move"
+  },
+  {
+    "cppref": "cpp/iterator/ranges/iter_swap",
+    "cppdoc": "cpp/library/iterator/ranges/iter_swap"
+  },
+  {
+    "cppref": "cpp/iterator/ranges/distance",
+    "cppdoc": "cpp/library/iterator/ranges/distance"
+  },
+  {
+    "cppref": "cpp/iterator/ranges/advance",
+    "cppdoc": "cpp/library/iterator/ranges/advance"
+  },
+  {
+    "cppref": "cpp/iterator/front_insert_iterator/front_insert_iterator",
+    "cppdoc": "cpp/library/iterator/front_insert_iterator/front_insert_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/front_insert_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/front_insert_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/front_insert_iterator/operator++",
+    "cppdoc": "cpp/library/iterator/front_insert_iterator/operator++"
+  },
+  {
+    "cppref": "cpp/iterator/front_insert_iterator/operator=",
+    "cppdoc": "cpp/library/iterator/front_insert_iterator/operator="
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/operator_at",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/iter_move",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/reverse_iterator",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/reverse_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/operator_arith",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/operator+",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/operator+"
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/operator_cmp",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/iter_swap",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/operator-",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/operator-"
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/operator=",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/operator="
+  },
+  {
+    "cppref": "cpp/iterator/reverse_iterator/base",
+    "cppdoc": "cpp/library/iterator/reverse_iterator/base"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/operator_at",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/basic_const_iterator",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/basic_const_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/iter_move",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/operator_cmp2",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/operator_cmp2"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/operator_constant_iterator",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/operator_constant_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/operator_arith",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/common_type",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/common_type"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/operator_cmp",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/operator-",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/operator-"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/operator_arith2",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/operator_arith2"
+  },
+  {
+    "cppref": "cpp/iterator/basic_const_iterator/base",
+    "cppdoc": "cpp/library/iterator/basic_const_iterator/base"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator/iter_move",
+    "cppdoc": "cpp/library/iterator/common_iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator/operator_arith",
+    "cppdoc": "cpp/library/iterator/common_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/common_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator/incrementable_traits",
+    "cppdoc": "cpp/library/iterator/common_iterator/incrementable_traits"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator/operator_cmp",
+    "cppdoc": "cpp/library/iterator/common_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator/iter_swap",
+    "cppdoc": "cpp/library/iterator/common_iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator/iterator_traits",
+    "cppdoc": "cpp/library/iterator/common_iterator/iterator_traits"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator/operator-",
+    "cppdoc": "cpp/library/iterator/common_iterator/operator-"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator/common_iterator",
+    "cppdoc": "cpp/library/iterator/common_iterator/common_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/common_iterator/operator=",
+    "cppdoc": "cpp/library/iterator/common_iterator/operator="
+  },
+  {
+    "cppref": "cpp/iterator/ostream_iterator/~ostream_iterator",
+    "cppdoc": "cpp/library/iterator/ostream_iterator/~ostream_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/ostream_iterator/ostream_iterator",
+    "cppdoc": "cpp/library/iterator/ostream_iterator/ostream_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/ostream_iterator/operator_arith",
+    "cppdoc": "cpp/library/iterator/ostream_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/iterator/ostream_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/ostream_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/ostream_iterator/operator=",
+    "cppdoc": "cpp/library/iterator/ostream_iterator/operator="
+  },
+  {
+    "cppref": "cpp/iterator/istream_iterator/istream_iterator",
+    "cppdoc": "cpp/library/iterator/istream_iterator/istream_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/istream_iterator/~istream_iterator",
+    "cppdoc": "cpp/library/iterator/istream_iterator/~istream_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/istream_iterator/operator_arith",
+    "cppdoc": "cpp/library/iterator/istream_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/iterator/istream_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/istream_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/istream_iterator/operator_cmp",
+    "cppdoc": "cpp/library/iterator/istream_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/iterator/insert_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/insert_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/insert_iterator/insert_iterator",
+    "cppdoc": "cpp/library/iterator/insert_iterator/insert_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/insert_iterator/operator++",
+    "cppdoc": "cpp/library/iterator/insert_iterator/operator++"
+  },
+  {
+    "cppref": "cpp/iterator/insert_iterator/operator=",
+    "cppdoc": "cpp/library/iterator/insert_iterator/operator="
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/operator_at",
+    "cppdoc": "cpp/library/iterator/move_iterator/operator_at"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/iter_move",
+    "cppdoc": "cpp/library/iterator/move_iterator/iter_move"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/operator_cmp2",
+    "cppdoc": "cpp/library/iterator/move_iterator/operator_cmp2"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/operator_arith",
+    "cppdoc": "cpp/library/iterator/move_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/operator+",
+    "cppdoc": "cpp/library/iterator/move_iterator/operator+"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/move_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/operator_cmp",
+    "cppdoc": "cpp/library/iterator/move_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/iter_swap",
+    "cppdoc": "cpp/library/iterator/move_iterator/iter_swap"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/operator-",
+    "cppdoc": "cpp/library/iterator/move_iterator/operator-"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/operator=",
+    "cppdoc": "cpp/library/iterator/move_iterator/operator="
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/base",
+    "cppdoc": "cpp/library/iterator/move_iterator/base"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/move_iterator",
+    "cppdoc": "cpp/library/iterator/move_iterator/move_iterator"
+  },
+  {
+    "cppref": "cpp/iterator/move_iterator/operator-2",
+    "cppdoc": "cpp/library/iterator/move_iterator/operator-2"
+  },
+  {
+    "cppref": "cpp/iterator/istreambuf_iterator/operator_arith",
+    "cppdoc": "cpp/library/iterator/istreambuf_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/iterator/istreambuf_iterator/operator_star_",
+    "cppdoc": "cpp/library/iterator/istreambuf_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/iterator/istreambuf_iterator/equal",
+    "cppdoc": "cpp/library/iterator/istreambuf_iterator/equal"
+  },
+  {
+    "cppref": "cpp/iterator/istreambuf_iterator/operator_cmp",
+    "cppdoc": "cpp/library/iterator/istreambuf_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/iterator/istreambuf_iterator/istreambuf_iterator",
+    "cppdoc": "cpp/library/iterator/istreambuf_iterator/istreambuf_iterator"
+  },
+  {
+    "cppref": "cpp/standard_library/decay-copy",
+    "cppdoc": "cpp/library/standard_library/decay-copy"
+  },
+  {
+    "cppref": "cpp/standard_library/synth-three-way",
+    "cppdoc": "cpp/library/standard_library/synth-three-way"
+  },
+  {
+    "cppref": "cpp/links/libs",
+    "cppdoc": "cpp/library/links/libs"
+  },
+  {
+    "cppref": "cpp/memory/voidify",
+    "cppdoc": "cpp/library/memory/voidify"
+  },
+  {
+    "cppref": "cpp/memory/auto_ptr",
+    "cppdoc": "cpp/library/memory/auto_ptr"
+  },
+  {
+    "cppref": "cpp/memory/uses_allocator_construction_args",
+    "cppdoc": "cpp/library/memory/uses_allocator_construction_args"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_value_construct_n",
+    "cppdoc": "cpp/library/memory/uninitialized_value_construct_n"
+  },
+  {
+    "cppref": "cpp/memory/owner_less_void",
+    "cppdoc": "cpp/library/memory/owner_less_void"
+  },
+  {
+    "cppref": "cpp/memory/set_default_resource",
+    "cppdoc": "cpp/library/memory/set_default_resource"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_construct_using_allocator",
+    "cppdoc": "cpp/library/memory/uninitialized_construct_using_allocator"
+  },
+  {
+    "cppref": "cpp/memory/owner_less",
+    "cppdoc": "cpp/library/memory/owner_less"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor"
+  },
+  {
+    "cppref": "cpp/memory/get_default_resource",
+    "cppdoc": "cpp/library/memory/get_default_resource"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator"
+  },
+  {
+    "cppref": "cpp/memory/raw_storage_iterator",
+    "cppdoc": "cpp/library/memory/raw_storage_iterator"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_move",
+    "cppdoc": "cpp/library/memory/uninitialized_move"
+  },
+  {
+    "cppref": "cpp/memory/monotonic_buffer_resource",
+    "cppdoc": "cpp/library/memory/monotonic_buffer_resource"
+  },
+  {
+    "cppref": "cpp/memory/addressof",
+    "cppdoc": "cpp/library/memory/addressof"
+  },
+  {
+    "cppref": "cpp/memory/pool_options",
+    "cppdoc": "cpp/library/memory/pool_options"
+  },
+  {
+    "cppref": "cpp/memory/bad_weak_ptr",
+    "cppdoc": "cpp/library/memory/bad_weak_ptr"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_move_n",
+    "cppdoc": "cpp/library/memory/uninitialized_move_n"
+  },
+  {
+    "cppref": "cpp/memory/unsynchronized_pool_resource",
+    "cppdoc": "cpp/library/memory/unsynchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/memory/assume_aligned",
+    "cppdoc": "cpp/library/memory/assume_aligned"
+  },
+  {
+    "cppref": "cpp/memory/new_delete_resource",
+    "cppdoc": "cpp/library/memory/new_delete_resource"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr",
+    "cppdoc": "cpp/library/memory/shared_ptr"
+  },
+  {
+    "cppref": "cpp/memory/pointer_traits",
+    "cppdoc": "cpp/library/memory/pointer_traits"
+  },
+  {
+    "cppref": "cpp/memory/new",
+    "cppdoc": "cpp/library/memory/new"
+  },
+  {
+    "cppref": "cpp/memory/to_address",
+    "cppdoc": "cpp/library/memory/to_address"
+  },
+  {
+    "cppref": "cpp/memory/make_obj_using_allocator",
+    "cppdoc": "cpp/library/memory/make_obj_using_allocator"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr",
+    "cppdoc": "cpp/library/memory/weak_ptr"
+  },
+  {
+    "cppref": "cpp/memory/allocator_traits",
+    "cppdoc": "cpp/library/memory/allocator_traits"
+  },
+  {
+    "cppref": "cpp/memory/owner_equal",
+    "cppdoc": "cpp/library/memory/owner_equal"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_copy",
+    "cppdoc": "cpp/library/memory/uninitialized_copy"
+  },
+  {
+    "cppref": "cpp/memory/default_delete",
+    "cppdoc": "cpp/library/memory/default_delete"
+  },
+  {
+    "cppref": "cpp/memory/get_temporary_buffer",
+    "cppdoc": "cpp/library/memory/get_temporary_buffer"
+  },
+  {
+    "cppref": "cpp/memory/owner_hash",
+    "cppdoc": "cpp/library/memory/owner_hash"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_fill",
+    "cppdoc": "cpp/library/memory/uninitialized_fill"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_fill_n",
+    "cppdoc": "cpp/library/memory/uninitialized_fill_n"
+  },
+  {
+    "cppref": "cpp/memory/allocator_arg",
+    "cppdoc": "cpp/library/memory/allocator_arg"
+  },
+  {
+    "cppref": "cpp/memory/allocation_result",
+    "cppdoc": "cpp/library/memory/allocation_result"
+  },
+  {
+    "cppref": "cpp/memory/c",
+    "cppdoc": "cpp/library/memory/c"
+  },
+  {
+    "cppref": "cpp/memory/out_ptr_t",
+    "cppdoc": "cpp/library/memory/out_ptr_t"
+  },
+  {
+    "cppref": "cpp/memory/align",
+    "cppdoc": "cpp/library/memory/align"
+  },
+  {
+    "cppref": "cpp/memory/destroy",
+    "cppdoc": "cpp/library/memory/destroy"
+  },
+  {
+    "cppref": "cpp/memory/inout_ptr_t",
+    "cppdoc": "cpp/library/memory/inout_ptr_t"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_default_construct",
+    "cppdoc": "cpp/library/memory/uninitialized_default_construct"
+  },
+  {
+    "cppref": "cpp/memory/destroy_at",
+    "cppdoc": "cpp/library/memory/destroy_at"
+  },
+  {
+    "cppref": "cpp/memory/start_lifetime_as",
+    "cppdoc": "cpp/library/memory/start_lifetime_as"
+  },
+  {
+    "cppref": "cpp/memory/destroy_n",
+    "cppdoc": "cpp/library/memory/destroy_n"
+  },
+  {
+    "cppref": "cpp/memory/construct_at",
+    "cppdoc": "cpp/library/memory/construct_at"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_value_construct",
+    "cppdoc": "cpp/library/memory/uninitialized_value_construct"
+  },
+  {
+    "cppref": "cpp/memory/is_sufficiently_aligned",
+    "cppdoc": "cpp/library/memory/is_sufficiently_aligned"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_default_construct_n",
+    "cppdoc": "cpp/library/memory/uninitialized_default_construct_n"
+  },
+  {
+    "cppref": "cpp/memory/enable_shared_from_this",
+    "cppdoc": "cpp/library/memory/enable_shared_from_this"
+  },
+  {
+    "cppref": "cpp/memory/return_temporary_buffer",
+    "cppdoc": "cpp/library/memory/return_temporary_buffer"
+  },
+  {
+    "cppref": "cpp/memory/allocator",
+    "cppdoc": "cpp/library/memory/allocator"
+  },
+  {
+    "cppref": "cpp/memory/allocator_arg_t",
+    "cppdoc": "cpp/library/memory/allocator_arg_t"
+  },
+  {
+    "cppref": "cpp/memory/synchronized_pool_resource",
+    "cppdoc": "cpp/library/memory/synchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/memory/null_memory_resource",
+    "cppdoc": "cpp/library/memory/null_memory_resource"
+  },
+  {
+    "cppref": "cpp/memory/uninitialized_copy_n",
+    "cppdoc": "cpp/library/memory/uninitialized_copy_n"
+  },
+  {
+    "cppref": "cpp/memory/uses_allocator",
+    "cppdoc": "cpp/library/memory/uses_allocator"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr",
+    "cppdoc": "cpp/library/memory/unique_ptr"
+  },
+  {
+    "cppref": "cpp/memory/memory_resource",
+    "cppdoc": "cpp/library/memory/memory_resource"
+  },
+  {
+    "cppref": "cpp/memory/enable_shared_from_this/shared_from_this",
+    "cppdoc": "cpp/library/memory/enable_shared_from_this/shared_from_this"
+  },
+  {
+    "cppref": "cpp/memory/enable_shared_from_this/weak_from_this",
+    "cppdoc": "cpp/library/memory/enable_shared_from_this/weak_from_this"
+  },
+  {
+    "cppref": "cpp/memory/enable_shared_from_this/~enable_shared_from_this",
+    "cppdoc": "cpp/library/memory/enable_shared_from_this/~enable_shared_from_this"
+  },
+  {
+    "cppref": "cpp/memory/enable_shared_from_this/operator=",
+    "cppdoc": "cpp/library/memory/enable_shared_from_this/operator="
+  },
+  {
+    "cppref": "cpp/memory/enable_shared_from_this/enable_shared_from_this",
+    "cppdoc": "cpp/library/memory/enable_shared_from_this/enable_shared_from_this"
+  },
+  {
+    "cppref": "cpp/memory/auto_ptr/auto_ptr",
+    "cppdoc": "cpp/library/memory/auto_ptr/auto_ptr"
+  },
+  {
+    "cppref": "cpp/memory/auto_ptr/operator_auto_ptr",
+    "cppdoc": "cpp/library/memory/auto_ptr/operator_auto_ptr"
+  },
+  {
+    "cppref": "cpp/memory/auto_ptr/~auto_ptr",
+    "cppdoc": "cpp/library/memory/auto_ptr/~auto_ptr"
+  },
+  {
+    "cppref": "cpp/memory/auto_ptr/reset",
+    "cppdoc": "cpp/library/memory/auto_ptr/reset"
+  },
+  {
+    "cppref": "cpp/memory/auto_ptr/operator_star_",
+    "cppdoc": "cpp/library/memory/auto_ptr/operator_star_"
+  },
+  {
+    "cppref": "cpp/memory/auto_ptr/release",
+    "cppdoc": "cpp/library/memory/auto_ptr/release"
+  },
+  {
+    "cppref": "cpp/memory/auto_ptr/get",
+    "cppdoc": "cpp/library/memory/auto_ptr/get"
+  },
+  {
+    "cppref": "cpp/memory/auto_ptr/operator=",
+    "cppdoc": "cpp/library/memory/auto_ptr/operator="
+  },
+  {
+    "cppref": "cpp/memory/unsynchronized_pool_resource/do_is_equal",
+    "cppdoc": "cpp/library/memory/unsynchronized_pool_resource/do_is_equal"
+  },
+  {
+    "cppref": "cpp/memory/unsynchronized_pool_resource/do_deallocate",
+    "cppdoc": "cpp/library/memory/unsynchronized_pool_resource/do_deallocate"
+  },
+  {
+    "cppref": "cpp/memory/unsynchronized_pool_resource/unsynchronized_pool_resource",
+    "cppdoc": "cpp/library/memory/unsynchronized_pool_resource/unsynchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/memory/unsynchronized_pool_resource/do_allocate",
+    "cppdoc": "cpp/library/memory/unsynchronized_pool_resource/do_allocate"
+  },
+  {
+    "cppref": "cpp/memory/unsynchronized_pool_resource/options",
+    "cppdoc": "cpp/library/memory/unsynchronized_pool_resource/options"
+  },
+  {
+    "cppref": "cpp/memory/unsynchronized_pool_resource/release",
+    "cppdoc": "cpp/library/memory/unsynchronized_pool_resource/release"
+  },
+  {
+    "cppref": "cpp/memory/unsynchronized_pool_resource/~unsynchronized_pool_resource",
+    "cppdoc": "cpp/library/memory/unsynchronized_pool_resource/~unsynchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/memory/unsynchronized_pool_resource/upstream_resource",
+    "cppdoc": "cpp/library/memory/unsynchronized_pool_resource/upstream_resource"
+  },
+  {
+    "cppref": "cpp/memory/memory_resource/do_is_equal",
+    "cppdoc": "cpp/library/memory/memory_resource/do_is_equal"
+  },
+  {
+    "cppref": "cpp/memory/memory_resource/operator_eq",
+    "cppdoc": "cpp/library/memory/memory_resource/operator_eq"
+  },
+  {
+    "cppref": "cpp/memory/memory_resource/allocate",
+    "cppdoc": "cpp/library/memory/memory_resource/allocate"
+  },
+  {
+    "cppref": "cpp/memory/memory_resource/deallocate",
+    "cppdoc": "cpp/library/memory/memory_resource/deallocate"
+  },
+  {
+    "cppref": "cpp/memory/memory_resource/do_deallocate",
+    "cppdoc": "cpp/library/memory/memory_resource/do_deallocate"
+  },
+  {
+    "cppref": "cpp/memory/memory_resource/do_allocate",
+    "cppdoc": "cpp/library/memory/memory_resource/do_allocate"
+  },
+  {
+    "cppref": "cpp/memory/memory_resource/is_equal",
+    "cppdoc": "cpp/library/memory/memory_resource/is_equal"
+  },
+  {
+    "cppref": "cpp/memory/memory_resource/memory_resource",
+    "cppdoc": "cpp/library/memory/memory_resource/memory_resource"
+  },
+  {
+    "cppref": "cpp/memory/new/operator_new",
+    "cppdoc": "cpp/library/memory/new/operator_new"
+  },
+  {
+    "cppref": "cpp/memory/new/set_new_handler",
+    "cppdoc": "cpp/library/memory/new/set_new_handler"
+  },
+  {
+    "cppref": "cpp/memory/new/get_new_handler",
+    "cppdoc": "cpp/library/memory/new/get_new_handler"
+  },
+  {
+    "cppref": "cpp/memory/new/bad_alloc",
+    "cppdoc": "cpp/library/memory/new/bad_alloc"
+  },
+  {
+    "cppref": "cpp/memory/new/align_val_t",
+    "cppdoc": "cpp/library/memory/new/align_val_t"
+  },
+  {
+    "cppref": "cpp/memory/new/nothrow_t",
+    "cppdoc": "cpp/library/memory/new/nothrow_t"
+  },
+  {
+    "cppref": "cpp/memory/new/nothrow",
+    "cppdoc": "cpp/library/memory/new/nothrow"
+  },
+  {
+    "cppref": "cpp/memory/new/new_handler",
+    "cppdoc": "cpp/library/memory/new/new_handler"
+  },
+  {
+    "cppref": "cpp/memory/new/bad_array_new_length",
+    "cppdoc": "cpp/library/memory/new/bad_array_new_length"
+  },
+  {
+    "cppref": "cpp/memory/new/destroying_delete_t",
+    "cppdoc": "cpp/library/memory/new/destroying_delete_t"
+  },
+  {
+    "cppref": "cpp/memory/new/operator_delete",
+    "cppdoc": "cpp/library/memory/new/operator_delete"
+  },
+  {
+    "cppref": "cpp/memory/monotonic_buffer_resource/~monotonic_buffer_resource",
+    "cppdoc": "cpp/library/memory/monotonic_buffer_resource/~monotonic_buffer_resource"
+  },
+  {
+    "cppref": "cpp/memory/monotonic_buffer_resource/do_is_equal",
+    "cppdoc": "cpp/library/memory/monotonic_buffer_resource/do_is_equal"
+  },
+  {
+    "cppref": "cpp/memory/monotonic_buffer_resource/monotonic_buffer_resource",
+    "cppdoc": "cpp/library/memory/monotonic_buffer_resource/monotonic_buffer_resource"
+  },
+  {
+    "cppref": "cpp/memory/monotonic_buffer_resource/do_deallocate",
+    "cppdoc": "cpp/library/memory/monotonic_buffer_resource/do_deallocate"
+  },
+  {
+    "cppref": "cpp/memory/monotonic_buffer_resource/do_allocate",
+    "cppdoc": "cpp/library/memory/monotonic_buffer_resource/do_allocate"
+  },
+  {
+    "cppref": "cpp/memory/monotonic_buffer_resource/release",
+    "cppdoc": "cpp/library/memory/monotonic_buffer_resource/release"
+  },
+  {
+    "cppref": "cpp/memory/monotonic_buffer_resource/upstream_resource",
+    "cppdoc": "cpp/library/memory/monotonic_buffer_resource/upstream_resource"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/helpers",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/helpers"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/outer_allocator",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/outer_allocator"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/allocate",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/allocate"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/inner_allocator",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/inner_allocator"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/scoped_allocator_adaptor",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/scoped_allocator_adaptor"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/deallocate",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/deallocate"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/max_size",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/max_size"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/deduction_guides",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/deduction_guides"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/select_on_container_copy_construction",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/select_on_container_copy_construction"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/construct",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/construct"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/operator_cmp",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/operator_cmp"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/destroy",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/destroy"
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/operator=",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/operator="
+  },
+  {
+    "cppref": "cpp/memory/scoped_allocator_adaptor/~scoped_allocator_adaptor",
+    "cppdoc": "cpp/library/memory/scoped_allocator_adaptor/~scoped_allocator_adaptor"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/operator_at",
+    "cppdoc": "cpp/library/memory/unique_ptr/operator_at"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/get_deleter",
+    "cppdoc": "cpp/library/memory/unique_ptr/get_deleter"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/hash",
+    "cppdoc": "cpp/library/memory/unique_ptr/hash"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/swap2",
+    "cppdoc": "cpp/library/memory/unique_ptr/swap2"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/reset",
+    "cppdoc": "cpp/library/memory/unique_ptr/reset"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/swap",
+    "cppdoc": "cpp/library/memory/unique_ptr/swap"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/operator_star_",
+    "cppdoc": "cpp/library/memory/unique_ptr/operator_star_"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/release",
+    "cppdoc": "cpp/library/memory/unique_ptr/release"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/get",
+    "cppdoc": "cpp/library/memory/unique_ptr/get"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/make_unique",
+    "cppdoc": "cpp/library/memory/unique_ptr/make_unique"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/operator_cmp",
+    "cppdoc": "cpp/library/memory/unique_ptr/operator_cmp"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/~unique_ptr",
+    "cppdoc": "cpp/library/memory/unique_ptr/~unique_ptr"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/operator_bool",
+    "cppdoc": "cpp/library/memory/unique_ptr/operator_bool"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/operator=",
+    "cppdoc": "cpp/library/memory/unique_ptr/operator="
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/operator_ltlt",
+    "cppdoc": "cpp/library/memory/unique_ptr/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/memory/unique_ptr/unique_ptr",
+    "cppdoc": "cpp/library/memory/unique_ptr/unique_ptr"
+  },
+  {
+    "cppref": "cpp/memory/ranges/uninitialized_value_construct_n",
+    "cppdoc": "cpp/library/memory/ranges/uninitialized_value_construct_n"
+  },
+  {
+    "cppref": "cpp/memory/ranges/nothrow_concepts",
+    "cppdoc": "cpp/library/memory/ranges/nothrow_concepts"
+  },
+  {
+    "cppref": "cpp/memory/ranges/uninitialized_move",
+    "cppdoc": "cpp/library/memory/ranges/uninitialized_move"
+  },
+  {
+    "cppref": "cpp/memory/ranges/uninitialized_move_n",
+    "cppdoc": "cpp/library/memory/ranges/uninitialized_move_n"
+  },
+  {
+    "cppref": "cpp/memory/ranges/uninitialized_copy",
+    "cppdoc": "cpp/library/memory/ranges/uninitialized_copy"
+  },
+  {
+    "cppref": "cpp/memory/ranges/uninitialized_fill",
+    "cppdoc": "cpp/library/memory/ranges/uninitialized_fill"
+  },
+  {
+    "cppref": "cpp/memory/ranges/uninitialized_fill_n",
+    "cppdoc": "cpp/library/memory/ranges/uninitialized_fill_n"
+  },
+  {
+    "cppref": "cpp/memory/ranges/destroy",
+    "cppdoc": "cpp/library/memory/ranges/destroy"
+  },
+  {
+    "cppref": "cpp/memory/ranges/uninitialized_default_construct",
+    "cppdoc": "cpp/library/memory/ranges/uninitialized_default_construct"
+  },
+  {
+    "cppref": "cpp/memory/ranges/destroy_at",
+    "cppdoc": "cpp/library/memory/ranges/destroy_at"
+  },
+  {
+    "cppref": "cpp/memory/ranges/destroy_n",
+    "cppdoc": "cpp/library/memory/ranges/destroy_n"
+  },
+  {
+    "cppref": "cpp/memory/ranges/construct_at",
+    "cppdoc": "cpp/library/memory/ranges/construct_at"
+  },
+  {
+    "cppref": "cpp/memory/ranges/uninitialized_value_construct",
+    "cppdoc": "cpp/library/memory/ranges/uninitialized_value_construct"
+  },
+  {
+    "cppref": "cpp/memory/ranges/uninitialized_default_construct_n",
+    "cppdoc": "cpp/library/memory/ranges/uninitialized_default_construct_n"
+  },
+  {
+    "cppref": "cpp/memory/ranges/uninitialized_copy_n",
+    "cppdoc": "cpp/library/memory/ranges/uninitialized_copy_n"
+  },
+  {
+    "cppref": "cpp/memory/inout_ptr_t/inout_ptr",
+    "cppdoc": "cpp/library/memory/inout_ptr_t/inout_ptr"
+  },
+  {
+    "cppref": "cpp/memory/inout_ptr_t/~inout_ptr_t",
+    "cppdoc": "cpp/library/memory/inout_ptr_t/~inout_ptr_t"
+  },
+  {
+    "cppref": "cpp/memory/inout_ptr_t/operator_ptr",
+    "cppdoc": "cpp/library/memory/inout_ptr_t/operator_ptr"
+  },
+  {
+    "cppref": "cpp/memory/inout_ptr_t/inout_ptr_t",
+    "cppdoc": "cpp/library/memory/inout_ptr_t/inout_ptr_t"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/allocate_object",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/allocate_object"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/operator_eq",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/operator_eq"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/allocate",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/allocate"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/deallocate",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/deallocate"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/polymorphic_allocator",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/polymorphic_allocator"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/deallocate_bytes",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/deallocate_bytes"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/delete_object",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/delete_object"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/deallocate_object",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/deallocate_object"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/allocate_bytes",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/allocate_bytes"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/select_on_container_copy_construction",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/select_on_container_copy_construction"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/construct",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/construct"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/new_object",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/new_object"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/destroy",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/destroy"
+  },
+  {
+    "cppref": "cpp/memory/polymorphic_allocator/resource",
+    "cppdoc": "cpp/library/memory/polymorphic_allocator/resource"
+  },
+  {
+    "cppref": "cpp/memory/c/free",
+    "cppdoc": "cpp/library/memory/c/free"
+  },
+  {
+    "cppref": "cpp/memory/c/calloc",
+    "cppdoc": "cpp/library/memory/c/calloc"
+  },
+  {
+    "cppref": "cpp/memory/c/realloc",
+    "cppdoc": "cpp/library/memory/c/realloc"
+  },
+  {
+    "cppref": "cpp/memory/c/malloc",
+    "cppdoc": "cpp/library/memory/c/malloc"
+  },
+  {
+    "cppref": "cpp/memory/c/aligned_alloc",
+    "cppdoc": "cpp/library/memory/c/aligned_alloc"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/operator_at",
+    "cppdoc": "cpp/library/memory/shared_ptr/operator_at"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/get_deleter",
+    "cppdoc": "cpp/library/memory/shared_ptr/get_deleter"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/atomic",
+    "cppdoc": "cpp/library/memory/shared_ptr/atomic"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/use_count",
+    "cppdoc": "cpp/library/memory/shared_ptr/use_count"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/owner_before",
+    "cppdoc": "cpp/library/memory/shared_ptr/owner_before"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/hash",
+    "cppdoc": "cpp/library/memory/shared_ptr/hash"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/swap2",
+    "cppdoc": "cpp/library/memory/shared_ptr/swap2"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/deduction_guides",
+    "cppdoc": "cpp/library/memory/shared_ptr/deduction_guides"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/reset",
+    "cppdoc": "cpp/library/memory/shared_ptr/reset"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/shared_ptr",
+    "cppdoc": "cpp/library/memory/shared_ptr/shared_ptr"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/swap",
+    "cppdoc": "cpp/library/memory/shared_ptr/swap"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/owner_equal",
+    "cppdoc": "cpp/library/memory/shared_ptr/owner_equal"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/atomic2",
+    "cppdoc": "cpp/library/memory/shared_ptr/atomic2"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/owner_hash",
+    "cppdoc": "cpp/library/memory/shared_ptr/owner_hash"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/operator_star_",
+    "cppdoc": "cpp/library/memory/shared_ptr/operator_star_"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/get",
+    "cppdoc": "cpp/library/memory/shared_ptr/get"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/operator_cmp",
+    "cppdoc": "cpp/library/memory/shared_ptr/operator_cmp"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/make_shared",
+    "cppdoc": "cpp/library/memory/shared_ptr/make_shared"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/unique",
+    "cppdoc": "cpp/library/memory/shared_ptr/unique"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/allocate_shared",
+    "cppdoc": "cpp/library/memory/shared_ptr/allocate_shared"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/operator_bool",
+    "cppdoc": "cpp/library/memory/shared_ptr/operator_bool"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/pointer_cast",
+    "cppdoc": "cpp/library/memory/shared_ptr/pointer_cast"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/operator=",
+    "cppdoc": "cpp/library/memory/shared_ptr/operator="
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/operator_ltlt",
+    "cppdoc": "cpp/library/memory/shared_ptr/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/memory/shared_ptr/~shared_ptr",
+    "cppdoc": "cpp/library/memory/shared_ptr/~shared_ptr"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/use_count",
+    "cppdoc": "cpp/library/memory/weak_ptr/use_count"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/owner_before",
+    "cppdoc": "cpp/library/memory/weak_ptr/owner_before"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/~weak_ptr",
+    "cppdoc": "cpp/library/memory/weak_ptr/~weak_ptr"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/swap2",
+    "cppdoc": "cpp/library/memory/weak_ptr/swap2"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/expired",
+    "cppdoc": "cpp/library/memory/weak_ptr/expired"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/deduction_guides",
+    "cppdoc": "cpp/library/memory/weak_ptr/deduction_guides"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/reset",
+    "cppdoc": "cpp/library/memory/weak_ptr/reset"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/weak_ptr",
+    "cppdoc": "cpp/library/memory/weak_ptr/weak_ptr"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/swap",
+    "cppdoc": "cpp/library/memory/weak_ptr/swap"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/owner_equal",
+    "cppdoc": "cpp/library/memory/weak_ptr/owner_equal"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/atomic2",
+    "cppdoc": "cpp/library/memory/weak_ptr/atomic2"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/lock",
+    "cppdoc": "cpp/library/memory/weak_ptr/lock"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/owner_hash",
+    "cppdoc": "cpp/library/memory/weak_ptr/owner_hash"
+  },
+  {
+    "cppref": "cpp/memory/weak_ptr/operator=",
+    "cppdoc": "cpp/library/memory/weak_ptr/operator="
+  },
+  {
+    "cppref": "cpp/memory/raw_storage_iterator/raw_storage_iterator",
+    "cppdoc": "cpp/library/memory/raw_storage_iterator/raw_storage_iterator"
+  },
+  {
+    "cppref": "cpp/memory/raw_storage_iterator/operator_arith",
+    "cppdoc": "cpp/library/memory/raw_storage_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/memory/raw_storage_iterator/operator_star_",
+    "cppdoc": "cpp/library/memory/raw_storage_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/memory/raw_storage_iterator/operator=",
+    "cppdoc": "cpp/library/memory/raw_storage_iterator/operator="
+  },
+  {
+    "cppref": "cpp/memory/raw_storage_iterator/base",
+    "cppdoc": "cpp/library/memory/raw_storage_iterator/base"
+  },
+  {
+    "cppref": "cpp/memory/allocator/allocate",
+    "cppdoc": "cpp/library/memory/allocator/allocate"
+  },
+  {
+    "cppref": "cpp/memory/allocator/deallocate",
+    "cppdoc": "cpp/library/memory/allocator/deallocate"
+  },
+  {
+    "cppref": "cpp/memory/allocator/max_size",
+    "cppdoc": "cpp/library/memory/allocator/max_size"
+  },
+  {
+    "cppref": "cpp/memory/allocator/~allocator",
+    "cppdoc": "cpp/library/memory/allocator/~allocator"
+  },
+  {
+    "cppref": "cpp/memory/allocator/address",
+    "cppdoc": "cpp/library/memory/allocator/address"
+  },
+  {
+    "cppref": "cpp/memory/allocator/allocate_at_least",
+    "cppdoc": "cpp/library/memory/allocator/allocate_at_least"
+  },
+  {
+    "cppref": "cpp/memory/allocator/construct",
+    "cppdoc": "cpp/library/memory/allocator/construct"
+  },
+  {
+    "cppref": "cpp/memory/allocator/operator_cmp",
+    "cppdoc": "cpp/library/memory/allocator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/memory/allocator/destroy",
+    "cppdoc": "cpp/library/memory/allocator/destroy"
+  },
+  {
+    "cppref": "cpp/memory/allocator/allocator",
+    "cppdoc": "cpp/library/memory/allocator/allocator"
+  },
+  {
+    "cppref": "cpp/memory/pointer_traits/pointer_to",
+    "cppdoc": "cpp/library/memory/pointer_traits/pointer_to"
+  },
+  {
+    "cppref": "cpp/memory/pointer_traits/to_address",
+    "cppdoc": "cpp/library/memory/pointer_traits/to_address"
+  },
+  {
+    "cppref": "cpp/memory/out_ptr_t/out_ptr",
+    "cppdoc": "cpp/library/memory/out_ptr_t/out_ptr"
+  },
+  {
+    "cppref": "cpp/memory/out_ptr_t/~out_ptr_t",
+    "cppdoc": "cpp/library/memory/out_ptr_t/~out_ptr_t"
+  },
+  {
+    "cppref": "cpp/memory/out_ptr_t/out_ptr_t",
+    "cppdoc": "cpp/library/memory/out_ptr_t/out_ptr_t"
+  },
+  {
+    "cppref": "cpp/memory/out_ptr_t/operator_ptr",
+    "cppdoc": "cpp/library/memory/out_ptr_t/operator_ptr"
+  },
+  {
+    "cppref": "cpp/memory/gc/get_pointer_safety",
+    "cppdoc": "cpp/library/memory/gc/get_pointer_safety"
+  },
+  {
+    "cppref": "cpp/memory/gc/declare_no_pointers",
+    "cppdoc": "cpp/library/memory/gc/declare_no_pointers"
+  },
+  {
+    "cppref": "cpp/memory/gc/undeclare_no_pointers",
+    "cppdoc": "cpp/library/memory/gc/undeclare_no_pointers"
+  },
+  {
+    "cppref": "cpp/memory/gc/declare_reachable",
+    "cppdoc": "cpp/library/memory/gc/declare_reachable"
+  },
+  {
+    "cppref": "cpp/memory/gc/pointer_safety",
+    "cppdoc": "cpp/library/memory/gc/pointer_safety"
+  },
+  {
+    "cppref": "cpp/memory/gc/undeclare_reachable",
+    "cppdoc": "cpp/library/memory/gc/undeclare_reachable"
+  },
+  {
+    "cppref": "cpp/memory/allocator_traits/allocate",
+    "cppdoc": "cpp/library/memory/allocator_traits/allocate"
+  },
+  {
+    "cppref": "cpp/memory/allocator_traits/deallocate",
+    "cppdoc": "cpp/library/memory/allocator_traits/deallocate"
+  },
+  {
+    "cppref": "cpp/memory/allocator_traits/max_size",
+    "cppdoc": "cpp/library/memory/allocator_traits/max_size"
+  },
+  {
+    "cppref": "cpp/memory/allocator_traits/allocate_at_least",
+    "cppdoc": "cpp/library/memory/allocator_traits/allocate_at_least"
+  },
+  {
+    "cppref": "cpp/memory/allocator_traits/select_on_container_copy_construction",
+    "cppdoc": "cpp/library/memory/allocator_traits/select_on_container_copy_construction"
+  },
+  {
+    "cppref": "cpp/memory/allocator_traits/construct",
+    "cppdoc": "cpp/library/memory/allocator_traits/construct"
+  },
+  {
+    "cppref": "cpp/memory/allocator_traits/destroy",
+    "cppdoc": "cpp/library/memory/allocator_traits/destroy"
+  },
+  {
+    "cppref": "cpp/memory/synchronized_pool_resource/do_is_equal",
+    "cppdoc": "cpp/library/memory/synchronized_pool_resource/do_is_equal"
+  },
+  {
+    "cppref": "cpp/memory/synchronized_pool_resource/do_deallocate",
+    "cppdoc": "cpp/library/memory/synchronized_pool_resource/do_deallocate"
+  },
+  {
+    "cppref": "cpp/memory/synchronized_pool_resource/do_allocate",
+    "cppdoc": "cpp/library/memory/synchronized_pool_resource/do_allocate"
+  },
+  {
+    "cppref": "cpp/memory/synchronized_pool_resource/options",
+    "cppdoc": "cpp/library/memory/synchronized_pool_resource/options"
+  },
+  {
+    "cppref": "cpp/memory/synchronized_pool_resource/release",
+    "cppdoc": "cpp/library/memory/synchronized_pool_resource/release"
+  },
+  {
+    "cppref": "cpp/memory/synchronized_pool_resource/~synchronized_pool_resource",
+    "cppdoc": "cpp/library/memory/synchronized_pool_resource/~synchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/memory/synchronized_pool_resource/synchronized_pool_resource",
+    "cppdoc": "cpp/library/memory/synchronized_pool_resource/synchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/memory/synchronized_pool_resource/upstream_resource",
+    "cppdoc": "cpp/library/memory/synchronized_pool_resource/upstream_resource"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_is_lock_free",
+    "cppdoc": "cpp/library/atomic/atomic_is_lock_free"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag",
+    "cppdoc": "cpp/library/atomic/atomic_flag"
+  },
+  {
+    "cppref": "cpp/atomic/atomic",
+    "cppdoc": "cpp/library/atomic/atomic"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_load",
+    "cppdoc": "cpp/library/atomic/atomic_load"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag_notify_one",
+    "cppdoc": "cpp/library/atomic/atomic_flag_notify_one"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_signal_fence",
+    "cppdoc": "cpp/library/atomic/atomic_signal_fence"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_store",
+    "cppdoc": "cpp/library/atomic/atomic_store"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_fetch_sub",
+    "cppdoc": "cpp/library/atomic/atomic_fetch_sub"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_fetch_max",
+    "cppdoc": "cpp/library/atomic/atomic_fetch_max"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_fetch_and",
+    "cppdoc": "cpp/library/atomic/atomic_fetch_and"
+  },
+  {
+    "cppref": "cpp/atomic/ATOMIC_FLAG_INIT",
+    "cppdoc": "cpp/library/atomic/ATOMIC_FLAG_INIT"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag_test",
+    "cppdoc": "cpp/library/atomic/atomic_flag_test"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref",
+    "cppdoc": "cpp/library/atomic/atomic_ref"
+  },
+  {
+    "cppref": "cpp/atomic/kill_dependency",
+    "cppdoc": "cpp/library/atomic/kill_dependency"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag_clear",
+    "cppdoc": "cpp/library/atomic/atomic_flag_clear"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_notify_one",
+    "cppdoc": "cpp/library/atomic/atomic_notify_one"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_notify_all",
+    "cppdoc": "cpp/library/atomic/atomic_notify_all"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag_notify_all",
+    "cppdoc": "cpp/library/atomic/atomic_flag_notify_all"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_fetch_or",
+    "cppdoc": "cpp/library/atomic/atomic_fetch_or"
+  },
+  {
+    "cppref": "cpp/atomic/memory_order",
+    "cppdoc": "cpp/library/atomic/memory_order"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_wait",
+    "cppdoc": "cpp/library/atomic/atomic_wait"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_init",
+    "cppdoc": "cpp/library/atomic/atomic_init"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_fetch_min",
+    "cppdoc": "cpp/library/atomic/atomic_fetch_min"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag_wait",
+    "cppdoc": "cpp/library/atomic/atomic_flag_wait"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_fetch_xor",
+    "cppdoc": "cpp/library/atomic/atomic_fetch_xor"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_exchange",
+    "cppdoc": "cpp/library/atomic/atomic_exchange"
+  },
+  {
+    "cppref": "cpp/atomic/ATOMIC_VAR_INIT",
+    "cppdoc": "cpp/library/atomic/ATOMIC_VAR_INIT"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag_test_and_set",
+    "cppdoc": "cpp/library/atomic/atomic_flag_test_and_set"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_compare_exchange",
+    "cppdoc": "cpp/library/atomic/atomic_compare_exchange"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_thread_fence",
+    "cppdoc": "cpp/library/atomic/atomic_thread_fence"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_fetch_add",
+    "cppdoc": "cpp/library/atomic/atomic_fetch_add"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag/atomic_flag",
+    "cppdoc": "cpp/library/atomic/atomic_flag/atomic_flag"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag/notify_all",
+    "cppdoc": "cpp/library/atomic/atomic_flag/notify_all"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag/test",
+    "cppdoc": "cpp/library/atomic/atomic_flag/test"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag/test_and_set",
+    "cppdoc": "cpp/library/atomic/atomic_flag/test_and_set"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag/notify_one",
+    "cppdoc": "cpp/library/atomic/atomic_flag/notify_one"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag/wait",
+    "cppdoc": "cpp/library/atomic/atomic_flag/wait"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag/operator=",
+    "cppdoc": "cpp/library/atomic/atomic_flag/operator="
+  },
+  {
+    "cppref": "cpp/atomic/atomic_flag/clear",
+    "cppdoc": "cpp/library/atomic/atomic_flag/clear"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/atomic",
+    "cppdoc": "cpp/library/atomic/atomic/atomic"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/exchange",
+    "cppdoc": "cpp/library/atomic/atomic/exchange"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/fetch_min",
+    "cppdoc": "cpp/library/atomic/atomic/fetch_min"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/fetch_xor",
+    "cppdoc": "cpp/library/atomic/atomic/fetch_xor"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/notify_all",
+    "cppdoc": "cpp/library/atomic/atomic/notify_all"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/is_always_lock_free",
+    "cppdoc": "cpp/library/atomic/atomic/is_always_lock_free"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/fetch_and",
+    "cppdoc": "cpp/library/atomic/atomic/fetch_and"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/compare_exchange",
+    "cppdoc": "cpp/library/atomic/atomic/compare_exchange"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/operator_arith",
+    "cppdoc": "cpp/library/atomic/atomic/operator_arith"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/operator_arith3",
+    "cppdoc": "cpp/library/atomic/atomic/operator_arith3"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/fetch_max",
+    "cppdoc": "cpp/library/atomic/atomic/fetch_max"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/notify_one",
+    "cppdoc": "cpp/library/atomic/atomic/notify_one"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/fetch_sub",
+    "cppdoc": "cpp/library/atomic/atomic/fetch_sub"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/wait",
+    "cppdoc": "cpp/library/atomic/atomic/wait"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/fetch_add",
+    "cppdoc": "cpp/library/atomic/atomic/fetch_add"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/is_lock_free",
+    "cppdoc": "cpp/library/atomic/atomic/is_lock_free"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/fetch_or",
+    "cppdoc": "cpp/library/atomic/atomic/fetch_or"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/operator_arith2",
+    "cppdoc": "cpp/library/atomic/atomic/operator_arith2"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/operator=",
+    "cppdoc": "cpp/library/atomic/atomic/operator="
+  },
+  {
+    "cppref": "cpp/atomic/atomic/store",
+    "cppdoc": "cpp/library/atomic/atomic/store"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/load",
+    "cppdoc": "cpp/library/atomic/atomic/load"
+  },
+  {
+    "cppref": "cpp/atomic/atomic/operator_T",
+    "cppdoc": "cpp/library/atomic/atomic/operator_T"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/required_alignment",
+    "cppdoc": "cpp/library/atomic/atomic_ref/required_alignment"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/exchange",
+    "cppdoc": "cpp/library/atomic/atomic_ref/exchange"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/fetch_min",
+    "cppdoc": "cpp/library/atomic/atomic_ref/fetch_min"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/fetch_xor",
+    "cppdoc": "cpp/library/atomic/atomic_ref/fetch_xor"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/notify_all",
+    "cppdoc": "cpp/library/atomic/atomic_ref/notify_all"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/address",
+    "cppdoc": "cpp/library/atomic/atomic_ref/address"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/atomic_ref",
+    "cppdoc": "cpp/library/atomic/atomic_ref/atomic_ref"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/is_always_lock_free",
+    "cppdoc": "cpp/library/atomic/atomic_ref/is_always_lock_free"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/fetch_and",
+    "cppdoc": "cpp/library/atomic/atomic_ref/fetch_and"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/compare_exchange",
+    "cppdoc": "cpp/library/atomic/atomic_ref/compare_exchange"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/operator_arith",
+    "cppdoc": "cpp/library/atomic/atomic_ref/operator_arith"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/operator_arith3",
+    "cppdoc": "cpp/library/atomic/atomic_ref/operator_arith3"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/fetch_max",
+    "cppdoc": "cpp/library/atomic/atomic_ref/fetch_max"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/notify_one",
+    "cppdoc": "cpp/library/atomic/atomic_ref/notify_one"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/fetch_sub",
+    "cppdoc": "cpp/library/atomic/atomic_ref/fetch_sub"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/wait",
+    "cppdoc": "cpp/library/atomic/atomic_ref/wait"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/fetch_add",
+    "cppdoc": "cpp/library/atomic/atomic_ref/fetch_add"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/is_lock_free",
+    "cppdoc": "cpp/library/atomic/atomic_ref/is_lock_free"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/fetch_or",
+    "cppdoc": "cpp/library/atomic/atomic_ref/fetch_or"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/operator_arith2",
+    "cppdoc": "cpp/library/atomic/atomic_ref/operator_arith2"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/operator=",
+    "cppdoc": "cpp/library/atomic/atomic_ref/operator="
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/store",
+    "cppdoc": "cpp/library/atomic/atomic_ref/store"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/load",
+    "cppdoc": "cpp/library/atomic/atomic_ref/load"
+  },
+  {
+    "cppref": "cpp/atomic/atomic_ref/operator_T",
+    "cppdoc": "cpp/library/atomic/atomic_ref/operator_T"
+  },
+  {
+    "cppref": "cpp/utility/to_chars",
+    "cppdoc": "cpp/library/text/to_chars"
+  },
+  {
+    "cppref": "cpp/utility/as_const",
+    "cppdoc": "cpp/library/utility/as_const"
+  },
+  {
+    "cppref": "cpp/utility/initializer_list",
+    "cppdoc": "cpp/library/utility/initializer_list"
+  },
+  {
+    "cppref": "cpp/utility/exchange",
+    "cppdoc": "cpp/library/utility/exchange"
+  },
+  {
+    "cppref": "cpp/utility/declval",
+    "cppdoc": "cpp/library/utility/declval"
+  },
+  {
+    "cppref": "cpp/utility/source_location",
+    "cppdoc": "cpp/library/utility/source_location"
+  },
+  {
+    "cppref": "cpp/utility/hash",
+    "cppdoc": "cpp/library/utility/hash"
+  },
+  {
+    "cppref": "cpp/utility/integer_sequence",
+    "cppdoc": "cpp/library/meta/integer_sequence"
+  },
+  {
+    "cppref": "cpp/utility/move",
+    "cppdoc": "cpp/library/utility/move"
+  },
+  {
+    "cppref": "cpp/utility/any",
+    "cppdoc": "cpp/library/utility/any"
+  },
+  {
+    "cppref": "cpp/utility/breakpoint_if_debugging",
+    "cppdoc": "cpp/library/error/breakpoint_if_debugging"
+  },
+  {
+    "cppref": "cpp/utility/tuple",
+    "cppdoc": "cpp/library/utility/tuple"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace",
+    "cppdoc": "cpp/library/error/basic_stacktrace"
+  },
+  {
+    "cppref": "cpp/utility/format",
+    "cppdoc": "cpp/library/text/format"
+  },
+  {
+    "cppref": "cpp/utility/variant",
+    "cppdoc": "cpp/library/utility/variant"
+  },
+  {
+    "cppref": "cpp/utility/from_chars",
+    "cppdoc": "cpp/library/text/from_chars"
+  },
+  {
+    "cppref": "cpp/utility/to_chars_result",
+    "cppdoc": "cpp/library/text/to_chars_result"
+  },
+  {
+    "cppref": "cpp/utility/variadic",
+    "cppdoc": "cpp/library/utility/variadic"
+  },
+  {
+    "cppref": "cpp/utility/launder",
+    "cppdoc": "cpp/library/memory/new/launder"
+  },
+  {
+    "cppref": "cpp/utility/in_place",
+    "cppdoc": "cpp/library/utility/in_place"
+  },
+  {
+    "cppref": "cpp/utility/bitset",
+    "cppdoc": "cpp/library/utility/bitset"
+  },
+  {
+    "cppref": "cpp/utility/swap",
+    "cppdoc": "cpp/library/algorithm/swap"
+  },
+  {
+    "cppref": "cpp/utility/make_from_tuple",
+    "cppdoc": "cpp/library/utility/make_from_tuple"
+  },
+  {
+    "cppref": "cpp/utility/feature_test",
+    "cppdoc": "cpp/library/utility/feature_test"
+  },
+  {
+    "cppref": "cpp/utility/from_chars_result",
+    "cppdoc": "cpp/library/text/from_chars_result"
+  },
+  {
+    "cppref": "cpp/utility/tuple_size",
+    "cppdoc": "cpp/library/utility/tuple_size"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry",
+    "cppdoc": "cpp/library/error/stacktrace_entry"
+  },
+  {
+    "cppref": "cpp/utility/forward",
+    "cppdoc": "cpp/library/utility/forward"
+  },
+  {
+    "cppref": "cpp/utility/bit",
+    "cppdoc": "cpp/library/utility/bit"
+  },
+  {
+    "cppref": "cpp/utility/pair",
+    "cppdoc": "cpp/library/utility/pair"
+  },
+  {
+    "cppref": "cpp/utility/apply",
+    "cppdoc": "cpp/library/utility/apply"
+  },
+  {
+    "cppref": "cpp/utility/intcmp",
+    "cppdoc": "cpp/library/utility/intcmp"
+  },
+  {
+    "cppref": "cpp/utility/forward_like",
+    "cppdoc": "cpp/library/utility/forward_like"
+  },
+  {
+    "cppref": "cpp/utility/expected",
+    "cppdoc": "cpp/library/utility/expected"
+  },
+  {
+    "cppref": "cpp/utility/breakpoint",
+    "cppdoc": "cpp/library/error/breakpoint"
+  },
+  {
+    "cppref": "cpp/utility/tuple_element",
+    "cppdoc": "cpp/library/utility/tuple_element"
+  },
+  {
+    "cppref": "cpp/utility/chars_format",
+    "cppdoc": "cpp/library/text/chars_format"
+  },
+  {
+    "cppref": "cpp/utility/optional",
+    "cppdoc": "cpp/library/utility/optional"
+  },
+  {
+    "cppref": "cpp/utility/functional",
+    "cppdoc": "cpp/library/utility/functional"
+  },
+  {
+    "cppref": "cpp/utility/to_underlying",
+    "cppdoc": "cpp/library/utility/to_underlying"
+  },
+  {
+    "cppref": "cpp/utility/move_if_noexcept",
+    "cppdoc": "cpp/library/utility/move_if_noexcept"
+  },
+  {
+    "cppref": "cpp/utility/in_range",
+    "cppdoc": "cpp/library/utility/in_range"
+  },
+  {
+    "cppref": "cpp/utility/program",
+    "cppdoc": "cpp/library/utility/program"
+  },
+  {
+    "cppref": "cpp/utility/is_debugger_present",
+    "cppdoc": "cpp/library/error/is_debugger_present"
+  },
+  {
+    "cppref": "cpp/utility/pair/make_pair",
+    "cppdoc": "cpp/library/utility/pair/make_pair"
+  },
+  {
+    "cppref": "cpp/utility/pair/swap2",
+    "cppdoc": "cpp/library/utility/pair/swap2"
+  },
+  {
+    "cppref": "cpp/utility/pair/deduction_guides",
+    "cppdoc": "cpp/library/utility/pair/deduction_guides"
+  },
+  {
+    "cppref": "cpp/utility/pair/swap",
+    "cppdoc": "cpp/library/utility/pair/swap"
+  },
+  {
+    "cppref": "cpp/utility/pair/tuple_size",
+    "cppdoc": "cpp/library/utility/pair/tuple_size"
+  },
+  {
+    "cppref": "cpp/utility/pair/common_type",
+    "cppdoc": "cpp/library/utility/pair/common_type"
+  },
+  {
+    "cppref": "cpp/utility/pair/get",
+    "cppdoc": "cpp/library/utility/pair/get"
+  },
+  {
+    "cppref": "cpp/utility/pair/pair",
+    "cppdoc": "cpp/library/utility/pair/pair"
+  },
+  {
+    "cppref": "cpp/utility/pair/operator_cmp",
+    "cppdoc": "cpp/library/utility/pair/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/pair/tuple_element",
+    "cppdoc": "cpp/library/utility/pair/tuple_element"
+  },
+  {
+    "cppref": "cpp/utility/pair/operator=",
+    "cppdoc": "cpp/library/utility/pair/operator="
+  },
+  {
+    "cppref": "cpp/utility/pair/basic_common_reference",
+    "cppdoc": "cpp/library/utility/pair/basic_common_reference"
+  },
+  {
+    "cppref": "cpp/utility/variadic/va_list",
+    "cppdoc": "cpp/library/utility/variadic/va_list"
+  },
+  {
+    "cppref": "cpp/utility/variadic/va_copy",
+    "cppdoc": "cpp/library/utility/variadic/va_copy"
+  },
+  {
+    "cppref": "cpp/utility/variadic/va_arg",
+    "cppdoc": "cpp/library/utility/variadic/va_arg"
+  },
+  {
+    "cppref": "cpp/utility/variadic/va_start",
+    "cppdoc": "cpp/library/utility/variadic/va_start"
+  },
+  {
+    "cppref": "cpp/utility/variadic/va_end",
+    "cppdoc": "cpp/library/utility/variadic/va_end"
+  },
+  {
+    "cppref": "cpp/utility/any/~any",
+    "cppdoc": "cpp/library/utility/any/~any"
+  },
+  {
+    "cppref": "cpp/utility/any/emplace",
+    "cppdoc": "cpp/library/utility/any/emplace"
+  },
+  {
+    "cppref": "cpp/utility/any/make_any",
+    "cppdoc": "cpp/library/utility/any/make_any"
+  },
+  {
+    "cppref": "cpp/utility/any/any",
+    "cppdoc": "cpp/library/utility/any/any"
+  },
+  {
+    "cppref": "cpp/utility/any/swap2",
+    "cppdoc": "cpp/library/utility/any/swap2"
+  },
+  {
+    "cppref": "cpp/utility/any/reset",
+    "cppdoc": "cpp/library/utility/any/reset"
+  },
+  {
+    "cppref": "cpp/utility/any/swap",
+    "cppdoc": "cpp/library/utility/any/swap"
+  },
+  {
+    "cppref": "cpp/utility/any/any_cast",
+    "cppdoc": "cpp/library/utility/any/any_cast"
+  },
+  {
+    "cppref": "cpp/utility/any/type",
+    "cppdoc": "cpp/library/utility/any/type"
+  },
+  {
+    "cppref": "cpp/utility/any/bad_any_cast",
+    "cppdoc": "cpp/library/utility/any/bad_any_cast"
+  },
+  {
+    "cppref": "cpp/utility/any/operator=",
+    "cppdoc": "cpp/library/utility/any/operator="
+  },
+  {
+    "cppref": "cpp/utility/any/has_value",
+    "cppdoc": "cpp/library/utility/any/has_value"
+  },
+  {
+    "cppref": "cpp/utility/compare/compare_three_way_result",
+    "cppdoc": "cpp/library/utility/compare/compare_three_way_result"
+  },
+  {
+    "cppref": "cpp/utility/compare/compare_weak_order_fallback",
+    "cppdoc": "cpp/library/utility/compare/compare_weak_order_fallback"
+  },
+  {
+    "cppref": "cpp/utility/compare/compare_strong_order_fallback",
+    "cppdoc": "cpp/library/utility/compare/compare_strong_order_fallback"
+  },
+  {
+    "cppref": "cpp/utility/compare/named_comparison_functions",
+    "cppdoc": "cpp/library/utility/compare/named_comparison_functions"
+  },
+  {
+    "cppref": "cpp/utility/compare/partial_order",
+    "cppdoc": "cpp/library/utility/compare/partial_order"
+  },
+  {
+    "cppref": "cpp/utility/compare/strong_order",
+    "cppdoc": "cpp/library/utility/compare/strong_order"
+  },
+  {
+    "cppref": "cpp/utility/compare/weak_order",
+    "cppdoc": "cpp/library/utility/compare/weak_order"
+  },
+  {
+    "cppref": "cpp/utility/compare/strong_ordering",
+    "cppdoc": "cpp/library/utility/compare/strong_ordering"
+  },
+  {
+    "cppref": "cpp/utility/compare/three_way_comparable",
+    "cppdoc": "cpp/library/utility/compare/three_way_comparable"
+  },
+  {
+    "cppref": "cpp/utility/compare/compare_three_way",
+    "cppdoc": "cpp/library/utility/functional/compare_three_way"
+  },
+  {
+    "cppref": "cpp/utility/compare/compare_partial_order_fallback",
+    "cppdoc": "cpp/library/utility/compare/compare_partial_order_fallback"
+  },
+  {
+    "cppref": "cpp/utility/compare/weak_ordering",
+    "cppdoc": "cpp/library/utility/compare/weak_ordering"
+  },
+  {
+    "cppref": "cpp/utility/compare/partial_ordering",
+    "cppdoc": "cpp/library/utility/compare/partial_ordering"
+  },
+  {
+    "cppref": "cpp/utility/compare/common_comparison_category",
+    "cppdoc": "cpp/library/utility/compare/common_comparison_category"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/hash",
+    "cppdoc": "cpp/library/error/stacktrace_entry/hash"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/to_string",
+    "cppdoc": "cpp/library/error/stacktrace_entry/to_string"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/formatter",
+    "cppdoc": "cpp/library/error/stacktrace_entry/formatter"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/source_file",
+    "cppdoc": "cpp/library/error/stacktrace_entry/source_file"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/source_line",
+    "cppdoc": "cpp/library/error/stacktrace_entry/source_line"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/stacktrace_entry",
+    "cppdoc": "cpp/library/error/stacktrace_entry/stacktrace_entry"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/operator_cmp",
+    "cppdoc": "cpp/library/error/stacktrace_entry/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/operator_bool",
+    "cppdoc": "cpp/library/error/stacktrace_entry/operator_bool"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/operator=",
+    "cppdoc": "cpp/library/error/stacktrace_entry/operator="
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/operator_ltlt",
+    "cppdoc": "cpp/library/error/stacktrace_entry/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/description",
+    "cppdoc": "cpp/library/error/stacktrace_entry/description"
+  },
+  {
+    "cppref": "cpp/utility/stacktrace_entry/native_handle",
+    "cppdoc": "cpp/library/error/stacktrace_entry/native_handle"
+  },
+  {
+    "cppref": "cpp/utility/ranges/swap",
+    "cppdoc": "cpp/library/utility/ranges/swap"
+  },
+  {
+    "cppref": "cpp/utility/source_location/file_name",
+    "cppdoc": "cpp/library/utility/source_location/file_name"
+  },
+  {
+    "cppref": "cpp/utility/source_location/source_location",
+    "cppdoc": "cpp/library/utility/source_location/source_location"
+  },
+  {
+    "cppref": "cpp/utility/source_location/line",
+    "cppdoc": "cpp/library/utility/source_location/line"
+  },
+  {
+    "cppref": "cpp/utility/source_location/current",
+    "cppdoc": "cpp/library/utility/source_location/current"
+  },
+  {
+    "cppref": "cpp/utility/source_location/function_name",
+    "cppdoc": "cpp/library/utility/source_location/function_name"
+  },
+  {
+    "cppref": "cpp/utility/source_location/column",
+    "cppdoc": "cpp/library/utility/source_location/column"
+  },
+  {
+    "cppref": "cpp/utility/bitset/operator_at",
+    "cppdoc": "cpp/library/utility/bitset/operator_at"
+  },
+  {
+    "cppref": "cpp/utility/bitset/to_ullong",
+    "cppdoc": "cpp/library/utility/bitset/to_ullong"
+  },
+  {
+    "cppref": "cpp/utility/bitset/hash",
+    "cppdoc": "cpp/library/utility/bitset/hash"
+  },
+  {
+    "cppref": "cpp/utility/bitset/size",
+    "cppdoc": "cpp/library/utility/bitset/size"
+  },
+  {
+    "cppref": "cpp/utility/bitset/test",
+    "cppdoc": "cpp/library/utility/bitset/test"
+  },
+  {
+    "cppref": "cpp/utility/bitset/to_string",
+    "cppdoc": "cpp/library/utility/bitset/to_string"
+  },
+  {
+    "cppref": "cpp/utility/bitset/operator_ltltgtgt",
+    "cppdoc": "cpp/library/utility/bitset/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/utility/bitset/reset",
+    "cppdoc": "cpp/library/utility/bitset/reset"
+  },
+  {
+    "cppref": "cpp/utility/bitset/operator_logic",
+    "cppdoc": "cpp/library/utility/bitset/operator_logic"
+  },
+  {
+    "cppref": "cpp/utility/bitset/bitset",
+    "cppdoc": "cpp/library/utility/bitset/bitset"
+  },
+  {
+    "cppref": "cpp/utility/bitset/to_ulong",
+    "cppdoc": "cpp/library/utility/bitset/to_ulong"
+  },
+  {
+    "cppref": "cpp/utility/bitset/count",
+    "cppdoc": "cpp/library/utility/bitset/count"
+  },
+  {
+    "cppref": "cpp/utility/bitset/flip",
+    "cppdoc": "cpp/library/utility/bitset/flip"
+  },
+  {
+    "cppref": "cpp/utility/bitset/operator_ltltgtgt2",
+    "cppdoc": "cpp/library/utility/bitset/operator_ltltgtgt2"
+  },
+  {
+    "cppref": "cpp/utility/bitset/operator_cmp",
+    "cppdoc": "cpp/library/utility/bitset/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/bitset/all_any_none",
+    "cppdoc": "cpp/library/utility/bitset/all_any_none"
+  },
+  {
+    "cppref": "cpp/utility/bitset/operator_logic2",
+    "cppdoc": "cpp/library/utility/bitset/operator_logic2"
+  },
+  {
+    "cppref": "cpp/utility/bitset/reference",
+    "cppdoc": "cpp/library/utility/bitset/reference"
+  },
+  {
+    "cppref": "cpp/utility/bitset/set",
+    "cppdoc": "cpp/library/utility/bitset/set"
+  },
+  {
+    "cppref": "cpp/utility/rel_ops/operator_cmp",
+    "cppdoc": "cpp/library/utility/rel_ops/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/expected/and_then",
+    "cppdoc": "cpp/library/utility/expected/and_then"
+  },
+  {
+    "cppref": "cpp/utility/expected/emplace",
+    "cppdoc": "cpp/library/utility/expected/emplace"
+  },
+  {
+    "cppref": "cpp/utility/expected/value_or",
+    "cppdoc": "cpp/library/utility/expected/value_or"
+  },
+  {
+    "cppref": "cpp/utility/expected/transform_error",
+    "cppdoc": "cpp/library/utility/expected/transform_error"
+  },
+  {
+    "cppref": "cpp/utility/expected/bad_expected_access",
+    "cppdoc": "cpp/library/utility/expected/bad_expected_access"
+  },
+  {
+    "cppref": "cpp/utility/expected/swap2",
+    "cppdoc": "cpp/library/utility/expected/swap2"
+  },
+  {
+    "cppref": "cpp/utility/expected/unexpect_t",
+    "cppdoc": "cpp/library/utility/expected/unexpect_t"
+  },
+  {
+    "cppref": "cpp/utility/expected/or_else",
+    "cppdoc": "cpp/library/utility/expected/or_else"
+  },
+  {
+    "cppref": "cpp/utility/expected/error",
+    "cppdoc": "cpp/library/utility/expected/error"
+  },
+  {
+    "cppref": "cpp/utility/expected/error_or",
+    "cppdoc": "cpp/library/utility/expected/error_or"
+  },
+  {
+    "cppref": "cpp/utility/expected/swap",
+    "cppdoc": "cpp/library/utility/expected/swap"
+  },
+  {
+    "cppref": "cpp/utility/expected/value",
+    "cppdoc": "cpp/library/utility/expected/value"
+  },
+  {
+    "cppref": "cpp/utility/expected/unexpected",
+    "cppdoc": "cpp/library/utility/expected/unexpected"
+  },
+  {
+    "cppref": "cpp/utility/expected/operator_star_",
+    "cppdoc": "cpp/library/utility/expected/operator_star_"
+  },
+  {
+    "cppref": "cpp/utility/expected/operator_cmp",
+    "cppdoc": "cpp/library/utility/expected/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/expected/expected",
+    "cppdoc": "cpp/library/utility/expected/expected"
+  },
+  {
+    "cppref": "cpp/utility/expected/operator_bool",
+    "cppdoc": "cpp/library/utility/expected/operator_bool"
+  },
+  {
+    "cppref": "cpp/utility/expected/operator=",
+    "cppdoc": "cpp/library/utility/expected/operator="
+  },
+  {
+    "cppref": "cpp/utility/expected/transform",
+    "cppdoc": "cpp/library/utility/expected/transform"
+  },
+  {
+    "cppref": "cpp/utility/expected/~expected",
+    "cppdoc": "cpp/library/utility/expected/~expected"
+  },
+  {
+    "cppref": "cpp/utility/tuple/make_tuple",
+    "cppdoc": "cpp/library/utility/tuple/make_tuple"
+  },
+  {
+    "cppref": "cpp/utility/tuple/tie",
+    "cppdoc": "cpp/library/utility/tuple/tie"
+  },
+  {
+    "cppref": "cpp/utility/tuple/tuple-like",
+    "cppdoc": "cpp/library/utility/tuple/tuple-like"
+  },
+  {
+    "cppref": "cpp/utility/tuple/tuple",
+    "cppdoc": "cpp/library/utility/tuple/tuple"
+  },
+  {
+    "cppref": "cpp/utility/tuple/forward_as_tuple",
+    "cppdoc": "cpp/library/utility/tuple/forward_as_tuple"
+  },
+  {
+    "cppref": "cpp/utility/tuple/swap2",
+    "cppdoc": "cpp/library/utility/tuple/swap2"
+  },
+  {
+    "cppref": "cpp/utility/tuple/tuple_cat",
+    "cppdoc": "cpp/library/utility/tuple/tuple_cat"
+  },
+  {
+    "cppref": "cpp/utility/tuple/deduction_guides",
+    "cppdoc": "cpp/library/utility/tuple/deduction_guides"
+  },
+  {
+    "cppref": "cpp/utility/tuple/ignore",
+    "cppdoc": "cpp/library/utility/tuple/ignore"
+  },
+  {
+    "cppref": "cpp/utility/tuple/swap",
+    "cppdoc": "cpp/library/utility/tuple/swap"
+  },
+  {
+    "cppref": "cpp/utility/tuple/tuple_size",
+    "cppdoc": "cpp/library/utility/tuple/tuple_size"
+  },
+  {
+    "cppref": "cpp/utility/tuple/common_type",
+    "cppdoc": "cpp/library/utility/tuple/common_type"
+  },
+  {
+    "cppref": "cpp/utility/tuple/get",
+    "cppdoc": "cpp/library/utility/tuple/get"
+  },
+  {
+    "cppref": "cpp/utility/tuple/operator_cmp",
+    "cppdoc": "cpp/library/utility/tuple/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/tuple/tuple_element",
+    "cppdoc": "cpp/library/utility/tuple/tuple_element"
+  },
+  {
+    "cppref": "cpp/utility/tuple/operator=",
+    "cppdoc": "cpp/library/utility/tuple/operator="
+  },
+  {
+    "cppref": "cpp/utility/tuple/basic_common_reference",
+    "cppdoc": "cpp/library/utility/tuple/basic_common_reference"
+  },
+  {
+    "cppref": "cpp/utility/tuple/uses_allocator",
+    "cppdoc": "cpp/library/utility/tuple/uses_allocator"
+  },
+  {
+    "cppref": "cpp/utility/hash/hash",
+    "cppdoc": "cpp/library/utility/hash/hash"
+  },
+  {
+    "cppref": "cpp/utility/hash/operator()",
+    "cppdoc": "cpp/library/utility/hash/operator()"
+  },
+  {
+    "cppref": "cpp/utility/functional/multiplies",
+    "cppdoc": "cpp/library/utility/functional/multiplies"
+  },
+  {
+    "cppref": "cpp/utility/functional/greater_void",
+    "cppdoc": "cpp/library/utility/functional/greater_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/less_void",
+    "cppdoc": "cpp/library/utility/functional/less_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/plus",
+    "cppdoc": "cpp/library/utility/functional/plus"
+  },
+  {
+    "cppref": "cpp/utility/functional/logical_or_void",
+    "cppdoc": "cpp/library/utility/functional/logical_or_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/not_equal_to_void",
+    "cppdoc": "cpp/library/utility/functional/not_equal_to_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/not1",
+    "cppdoc": "cpp/library/utility/functional/not1"
+  },
+  {
+    "cppref": "cpp/utility/functional/bit_not",
+    "cppdoc": "cpp/library/utility/functional/bit_not"
+  },
+  {
+    "cppref": "cpp/utility/functional/logical_and",
+    "cppdoc": "cpp/library/utility/functional/logical_and"
+  },
+  {
+    "cppref": "cpp/utility/functional/invoke",
+    "cppdoc": "cpp/library/utility/functional/invoke"
+  },
+  {
+    "cppref": "cpp/utility/functional/not_equal_to",
+    "cppdoc": "cpp/library/utility/functional/not_equal_to"
+  },
+  {
+    "cppref": "cpp/utility/functional/bind",
+    "cppdoc": "cpp/library/utility/functional/bind"
+  },
+  {
+    "cppref": "cpp/utility/functional/boyer_moore_searcher",
+    "cppdoc": "cpp/library/utility/functional/boyer_moore_searcher"
+  },
+  {
+    "cppref": "cpp/utility/functional/binary_negate",
+    "cppdoc": "cpp/library/utility/functional/binary_negate"
+  },
+  {
+    "cppref": "cpp/utility/functional/unary_function",
+    "cppdoc": "cpp/library/utility/functional/unary_function"
+  },
+  {
+    "cppref": "cpp/utility/functional/equal_to",
+    "cppdoc": "cpp/library/utility/functional/equal_to"
+  },
+  {
+    "cppref": "cpp/utility/functional/bit_and",
+    "cppdoc": "cpp/library/utility/functional/bit_and"
+  },
+  {
+    "cppref": "cpp/utility/functional/minus_void",
+    "cppdoc": "cpp/library/utility/functional/minus_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/placeholders",
+    "cppdoc": "cpp/library/utility/functional/placeholders"
+  },
+  {
+    "cppref": "cpp/utility/functional/divides",
+    "cppdoc": "cpp/library/utility/functional/divides"
+  },
+  {
+    "cppref": "cpp/utility/functional/not_fn",
+    "cppdoc": "cpp/library/utility/functional/not_fn"
+  },
+  {
+    "cppref": "cpp/utility/functional/less",
+    "cppdoc": "cpp/library/utility/functional/less"
+  },
+  {
+    "cppref": "cpp/utility/functional/default_searcher",
+    "cppdoc": "cpp/library/utility/functional/default_searcher"
+  },
+  {
+    "cppref": "cpp/utility/functional/mem_fn",
+    "cppdoc": "cpp/library/utility/functional/mem_fn"
+  },
+  {
+    "cppref": "cpp/utility/functional/mem_fun_t",
+    "cppdoc": "cpp/library/utility/functional/mem_fun_t"
+  },
+  {
+    "cppref": "cpp/utility/functional/ref",
+    "cppdoc": "cpp/library/utility/functional/ref"
+  },
+  {
+    "cppref": "cpp/utility/functional/ptr_fun",
+    "cppdoc": "cpp/library/utility/functional/ptr_fun"
+  },
+  {
+    "cppref": "cpp/utility/functional/mem_fun",
+    "cppdoc": "cpp/library/utility/functional/mem_fun"
+  },
+  {
+    "cppref": "cpp/utility/functional/binary_function",
+    "cppdoc": "cpp/library/utility/functional/binary_function"
+  },
+  {
+    "cppref": "cpp/utility/functional/bind12",
+    "cppdoc": "cpp/library/utility/functional/bind12"
+  },
+  {
+    "cppref": "cpp/utility/functional/logical_not",
+    "cppdoc": "cpp/library/utility/functional/logical_not"
+  },
+  {
+    "cppref": "cpp/utility/functional/identity",
+    "cppdoc": "cpp/library/utility/functional/identity"
+  },
+  {
+    "cppref": "cpp/utility/functional/logical_or",
+    "cppdoc": "cpp/library/utility/functional/logical_or"
+  },
+  {
+    "cppref": "cpp/utility/functional/logical_and_void",
+    "cppdoc": "cpp/library/utility/functional/logical_and_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/boyer_moore_horspool_searcher",
+    "cppdoc": "cpp/library/utility/functional/boyer_moore_horspool_searcher"
+  },
+  {
+    "cppref": "cpp/utility/functional/modulus",
+    "cppdoc": "cpp/library/utility/functional/modulus"
+  },
+  {
+    "cppref": "cpp/utility/functional/logical_not_void",
+    "cppdoc": "cpp/library/utility/functional/logical_not_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/divides_void",
+    "cppdoc": "cpp/library/utility/functional/divides_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/plus_void",
+    "cppdoc": "cpp/library/utility/functional/plus_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/bit_not_void",
+    "cppdoc": "cpp/library/utility/functional/bit_not_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/mem_fun_ref",
+    "cppdoc": "cpp/library/utility/functional/mem_fun_ref"
+  },
+  {
+    "cppref": "cpp/utility/functional/modulus_void",
+    "cppdoc": "cpp/library/utility/functional/modulus_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/negate",
+    "cppdoc": "cpp/library/utility/functional/negate"
+  },
+  {
+    "cppref": "cpp/utility/functional/function",
+    "cppdoc": "cpp/library/utility/functional/function"
+  },
+  {
+    "cppref": "cpp/utility/functional/minus",
+    "cppdoc": "cpp/library/utility/functional/minus"
+  },
+  {
+    "cppref": "cpp/utility/functional/reference_wrapper",
+    "cppdoc": "cpp/library/utility/functional/reference_wrapper"
+  },
+  {
+    "cppref": "cpp/utility/functional/multiplies_void",
+    "cppdoc": "cpp/library/utility/functional/multiplies_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/greater_equal",
+    "cppdoc": "cpp/library/utility/functional/greater_equal"
+  },
+  {
+    "cppref": "cpp/utility/functional/greater_equal_void",
+    "cppdoc": "cpp/library/utility/functional/greater_equal_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/is_placeholder",
+    "cppdoc": "cpp/library/utility/functional/is_placeholder"
+  },
+  {
+    "cppref": "cpp/utility/functional/bit_or_void",
+    "cppdoc": "cpp/library/utility/functional/bit_or_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/pointer_to_unary_function",
+    "cppdoc": "cpp/library/utility/functional/pointer_to_unary_function"
+  },
+  {
+    "cppref": "cpp/utility/functional/unwrap_reference",
+    "cppdoc": "cpp/library/utility/functional/unwrap_reference"
+  },
+  {
+    "cppref": "cpp/utility/functional/not2",
+    "cppdoc": "cpp/library/utility/functional/not2"
+  },
+  {
+    "cppref": "cpp/utility/functional/binder12",
+    "cppdoc": "cpp/library/utility/functional/binder12"
+  },
+  {
+    "cppref": "cpp/utility/functional/move_only_function",
+    "cppdoc": "cpp/library/utility/functional/move_only_function"
+  },
+  {
+    "cppref": "cpp/utility/functional/unary_negate",
+    "cppdoc": "cpp/library/utility/functional/unary_negate"
+  },
+  {
+    "cppref": "cpp/utility/functional/bit_and_void",
+    "cppdoc": "cpp/library/utility/functional/bit_and_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/pointer_to_binary_function",
+    "cppdoc": "cpp/library/utility/functional/pointer_to_binary_function"
+  },
+  {
+    "cppref": "cpp/utility/functional/negate_void",
+    "cppdoc": "cpp/library/utility/functional/negate_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/mem_fun_ref_t",
+    "cppdoc": "cpp/library/utility/functional/mem_fun_ref_t"
+  },
+  {
+    "cppref": "cpp/utility/functional/function_ref",
+    "cppdoc": "cpp/library/utility/functional/function_ref"
+  },
+  {
+    "cppref": "cpp/utility/functional/is_bind_expression",
+    "cppdoc": "cpp/library/utility/functional/is_bind_expression"
+  },
+  {
+    "cppref": "cpp/utility/functional/bind_front",
+    "cppdoc": "cpp/library/utility/functional/bind_front"
+  },
+  {
+    "cppref": "cpp/utility/functional/bit_or",
+    "cppdoc": "cpp/library/utility/functional/bit_or"
+  },
+  {
+    "cppref": "cpp/utility/functional/equal_to_void",
+    "cppdoc": "cpp/library/utility/functional/equal_to_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/bad_function_call",
+    "cppdoc": "cpp/library/utility/functional/bad_function_call"
+  },
+  {
+    "cppref": "cpp/utility/functional/less_equal",
+    "cppdoc": "cpp/library/utility/functional/less_equal"
+  },
+  {
+    "cppref": "cpp/utility/functional/greater",
+    "cppdoc": "cpp/library/utility/functional/greater"
+  },
+  {
+    "cppref": "cpp/utility/functional/less_equal_void",
+    "cppdoc": "cpp/library/utility/functional/less_equal_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/bit_xor",
+    "cppdoc": "cpp/library/utility/functional/bit_xor"
+  },
+  {
+    "cppref": "cpp/utility/functional/copyable_function",
+    "cppdoc": "cpp/library/utility/functional/copyable_function"
+  },
+  {
+    "cppref": "cpp/utility/functional/bit_xor_void",
+    "cppdoc": "cpp/library/utility/functional/bit_xor_void"
+  },
+  {
+    "cppref": "cpp/utility/functional/move_only_function/operator==",
+    "cppdoc": "cpp/library/utility/functional/move_only_function/operator=="
+  },
+  {
+    "cppref": "cpp/utility/functional/move_only_function/~move_only_function",
+    "cppdoc": "cpp/library/utility/functional/move_only_function/~move_only_function"
+  },
+  {
+    "cppref": "cpp/utility/functional/move_only_function/swap2",
+    "cppdoc": "cpp/library/utility/functional/move_only_function/swap2"
+  },
+  {
+    "cppref": "cpp/utility/functional/move_only_function/swap",
+    "cppdoc": "cpp/library/utility/functional/move_only_function/swap"
+  },
+  {
+    "cppref": "cpp/utility/functional/move_only_function/operator()",
+    "cppdoc": "cpp/library/utility/functional/move_only_function/operator()"
+  },
+  {
+    "cppref": "cpp/utility/functional/move_only_function/move_only_function",
+    "cppdoc": "cpp/library/utility/functional/move_only_function/move_only_function"
+  },
+  {
+    "cppref": "cpp/utility/functional/move_only_function/operator_bool",
+    "cppdoc": "cpp/library/utility/functional/move_only_function/operator_bool"
+  },
+  {
+    "cppref": "cpp/utility/functional/move_only_function/operator=",
+    "cppdoc": "cpp/library/utility/functional/move_only_function/operator="
+  },
+  {
+    "cppref": "cpp/utility/functional/copyable_function/operator==",
+    "cppdoc": "cpp/library/utility/functional/copyable_function/operator=="
+  },
+  {
+    "cppref": "cpp/utility/functional/copyable_function/~copyable_function",
+    "cppdoc": "cpp/library/utility/functional/copyable_function/~copyable_function"
+  },
+  {
+    "cppref": "cpp/utility/functional/copyable_function/swap2",
+    "cppdoc": "cpp/library/utility/functional/copyable_function/swap2"
+  },
+  {
+    "cppref": "cpp/utility/functional/copyable_function/swap",
+    "cppdoc": "cpp/library/utility/functional/copyable_function/swap"
+  },
+  {
+    "cppref": "cpp/utility/functional/copyable_function/operator()",
+    "cppdoc": "cpp/library/utility/functional/copyable_function/operator()"
+  },
+  {
+    "cppref": "cpp/utility/functional/copyable_function/operator_bool",
+    "cppdoc": "cpp/library/utility/functional/copyable_function/operator_bool"
+  },
+  {
+    "cppref": "cpp/utility/functional/copyable_function/operator=",
+    "cppdoc": "cpp/library/utility/functional/copyable_function/operator="
+  },
+  {
+    "cppref": "cpp/utility/functional/copyable_function/copyable_function",
+    "cppdoc": "cpp/library/utility/functional/copyable_function/copyable_function"
+  },
+  {
+    "cppref": "cpp/utility/functional/function_ref/deduction_guides",
+    "cppdoc": "cpp/library/utility/functional/function_ref/deduction_guides"
+  },
+  {
+    "cppref": "cpp/utility/functional/function_ref/operator()",
+    "cppdoc": "cpp/library/utility/functional/function_ref/operator()"
+  },
+  {
+    "cppref": "cpp/utility/functional/function_ref/operator=",
+    "cppdoc": "cpp/library/utility/functional/function_ref/operator="
+  },
+  {
+    "cppref": "cpp/utility/functional/function_ref/function_ref",
+    "cppdoc": "cpp/library/utility/functional/function_ref/function_ref"
+  },
+  {
+    "cppref": "cpp/utility/functional/ranges/not_equal_to",
+    "cppdoc": "cpp/library/utility/functional/ranges/not_equal_to"
+  },
+  {
+    "cppref": "cpp/utility/functional/ranges/equal_to",
+    "cppdoc": "cpp/library/utility/functional/ranges/equal_to"
+  },
+  {
+    "cppref": "cpp/utility/functional/ranges/less",
+    "cppdoc": "cpp/library/utility/functional/ranges/less"
+  },
+  {
+    "cppref": "cpp/utility/functional/ranges/greater_equal",
+    "cppdoc": "cpp/library/utility/functional/ranges/greater_equal"
+  },
+  {
+    "cppref": "cpp/utility/functional/ranges/less_equal",
+    "cppdoc": "cpp/library/utility/functional/ranges/less_equal"
+  },
+  {
+    "cppref": "cpp/utility/functional/ranges/greater",
+    "cppdoc": "cpp/library/utility/functional/ranges/greater"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/assign",
+    "cppdoc": "cpp/library/utility/functional/function/assign"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/~function",
+    "cppdoc": "cpp/library/utility/functional/function/~function"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/target",
+    "cppdoc": "cpp/library/utility/functional/function/target"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/swap2",
+    "cppdoc": "cpp/library/utility/functional/function/swap2"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/deduction_guides",
+    "cppdoc": "cpp/library/utility/functional/function/deduction_guides"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/swap",
+    "cppdoc": "cpp/library/utility/functional/function/swap"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/operator()",
+    "cppdoc": "cpp/library/utility/functional/function/operator()"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/function",
+    "cppdoc": "cpp/library/utility/functional/function/function"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/operator_cmp",
+    "cppdoc": "cpp/library/utility/functional/function/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/operator_bool",
+    "cppdoc": "cpp/library/utility/functional/function/operator_bool"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/operator=",
+    "cppdoc": "cpp/library/utility/functional/function/operator="
+  },
+  {
+    "cppref": "cpp/utility/functional/function/target_type",
+    "cppdoc": "cpp/library/utility/functional/function/target_type"
+  },
+  {
+    "cppref": "cpp/utility/functional/function/uses_allocator",
+    "cppdoc": "cpp/library/utility/functional/function/uses_allocator"
+  },
+  {
+    "cppref": "cpp/utility/functional/reference_wrapper/deduction_guides",
+    "cppdoc": "cpp/library/utility/functional/reference_wrapper/deduction_guides"
+  },
+  {
+    "cppref": "cpp/utility/functional/reference_wrapper/operator()",
+    "cppdoc": "cpp/library/utility/functional/reference_wrapper/operator()"
+  },
+  {
+    "cppref": "cpp/utility/functional/reference_wrapper/get",
+    "cppdoc": "cpp/library/utility/functional/reference_wrapper/get"
+  },
+  {
+    "cppref": "cpp/utility/functional/reference_wrapper/reference_wrapper",
+    "cppdoc": "cpp/library/utility/functional/reference_wrapper/reference_wrapper"
+  },
+  {
+    "cppref": "cpp/utility/functional/reference_wrapper/operator_cmp",
+    "cppdoc": "cpp/library/utility/functional/reference_wrapper/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/functional/reference_wrapper/operator=",
+    "cppdoc": "cpp/library/utility/functional/reference_wrapper/operator="
+  },
+  {
+    "cppref": "cpp/utility/functional/reference_wrapper/basic_common_reference",
+    "cppdoc": "cpp/library/utility/functional/reference_wrapper/basic_common_reference"
+  },
+  {
+    "cppref": "cpp/utility/format/enable_nonlocking_formatter_optimization",
+    "cppdoc": "cpp/library/text/format/enable_nonlocking_formatter_optimization"
+  },
+  {
+    "cppref": "cpp/utility/format/spec",
+    "cppdoc": "cpp/library/text/format/spec"
+  },
+  {
+    "cppref": "cpp/utility/format/basic_format_string",
+    "cppdoc": "cpp/library/text/format/basic_format_string"
+  },
+  {
+    "cppref": "cpp/utility/format/vformat_to",
+    "cppdoc": "cpp/library/text/format/vformat_to"
+  },
+  {
+    "cppref": "cpp/utility/format/formatted_size",
+    "cppdoc": "cpp/library/text/format/formatted_size"
+  },
+  {
+    "cppref": "cpp/utility/format/basic_format_args",
+    "cppdoc": "cpp/library/text/format/basic_format_args"
+  },
+  {
+    "cppref": "cpp/utility/format/visit_format_arg",
+    "cppdoc": "cpp/library/text/format/visit_format_arg"
+  },
+  {
+    "cppref": "cpp/utility/format/format_kind",
+    "cppdoc": "cpp/library/text/format/format_kind"
+  },
+  {
+    "cppref": "cpp/utility/format/format_error",
+    "cppdoc": "cpp/library/text/format/format_error"
+  },
+  {
+    "cppref": "cpp/utility/format/formattable",
+    "cppdoc": "cpp/library/text/format/formattable"
+  },
+  {
+    "cppref": "cpp/utility/format/range_format",
+    "cppdoc": "cpp/library/text/format/range_format"
+  },
+  {
+    "cppref": "cpp/utility/format/basic_format_context",
+    "cppdoc": "cpp/library/text/format/basic_format_context"
+  },
+  {
+    "cppref": "cpp/utility/format/formatter",
+    "cppdoc": "cpp/library/text/format/formatter"
+  },
+  {
+    "cppref": "cpp/utility/format/format",
+    "cppdoc": "cpp/library/text/format/format"
+  },
+  {
+    "cppref": "cpp/utility/format/basic_format_arg",
+    "cppdoc": "cpp/library/text/format/basic_format_arg"
+  },
+  {
+    "cppref": "cpp/utility/format/format_to",
+    "cppdoc": "cpp/library/text/format/format_to"
+  },
+  {
+    "cppref": "cpp/utility/format/vformat",
+    "cppdoc": "cpp/library/text/format/vformat"
+  },
+  {
+    "cppref": "cpp/utility/format/tuple_formatter",
+    "cppdoc": "cpp/library/text/format/tuple_formatter"
+  },
+  {
+    "cppref": "cpp/utility/format/make_format_args",
+    "cppdoc": "cpp/library/text/format/make_format_args"
+  },
+  {
+    "cppref": "cpp/utility/format/basic_format_parse_context",
+    "cppdoc": "cpp/library/text/format/basic_format_parse_context"
+  },
+  {
+    "cppref": "cpp/utility/format/ranges_formatter",
+    "cppdoc": "cpp/library/text/format/ranges_formatter"
+  },
+  {
+    "cppref": "cpp/utility/format/format_to_n",
+    "cppdoc": "cpp/library/text/format/format_to_n"
+  },
+  {
+    "cppref": "cpp/utility/format/range_formatter",
+    "cppdoc": "cpp/library/text/format/range_formatter"
+  },
+  {
+    "cppref": "cpp/utility/format/runtime_format",
+    "cppdoc": "cpp/library/text/format/runtime_format"
+  },
+  {
+    "cppref": "cpp/utility/format/ranges_formatter/range_default_formatter_string",
+    "cppdoc": "cpp/library/text/format/ranges_formatter/range_default_formatter_string"
+  },
+  {
+    "cppref": "cpp/utility/format/ranges_formatter/range_default_formatter_map",
+    "cppdoc": "cpp/library/text/format/ranges_formatter/range_default_formatter_map"
+  },
+  {
+    "cppref": "cpp/utility/format/ranges_formatter/range_default_formatter_set",
+    "cppdoc": "cpp/library/text/format/ranges_formatter/range_default_formatter_set"
+  },
+  {
+    "cppref": "cpp/utility/format/ranges_formatter/range_default_formatter_sequence",
+    "cppdoc": "cpp/library/text/format/ranges_formatter/range_default_formatter_sequence"
+  },
+  {
+    "cppref": "cpp/utility/format/basic_format_arg/handle",
+    "cppdoc": "cpp/library/text/format/basic_format_arg/handle"
+  },
+  {
+    "cppref": "cpp/utility/optional/make_optional",
+    "cppdoc": "cpp/library/utility/optional/make_optional"
+  },
+  {
+    "cppref": "cpp/utility/optional/and_then",
+    "cppdoc": "cpp/library/utility/optional/and_then"
+  },
+  {
+    "cppref": "cpp/utility/optional/nullopt_t",
+    "cppdoc": "cpp/library/utility/optional/nullopt_t"
+  },
+  {
+    "cppref": "cpp/utility/optional/emplace",
+    "cppdoc": "cpp/library/utility/optional/emplace"
+  },
+  {
+    "cppref": "cpp/utility/optional/value_or",
+    "cppdoc": "cpp/library/utility/optional/value_or"
+  },
+  {
+    "cppref": "cpp/utility/optional/hash",
+    "cppdoc": "cpp/library/utility/optional/hash"
+  },
+  {
+    "cppref": "cpp/utility/optional/nullopt",
+    "cppdoc": "cpp/library/utility/optional/nullopt"
+  },
+  {
+    "cppref": "cpp/utility/optional/swap2",
+    "cppdoc": "cpp/library/utility/optional/swap2"
+  },
+  {
+    "cppref": "cpp/utility/optional/end",
+    "cppdoc": "cpp/library/utility/optional/end"
+  },
+  {
+    "cppref": "cpp/utility/optional/or_else",
+    "cppdoc": "cpp/library/utility/optional/or_else"
+  },
+  {
+    "cppref": "cpp/utility/optional/begin",
+    "cppdoc": "cpp/library/utility/optional/begin"
+  },
+  {
+    "cppref": "cpp/utility/optional/deduction_guides",
+    "cppdoc": "cpp/library/utility/optional/deduction_guides"
+  },
+  {
+    "cppref": "cpp/utility/optional/reset",
+    "cppdoc": "cpp/library/utility/optional/reset"
+  },
+  {
+    "cppref": "cpp/utility/optional/bad_optional_access",
+    "cppdoc": "cpp/library/utility/optional/bad_optional_access"
+  },
+  {
+    "cppref": "cpp/utility/optional/~optional",
+    "cppdoc": "cpp/library/utility/optional/~optional"
+  },
+  {
+    "cppref": "cpp/utility/optional/swap",
+    "cppdoc": "cpp/library/utility/optional/swap"
+  },
+  {
+    "cppref": "cpp/utility/optional/value",
+    "cppdoc": "cpp/library/utility/optional/value"
+  },
+  {
+    "cppref": "cpp/utility/optional/operator_star_",
+    "cppdoc": "cpp/library/utility/optional/operator_star_"
+  },
+  {
+    "cppref": "cpp/utility/optional/operator_cmp",
+    "cppdoc": "cpp/library/utility/optional/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/optional/operator_bool",
+    "cppdoc": "cpp/library/utility/optional/operator_bool"
+  },
+  {
+    "cppref": "cpp/utility/optional/operator=",
+    "cppdoc": "cpp/library/utility/optional/operator="
+  },
+  {
+    "cppref": "cpp/utility/optional/optional",
+    "cppdoc": "cpp/library/utility/optional/optional"
+  },
+  {
+    "cppref": "cpp/utility/optional/transform",
+    "cppdoc": "cpp/library/utility/optional/transform"
+  },
+  {
+    "cppref": "cpp/utility/initializer_list/end2",
+    "cppdoc": "cpp/library/utility/initializer_list/end2"
+  },
+  {
+    "cppref": "cpp/utility/initializer_list/initializer_list",
+    "cppdoc": "cpp/library/utility/initializer_list/initializer_list"
+  },
+  {
+    "cppref": "cpp/utility/initializer_list/size",
+    "cppdoc": "cpp/library/utility/initializer_list/size"
+  },
+  {
+    "cppref": "cpp/utility/initializer_list/end",
+    "cppdoc": "cpp/library/utility/initializer_list/end"
+  },
+  {
+    "cppref": "cpp/utility/initializer_list/begin2",
+    "cppdoc": "cpp/library/utility/initializer_list/begin2"
+  },
+  {
+    "cppref": "cpp/utility/initializer_list/begin",
+    "cppdoc": "cpp/library/utility/initializer_list/begin"
+  },
+  {
+    "cppref": "cpp/utility/program/at_quick_exit",
+    "cppdoc": "cpp/library/utility/program/at_quick_exit"
+  },
+  {
+    "cppref": "cpp/utility/program/raise",
+    "cppdoc": "cpp/library/utility/program/raise"
+  },
+  {
+    "cppref": "cpp/utility/program/EXIT_status",
+    "cppdoc": "cpp/library/utility/program/EXIT_status"
+  },
+  {
+    "cppref": "cpp/utility/program/longjmp",
+    "cppdoc": "cpp/library/utility/program/longjmp"
+  },
+  {
+    "cppref": "cpp/utility/program/jmp_buf",
+    "cppdoc": "cpp/library/utility/program/jmp_buf"
+  },
+  {
+    "cppref": "cpp/utility/program/quick_exit",
+    "cppdoc": "cpp/library/utility/program/quick_exit"
+  },
+  {
+    "cppref": "cpp/utility/program/atexit",
+    "cppdoc": "cpp/library/utility/program/atexit"
+  },
+  {
+    "cppref": "cpp/utility/program/signal",
+    "cppdoc": "cpp/library/utility/program/signal"
+  },
+  {
+    "cppref": "cpp/utility/program/sig_atomic_t",
+    "cppdoc": "cpp/library/utility/program/sig_atomic_t"
+  },
+  {
+    "cppref": "cpp/utility/program/SIG_types",
+    "cppdoc": "cpp/library/utility/program/SIG_types"
+  },
+  {
+    "cppref": "cpp/utility/program/abort",
+    "cppdoc": "cpp/library/utility/program/abort"
+  },
+  {
+    "cppref": "cpp/utility/program/system",
+    "cppdoc": "cpp/library/utility/program/system"
+  },
+  {
+    "cppref": "cpp/utility/program/exit",
+    "cppdoc": "cpp/library/utility/program/exit"
+  },
+  {
+    "cppref": "cpp/utility/program/setjmp",
+    "cppdoc": "cpp/library/utility/program/setjmp"
+  },
+  {
+    "cppref": "cpp/utility/program/_Exit",
+    "cppdoc": "cpp/library/utility/program/_Exit"
+  },
+  {
+    "cppref": "cpp/utility/program/getenv",
+    "cppdoc": "cpp/library/utility/program/getenv"
+  },
+  {
+    "cppref": "cpp/utility/program/SIG_strategies",
+    "cppdoc": "cpp/library/utility/program/SIG_strategies"
+  },
+  {
+    "cppref": "cpp/utility/program/SIG_ERR",
+    "cppdoc": "cpp/library/utility/program/SIG_ERR"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/operator_at",
+    "cppdoc": "cpp/library/error/basic_stacktrace/operator_at"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/at",
+    "cppdoc": "cpp/library/error/basic_stacktrace/at"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/empty",
+    "cppdoc": "cpp/library/error/basic_stacktrace/empty"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/hash",
+    "cppdoc": "cpp/library/error/basic_stacktrace/hash"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/max_size",
+    "cppdoc": "cpp/library/error/basic_stacktrace/max_size"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/size",
+    "cppdoc": "cpp/library/error/basic_stacktrace/size"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/to_string",
+    "cppdoc": "cpp/library/error/basic_stacktrace/to_string"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/basic_stacktrace",
+    "cppdoc": "cpp/library/error/basic_stacktrace/basic_stacktrace"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/swap2",
+    "cppdoc": "cpp/library/error/basic_stacktrace/swap2"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/end",
+    "cppdoc": "cpp/library/error/basic_stacktrace/end"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/formatter",
+    "cppdoc": "cpp/library/error/basic_stacktrace/formatter"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/rend",
+    "cppdoc": "cpp/library/error/basic_stacktrace/rend"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/begin",
+    "cppdoc": "cpp/library/error/basic_stacktrace/begin"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/current",
+    "cppdoc": "cpp/library/error/basic_stacktrace/current"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/swap",
+    "cppdoc": "cpp/library/error/basic_stacktrace/swap"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/rbegin",
+    "cppdoc": "cpp/library/error/basic_stacktrace/rbegin"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/~basic_stacktrace",
+    "cppdoc": "cpp/library/error/basic_stacktrace/~basic_stacktrace"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/operator_cmp",
+    "cppdoc": "cpp/library/error/basic_stacktrace/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/get_allocator",
+    "cppdoc": "cpp/library/error/basic_stacktrace/get_allocator"
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/operator=",
+    "cppdoc": "cpp/library/error/basic_stacktrace/operator="
+  },
+  {
+    "cppref": "cpp/utility/basic_stacktrace/operator_ltlt",
+    "cppdoc": "cpp/library/error/basic_stacktrace/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/utility/variant/monostate",
+    "cppdoc": "cpp/library/utility/variant/monostate"
+  },
+  {
+    "cppref": "cpp/utility/variant/index",
+    "cppdoc": "cpp/library/utility/variant/index"
+  },
+  {
+    "cppref": "cpp/utility/variant/emplace",
+    "cppdoc": "cpp/library/utility/variant/emplace"
+  },
+  {
+    "cppref": "cpp/utility/variant/hash",
+    "cppdoc": "cpp/library/utility/variant/hash"
+  },
+  {
+    "cppref": "cpp/utility/variant/valueless_by_exception",
+    "cppdoc": "cpp/library/utility/variant/valueless_by_exception"
+  },
+  {
+    "cppref": "cpp/utility/variant/swap2",
+    "cppdoc": "cpp/library/utility/variant/swap2"
+  },
+  {
+    "cppref": "cpp/utility/variant/variant_alternative",
+    "cppdoc": "cpp/library/utility/variant/variant_alternative"
+  },
+  {
+    "cppref": "cpp/utility/variant/variant",
+    "cppdoc": "cpp/library/utility/variant/variant"
+  },
+  {
+    "cppref": "cpp/utility/variant/swap",
+    "cppdoc": "cpp/library/utility/variant/swap"
+  },
+  {
+    "cppref": "cpp/utility/variant/visit2",
+    "cppdoc": "cpp/library/utility/variant/visit2"
+  },
+  {
+    "cppref": "cpp/utility/variant/get",
+    "cppdoc": "cpp/library/utility/variant/get"
+  },
+  {
+    "cppref": "cpp/utility/variant/operator_cmp",
+    "cppdoc": "cpp/library/utility/variant/operator_cmp"
+  },
+  {
+    "cppref": "cpp/utility/variant/visit",
+    "cppdoc": "cpp/library/utility/variant/visit"
+  },
+  {
+    "cppref": "cpp/utility/variant/variant_npos",
+    "cppdoc": "cpp/library/utility/variant/variant_npos"
+  },
+  {
+    "cppref": "cpp/utility/variant/get_if",
+    "cppdoc": "cpp/library/utility/variant/get_if"
+  },
+  {
+    "cppref": "cpp/utility/variant/holds_alternative",
+    "cppdoc": "cpp/library/utility/variant/holds_alternative"
+  },
+  {
+    "cppref": "cpp/utility/variant/variant_size",
+    "cppdoc": "cpp/library/utility/variant/variant_size"
+  },
+  {
+    "cppref": "cpp/utility/variant/bad_variant_access",
+    "cppdoc": "cpp/library/utility/variant/bad_variant_access"
+  },
+  {
+    "cppref": "cpp/utility/variant/operator=",
+    "cppdoc": "cpp/library/utility/variant/operator="
+  },
+  {
+    "cppref": "cpp/utility/variant/~variant",
+    "cppdoc": "cpp/library/utility/variant/~variant"
+  },
+  {
+    "cppref": "cpp/thread/promise",
+    "cppdoc": "cpp/library/atomic/promise"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock",
+    "cppdoc": "cpp/library/atomic/shared_lock"
+  },
+  {
+    "cppref": "cpp/thread/scoped_lock",
+    "cppdoc": "cpp/library/atomic/scoped_lock"
+  },
+  {
+    "cppref": "cpp/thread/latch",
+    "cppdoc": "cpp/library/atomic/latch"
+  },
+  {
+    "cppref": "cpp/thread/future",
+    "cppdoc": "cpp/library/atomic/future"
+  },
+  {
+    "cppref": "cpp/thread/mutex",
+    "cppdoc": "cpp/library/atomic/mutex"
+  },
+  {
+    "cppref": "cpp/thread/jthread",
+    "cppdoc": "cpp/library/atomic/jthread"
+  },
+  {
+    "cppref": "cpp/thread/thread",
+    "cppdoc": "cpp/library/atomic/thread"
+  },
+  {
+    "cppref": "cpp/thread/async",
+    "cppdoc": "cpp/library/atomic/async"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task",
+    "cppdoc": "cpp/library/atomic/packaged_task"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable",
+    "cppdoc": "cpp/library/atomic/condition_variable"
+  },
+  {
+    "cppref": "cpp/thread/future_category",
+    "cppdoc": "cpp/library/atomic/future_category"
+  },
+  {
+    "cppref": "cpp/thread/lock_tag_t",
+    "cppdoc": "cpp/library/atomic/lock_tag_t"
+  },
+  {
+    "cppref": "cpp/thread/get_id",
+    "cppdoc": "cpp/library/atomic/get_id"
+  },
+  {
+    "cppref": "cpp/thread/barrier",
+    "cppdoc": "cpp/library/atomic/barrier"
+  },
+  {
+    "cppref": "cpp/thread/stop_callback_for_t",
+    "cppdoc": "cpp/library/atomic/stop_callback_for_t"
+  },
+  {
+    "cppref": "cpp/thread/timed_mutex",
+    "cppdoc": "cpp/library/atomic/timed_mutex"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex"
+  },
+  {
+    "cppref": "cpp/thread/shared_future",
+    "cppdoc": "cpp/library/atomic/shared_future"
+  },
+  {
+    "cppref": "cpp/thread/future_status",
+    "cppdoc": "cpp/library/atomic/future_status"
+  },
+  {
+    "cppref": "cpp/thread/future_error",
+    "cppdoc": "cpp/library/atomic/future_error"
+  },
+  {
+    "cppref": "cpp/thread/hardware_destructive_interference_size",
+    "cppdoc": "cpp/library/atomic/hardware_destructive_interference_size"
+  },
+  {
+    "cppref": "cpp/thread/future_errc",
+    "cppdoc": "cpp/library/atomic/future_errc"
+  },
+  {
+    "cppref": "cpp/thread/sleep_for",
+    "cppdoc": "cpp/library/atomic/sleep_for"
+  },
+  {
+    "cppref": "cpp/thread/call_once",
+    "cppdoc": "cpp/library/atomic/call_once"
+  },
+  {
+    "cppref": "cpp/thread/cv_status",
+    "cppdoc": "cpp/library/atomic/cv_status"
+  },
+  {
+    "cppref": "cpp/thread/lock_tag",
+    "cppdoc": "cpp/library/atomic/lock_tag"
+  },
+  {
+    "cppref": "cpp/thread/recursive_timed_mutex",
+    "cppdoc": "cpp/library/atomic/recursive_timed_mutex"
+  },
+  {
+    "cppref": "cpp/thread/recursive_mutex",
+    "cppdoc": "cpp/library/atomic/recursive_mutex"
+  },
+  {
+    "cppref": "cpp/thread/lock",
+    "cppdoc": "cpp/library/atomic/lock"
+  },
+  {
+    "cppref": "cpp/thread/stop_callback",
+    "cppdoc": "cpp/library/atomic/stop_callback"
+  },
+  {
+    "cppref": "cpp/thread/stop_token",
+    "cppdoc": "cpp/library/atomic/stop_token"
+  },
+  {
+    "cppref": "cpp/thread/notify_all_at_thread_exit",
+    "cppdoc": "cpp/library/atomic/notify_all_at_thread_exit"
+  },
+  {
+    "cppref": "cpp/thread/lock_guard",
+    "cppdoc": "cpp/library/atomic/lock_guard"
+  },
+  {
+    "cppref": "cpp/thread/counting_semaphore",
+    "cppdoc": "cpp/library/atomic/counting_semaphore"
+  },
+  {
+    "cppref": "cpp/thread/unstoppable_token",
+    "cppdoc": "cpp/library/atomic/unstoppable_token"
+  },
+  {
+    "cppref": "cpp/thread/yield",
+    "cppdoc": "cpp/library/atomic/yield"
+  },
+  {
+    "cppref": "cpp/thread/try_lock",
+    "cppdoc": "cpp/library/atomic/try_lock"
+  },
+  {
+    "cppref": "cpp/thread/once_flag",
+    "cppdoc": "cpp/library/atomic/once_flag"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock",
+    "cppdoc": "cpp/library/atomic/unique_lock"
+  },
+  {
+    "cppref": "cpp/thread/stop_source",
+    "cppdoc": "cpp/library/atomic/stop_source"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable_any",
+    "cppdoc": "cpp/library/atomic/condition_variable_any"
+  },
+  {
+    "cppref": "cpp/thread/shared_mutex",
+    "cppdoc": "cpp/library/atomic/shared_mutex"
+  },
+  {
+    "cppref": "cpp/thread/sleep_until",
+    "cppdoc": "cpp/library/atomic/sleep_until"
+  },
+  {
+    "cppref": "cpp/thread/stoppable_token",
+    "cppdoc": "cpp/library/atomic/stoppable_token"
+  },
+  {
+    "cppref": "cpp/thread/launch",
+    "cppdoc": "cpp/library/atomic/launch"
+  },
+  {
+    "cppref": "cpp/thread/never_stop_token",
+    "cppdoc": "cpp/library/atomic/never_stop_token"
+  },
+  {
+    "cppref": "cpp/thread/mutex/~mutex",
+    "cppdoc": "cpp/library/atomic/mutex/~mutex"
+  },
+  {
+    "cppref": "cpp/thread/mutex/mutex",
+    "cppdoc": "cpp/library/atomic/mutex/mutex"
+  },
+  {
+    "cppref": "cpp/thread/mutex/lock",
+    "cppdoc": "cpp/library/atomic/mutex/lock"
+  },
+  {
+    "cppref": "cpp/thread/mutex/try_lock",
+    "cppdoc": "cpp/library/atomic/mutex/try_lock"
+  },
+  {
+    "cppref": "cpp/thread/mutex/native_handle",
+    "cppdoc": "cpp/library/atomic/mutex/native_handle"
+  },
+  {
+    "cppref": "cpp/thread/mutex/unlock",
+    "cppdoc": "cpp/library/atomic/mutex/unlock"
+  },
+  {
+    "cppref": "cpp/thread/barrier/barrier",
+    "cppdoc": "cpp/library/atomic/barrier/barrier"
+  },
+  {
+    "cppref": "cpp/thread/barrier/arrive",
+    "cppdoc": "cpp/library/atomic/barrier/arrive"
+  },
+  {
+    "cppref": "cpp/thread/barrier/max",
+    "cppdoc": "cpp/library/atomic/barrier/max"
+  },
+  {
+    "cppref": "cpp/thread/barrier/arrive_and_wait",
+    "cppdoc": "cpp/library/atomic/barrier/arrive_and_wait"
+  },
+  {
+    "cppref": "cpp/thread/barrier/wait",
+    "cppdoc": "cpp/library/atomic/barrier/wait"
+  },
+  {
+    "cppref": "cpp/thread/barrier/~barrier",
+    "cppdoc": "cpp/library/atomic/barrier/~barrier"
+  },
+  {
+    "cppref": "cpp/thread/barrier/arrive_and_drop",
+    "cppdoc": "cpp/library/atomic/barrier/arrive_and_drop"
+  },
+  {
+    "cppref": "cpp/thread/shared_future/wait_for",
+    "cppdoc": "cpp/library/atomic/shared_future/wait_for"
+  },
+  {
+    "cppref": "cpp/thread/shared_future/shared_future",
+    "cppdoc": "cpp/library/atomic/shared_future/shared_future"
+  },
+  {
+    "cppref": "cpp/thread/shared_future/valid",
+    "cppdoc": "cpp/library/atomic/shared_future/valid"
+  },
+  {
+    "cppref": "cpp/thread/shared_future/wait",
+    "cppdoc": "cpp/library/atomic/shared_future/wait"
+  },
+  {
+    "cppref": "cpp/thread/shared_future/get",
+    "cppdoc": "cpp/library/atomic/shared_future/get"
+  },
+  {
+    "cppref": "cpp/thread/shared_future/~shared_future",
+    "cppdoc": "cpp/library/atomic/shared_future/~shared_future"
+  },
+  {
+    "cppref": "cpp/thread/shared_future/operator=",
+    "cppdoc": "cpp/library/atomic/shared_future/operator="
+  },
+  {
+    "cppref": "cpp/thread/shared_future/wait_until",
+    "cppdoc": "cpp/library/atomic/shared_future/wait_until"
+  },
+  {
+    "cppref": "cpp/thread/latch/~latch",
+    "cppdoc": "cpp/library/atomic/latch/~latch"
+  },
+  {
+    "cppref": "cpp/thread/latch/latch",
+    "cppdoc": "cpp/library/atomic/latch/latch"
+  },
+  {
+    "cppref": "cpp/thread/latch/max",
+    "cppdoc": "cpp/library/atomic/latch/max"
+  },
+  {
+    "cppref": "cpp/thread/latch/arrive_and_wait",
+    "cppdoc": "cpp/library/atomic/latch/arrive_and_wait"
+  },
+  {
+    "cppref": "cpp/thread/latch/wait",
+    "cppdoc": "cpp/library/atomic/latch/wait"
+  },
+  {
+    "cppref": "cpp/thread/latch/count_down",
+    "cppdoc": "cpp/library/atomic/latch/count_down"
+  },
+  {
+    "cppref": "cpp/thread/latch/try_wait",
+    "cppdoc": "cpp/library/atomic/latch/try_wait"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/shared_lock",
+    "cppdoc": "cpp/library/atomic/shared_lock/shared_lock"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/mutex",
+    "cppdoc": "cpp/library/atomic/shared_lock/mutex"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/swap2",
+    "cppdoc": "cpp/library/atomic/shared_lock/swap2"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/try_lock_for",
+    "cppdoc": "cpp/library/atomic/shared_lock/try_lock_for"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/owns_lock",
+    "cppdoc": "cpp/library/atomic/shared_lock/owns_lock"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/swap",
+    "cppdoc": "cpp/library/atomic/shared_lock/swap"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/~shared_lock",
+    "cppdoc": "cpp/library/atomic/shared_lock/~shared_lock"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/lock",
+    "cppdoc": "cpp/library/atomic/shared_lock/lock"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/release",
+    "cppdoc": "cpp/library/atomic/shared_lock/release"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/try_lock_until",
+    "cppdoc": "cpp/library/atomic/shared_lock/try_lock_until"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/try_lock",
+    "cppdoc": "cpp/library/atomic/shared_lock/try_lock"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/operator_bool",
+    "cppdoc": "cpp/library/atomic/shared_lock/operator_bool"
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/operator=",
+    "cppdoc": "cpp/library/atomic/shared_lock/operator="
+  },
+  {
+    "cppref": "cpp/thread/shared_lock/unlock",
+    "cppdoc": "cpp/library/atomic/shared_lock/unlock"
+  },
+  {
+    "cppref": "cpp/thread/promise/promise",
+    "cppdoc": "cpp/library/atomic/promise/promise"
+  },
+  {
+    "cppref": "cpp/thread/promise/swap2",
+    "cppdoc": "cpp/library/atomic/promise/swap2"
+  },
+  {
+    "cppref": "cpp/thread/promise/get_future",
+    "cppdoc": "cpp/library/atomic/promise/get_future"
+  },
+  {
+    "cppref": "cpp/thread/promise/set_exception_at_thread_exit",
+    "cppdoc": "cpp/library/atomic/promise/set_exception_at_thread_exit"
+  },
+  {
+    "cppref": "cpp/thread/promise/~promise",
+    "cppdoc": "cpp/library/atomic/promise/~promise"
+  },
+  {
+    "cppref": "cpp/thread/promise/swap",
+    "cppdoc": "cpp/library/atomic/promise/swap"
+  },
+  {
+    "cppref": "cpp/thread/promise/set_value_at_thread_exit",
+    "cppdoc": "cpp/library/atomic/promise/set_value_at_thread_exit"
+  },
+  {
+    "cppref": "cpp/thread/promise/operator=",
+    "cppdoc": "cpp/library/atomic/promise/operator="
+  },
+  {
+    "cppref": "cpp/thread/promise/set_exception",
+    "cppdoc": "cpp/library/atomic/promise/set_exception"
+  },
+  {
+    "cppref": "cpp/thread/promise/set_value",
+    "cppdoc": "cpp/library/atomic/promise/set_value"
+  },
+  {
+    "cppref": "cpp/thread/promise/uses_allocator",
+    "cppdoc": "cpp/library/atomic/promise/uses_allocator"
+  },
+  {
+    "cppref": "cpp/thread/recursive_timed_mutex/~recursive_timed_mutex",
+    "cppdoc": "cpp/library/atomic/recursive_timed_mutex/~recursive_timed_mutex"
+  },
+  {
+    "cppref": "cpp/thread/recursive_timed_mutex/try_lock_for",
+    "cppdoc": "cpp/library/atomic/recursive_timed_mutex/try_lock_for"
+  },
+  {
+    "cppref": "cpp/thread/recursive_timed_mutex/recursive_timed_mutex",
+    "cppdoc": "cpp/library/atomic/recursive_timed_mutex/recursive_timed_mutex"
+  },
+  {
+    "cppref": "cpp/thread/recursive_timed_mutex/lock",
+    "cppdoc": "cpp/library/atomic/recursive_timed_mutex/lock"
+  },
+  {
+    "cppref": "cpp/thread/recursive_timed_mutex/try_lock_until",
+    "cppdoc": "cpp/library/atomic/recursive_timed_mutex/try_lock_until"
+  },
+  {
+    "cppref": "cpp/thread/recursive_timed_mutex/try_lock",
+    "cppdoc": "cpp/library/atomic/recursive_timed_mutex/try_lock"
+  },
+  {
+    "cppref": "cpp/thread/recursive_timed_mutex/native_handle",
+    "cppdoc": "cpp/library/atomic/recursive_timed_mutex/native_handle"
+  },
+  {
+    "cppref": "cpp/thread/recursive_timed_mutex/unlock",
+    "cppdoc": "cpp/library/atomic/recursive_timed_mutex/unlock"
+  },
+  {
+    "cppref": "cpp/thread/timed_mutex/try_lock_for",
+    "cppdoc": "cpp/library/atomic/timed_mutex/try_lock_for"
+  },
+  {
+    "cppref": "cpp/thread/timed_mutex/timed_mutex",
+    "cppdoc": "cpp/library/atomic/timed_mutex/timed_mutex"
+  },
+  {
+    "cppref": "cpp/thread/timed_mutex/lock",
+    "cppdoc": "cpp/library/atomic/timed_mutex/lock"
+  },
+  {
+    "cppref": "cpp/thread/timed_mutex/try_lock_until",
+    "cppdoc": "cpp/library/atomic/timed_mutex/try_lock_until"
+  },
+  {
+    "cppref": "cpp/thread/timed_mutex/try_lock",
+    "cppdoc": "cpp/library/atomic/timed_mutex/try_lock"
+  },
+  {
+    "cppref": "cpp/thread/timed_mutex/native_handle",
+    "cppdoc": "cpp/library/atomic/timed_mutex/native_handle"
+  },
+  {
+    "cppref": "cpp/thread/timed_mutex/~timed_mutex",
+    "cppdoc": "cpp/library/atomic/timed_mutex/~timed_mutex"
+  },
+  {
+    "cppref": "cpp/thread/timed_mutex/unlock",
+    "cppdoc": "cpp/library/atomic/timed_mutex/unlock"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/packaged_task",
+    "cppdoc": "cpp/library/atomic/packaged_task/packaged_task"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/swap2",
+    "cppdoc": "cpp/library/atomic/packaged_task/swap2"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/make_ready_at_thread_exit",
+    "cppdoc": "cpp/library/atomic/packaged_task/make_ready_at_thread_exit"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/get_future",
+    "cppdoc": "cpp/library/atomic/packaged_task/get_future"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/deduction_guides",
+    "cppdoc": "cpp/library/atomic/packaged_task/deduction_guides"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/reset",
+    "cppdoc": "cpp/library/atomic/packaged_task/reset"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/swap",
+    "cppdoc": "cpp/library/atomic/packaged_task/swap"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/valid",
+    "cppdoc": "cpp/library/atomic/packaged_task/valid"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/operator()",
+    "cppdoc": "cpp/library/atomic/packaged_task/operator()"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/~packaged_task",
+    "cppdoc": "cpp/library/atomic/packaged_task/~packaged_task"
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/operator=",
+    "cppdoc": "cpp/library/atomic/packaged_task/operator="
+  },
+  {
+    "cppref": "cpp/thread/packaged_task/uses_allocator",
+    "cppdoc": "cpp/library/atomic/packaged_task/uses_allocator"
+  },
+  {
+    "cppref": "cpp/thread/future/future",
+    "cppdoc": "cpp/library/atomic/future/future"
+  },
+  {
+    "cppref": "cpp/thread/future/~future",
+    "cppdoc": "cpp/library/atomic/future/~future"
+  },
+  {
+    "cppref": "cpp/thread/future/share",
+    "cppdoc": "cpp/library/atomic/future/share"
+  },
+  {
+    "cppref": "cpp/thread/future/wait_for",
+    "cppdoc": "cpp/library/atomic/future/wait_for"
+  },
+  {
+    "cppref": "cpp/thread/future/valid",
+    "cppdoc": "cpp/library/atomic/future/valid"
+  },
+  {
+    "cppref": "cpp/thread/future/wait",
+    "cppdoc": "cpp/library/atomic/future/wait"
+  },
+  {
+    "cppref": "cpp/thread/future/get",
+    "cppdoc": "cpp/library/atomic/future/get"
+  },
+  {
+    "cppref": "cpp/thread/future/operator=",
+    "cppdoc": "cpp/library/atomic/future/operator="
+  },
+  {
+    "cppref": "cpp/thread/future/wait_until",
+    "cppdoc": "cpp/library/atomic/future/wait_until"
+  },
+  {
+    "cppref": "cpp/thread/scoped_lock/scoped_lock",
+    "cppdoc": "cpp/library/atomic/scoped_lock/scoped_lock"
+  },
+  {
+    "cppref": "cpp/thread/scoped_lock/~scoped_lock",
+    "cppdoc": "cpp/library/atomic/scoped_lock/~scoped_lock"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable/notify_all",
+    "cppdoc": "cpp/library/atomic/condition_variable/notify_all"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable/condition_variable",
+    "cppdoc": "cpp/library/atomic/condition_variable/condition_variable"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable/wait_for",
+    "cppdoc": "cpp/library/atomic/condition_variable/wait_for"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable/~condition_variable",
+    "cppdoc": "cpp/library/atomic/condition_variable/~condition_variable"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable/notify_one",
+    "cppdoc": "cpp/library/atomic/condition_variable/notify_one"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable/wait",
+    "cppdoc": "cpp/library/atomic/condition_variable/wait"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable/wait_until",
+    "cppdoc": "cpp/library/atomic/condition_variable/wait_until"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable/native_handle",
+    "cppdoc": "cpp/library/atomic/condition_variable/native_handle"
+  },
+  {
+    "cppref": "cpp/thread/lock_guard/~lock_guard",
+    "cppdoc": "cpp/library/atomic/lock_guard/~lock_guard"
+  },
+  {
+    "cppref": "cpp/thread/lock_guard/lock_guard",
+    "cppdoc": "cpp/library/atomic/lock_guard/lock_guard"
+  },
+  {
+    "cppref": "cpp/thread/stop_callback/deduction_guides",
+    "cppdoc": "cpp/library/atomic/stop_callback/deduction_guides"
+  },
+  {
+    "cppref": "cpp/thread/stop_callback/stop_callback",
+    "cppdoc": "cpp/library/atomic/stop_callback/stop_callback"
+  },
+  {
+    "cppref": "cpp/thread/stop_callback/~stop_callback",
+    "cppdoc": "cpp/library/atomic/stop_callback/~stop_callback"
+  },
+  {
+    "cppref": "cpp/thread/stop_token/swap2",
+    "cppdoc": "cpp/library/atomic/stop_token/swap2"
+  },
+  {
+    "cppref": "cpp/thread/stop_token/stop_requested",
+    "cppdoc": "cpp/library/atomic/stop_token/stop_requested"
+  },
+  {
+    "cppref": "cpp/thread/stop_token/swap",
+    "cppdoc": "cpp/library/atomic/stop_token/swap"
+  },
+  {
+    "cppref": "cpp/thread/stop_token/stop_possible",
+    "cppdoc": "cpp/library/atomic/stop_token/stop_possible"
+  },
+  {
+    "cppref": "cpp/thread/stop_token/stop_token",
+    "cppdoc": "cpp/library/atomic/stop_token/stop_token"
+  },
+  {
+    "cppref": "cpp/thread/stop_token/operator_cmp",
+    "cppdoc": "cpp/library/atomic/stop_token/operator_cmp"
+  },
+  {
+    "cppref": "cpp/thread/stop_token/~stop_token",
+    "cppdoc": "cpp/library/atomic/stop_token/~stop_token"
+  },
+  {
+    "cppref": "cpp/thread/stop_token/operator=",
+    "cppdoc": "cpp/library/atomic/stop_token/operator="
+  },
+  {
+    "cppref": "cpp/thread/jthread/~jthread",
+    "cppdoc": "cpp/library/atomic/jthread/~jthread"
+  },
+  {
+    "cppref": "cpp/thread/jthread/request_stop",
+    "cppdoc": "cpp/library/atomic/jthread/request_stop"
+  },
+  {
+    "cppref": "cpp/thread/jthread/join",
+    "cppdoc": "cpp/library/atomic/jthread/join"
+  },
+  {
+    "cppref": "cpp/thread/jthread/get_stop_source",
+    "cppdoc": "cpp/library/atomic/jthread/get_stop_source"
+  },
+  {
+    "cppref": "cpp/thread/jthread/jthread",
+    "cppdoc": "cpp/library/atomic/jthread/jthread"
+  },
+  {
+    "cppref": "cpp/thread/jthread/get_id",
+    "cppdoc": "cpp/library/atomic/jthread/get_id"
+  },
+  {
+    "cppref": "cpp/thread/jthread/swap2",
+    "cppdoc": "cpp/library/atomic/jthread/swap2"
+  },
+  {
+    "cppref": "cpp/thread/jthread/get_stop_token",
+    "cppdoc": "cpp/library/atomic/jthread/get_stop_token"
+  },
+  {
+    "cppref": "cpp/thread/jthread/swap",
+    "cppdoc": "cpp/library/atomic/jthread/swap"
+  },
+  {
+    "cppref": "cpp/thread/jthread/joinable",
+    "cppdoc": "cpp/library/atomic/jthread/joinable"
+  },
+  {
+    "cppref": "cpp/thread/jthread/detach",
+    "cppdoc": "cpp/library/atomic/jthread/detach"
+  },
+  {
+    "cppref": "cpp/thread/jthread/operator=",
+    "cppdoc": "cpp/library/atomic/jthread/operator="
+  },
+  {
+    "cppref": "cpp/thread/jthread/hardware_concurrency",
+    "cppdoc": "cpp/library/atomic/jthread/hardware_concurrency"
+  },
+  {
+    "cppref": "cpp/thread/jthread/native_handle",
+    "cppdoc": "cpp/library/atomic/jthread/native_handle"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/mutex",
+    "cppdoc": "cpp/library/atomic/unique_lock/mutex"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/swap2",
+    "cppdoc": "cpp/library/atomic/unique_lock/swap2"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/try_lock_for",
+    "cppdoc": "cpp/library/atomic/unique_lock/try_lock_for"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/owns_lock",
+    "cppdoc": "cpp/library/atomic/unique_lock/owns_lock"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/swap",
+    "cppdoc": "cpp/library/atomic/unique_lock/swap"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/lock",
+    "cppdoc": "cpp/library/atomic/unique_lock/lock"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/release",
+    "cppdoc": "cpp/library/atomic/unique_lock/release"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/~unique_lock",
+    "cppdoc": "cpp/library/atomic/unique_lock/~unique_lock"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/try_lock_until",
+    "cppdoc": "cpp/library/atomic/unique_lock/try_lock_until"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/try_lock",
+    "cppdoc": "cpp/library/atomic/unique_lock/try_lock"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/operator_bool",
+    "cppdoc": "cpp/library/atomic/unique_lock/operator_bool"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/unique_lock",
+    "cppdoc": "cpp/library/atomic/unique_lock/unique_lock"
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/operator=",
+    "cppdoc": "cpp/library/atomic/unique_lock/operator="
+  },
+  {
+    "cppref": "cpp/thread/unique_lock/unlock",
+    "cppdoc": "cpp/library/atomic/unique_lock/unlock"
+  },
+  {
+    "cppref": "cpp/thread/counting_semaphore/~counting_semaphore",
+    "cppdoc": "cpp/library/atomic/counting_semaphore/~counting_semaphore"
+  },
+  {
+    "cppref": "cpp/thread/counting_semaphore/try_acquire",
+    "cppdoc": "cpp/library/atomic/counting_semaphore/try_acquire"
+  },
+  {
+    "cppref": "cpp/thread/counting_semaphore/max",
+    "cppdoc": "cpp/library/atomic/counting_semaphore/max"
+  },
+  {
+    "cppref": "cpp/thread/counting_semaphore/try_acquire_for",
+    "cppdoc": "cpp/library/atomic/counting_semaphore/try_acquire_for"
+  },
+  {
+    "cppref": "cpp/thread/counting_semaphore/release",
+    "cppdoc": "cpp/library/atomic/counting_semaphore/release"
+  },
+  {
+    "cppref": "cpp/thread/counting_semaphore/counting_semaphore",
+    "cppdoc": "cpp/library/atomic/counting_semaphore/counting_semaphore"
+  },
+  {
+    "cppref": "cpp/thread/counting_semaphore/acquire",
+    "cppdoc": "cpp/library/atomic/counting_semaphore/acquire"
+  },
+  {
+    "cppref": "cpp/thread/counting_semaphore/try_acquire_until",
+    "cppdoc": "cpp/library/atomic/counting_semaphore/try_acquire_until"
+  },
+  {
+    "cppref": "cpp/thread/thread/join",
+    "cppdoc": "cpp/library/atomic/thread/join"
+  },
+  {
+    "cppref": "cpp/thread/thread/~thread",
+    "cppdoc": "cpp/library/atomic/thread/~thread"
+  },
+  {
+    "cppref": "cpp/thread/thread/thread",
+    "cppdoc": "cpp/library/atomic/thread/thread"
+  },
+  {
+    "cppref": "cpp/thread/thread/get_id",
+    "cppdoc": "cpp/library/atomic/thread/get_id"
+  },
+  {
+    "cppref": "cpp/thread/thread/swap2",
+    "cppdoc": "cpp/library/atomic/thread/swap2"
+  },
+  {
+    "cppref": "cpp/thread/thread/swap",
+    "cppdoc": "cpp/library/atomic/thread/swap"
+  },
+  {
+    "cppref": "cpp/thread/thread/id",
+    "cppdoc": "cpp/library/atomic/thread/id"
+  },
+  {
+    "cppref": "cpp/thread/thread/joinable",
+    "cppdoc": "cpp/library/atomic/thread/joinable"
+  },
+  {
+    "cppref": "cpp/thread/thread/detach",
+    "cppdoc": "cpp/library/atomic/thread/detach"
+  },
+  {
+    "cppref": "cpp/thread/thread/operator=",
+    "cppdoc": "cpp/library/atomic/thread/operator="
+  },
+  {
+    "cppref": "cpp/thread/thread/hardware_concurrency",
+    "cppdoc": "cpp/library/atomic/thread/hardware_concurrency"
+  },
+  {
+    "cppref": "cpp/thread/thread/native_handle",
+    "cppdoc": "cpp/library/atomic/thread/native_handle"
+  },
+  {
+    "cppref": "cpp/thread/thread/id/hash",
+    "cppdoc": "cpp/library/atomic/thread/id/hash"
+  },
+  {
+    "cppref": "cpp/thread/thread/id/formatter",
+    "cppdoc": "cpp/library/atomic/thread/id/formatter"
+  },
+  {
+    "cppref": "cpp/thread/thread/id/id",
+    "cppdoc": "cpp/library/atomic/thread/id/id"
+  },
+  {
+    "cppref": "cpp/thread/thread/id/operator_cmp",
+    "cppdoc": "cpp/library/atomic/thread/id/operator_cmp"
+  },
+  {
+    "cppref": "cpp/thread/thread/id/operator_ltlt",
+    "cppdoc": "cpp/library/atomic/thread/id/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/thread/shared_mutex/unlock_shared",
+    "cppdoc": "cpp/library/atomic/shared_mutex/unlock_shared"
+  },
+  {
+    "cppref": "cpp/thread/shared_mutex/lock",
+    "cppdoc": "cpp/library/atomic/shared_mutex/lock"
+  },
+  {
+    "cppref": "cpp/thread/shared_mutex/~shared_mutex",
+    "cppdoc": "cpp/library/atomic/shared_mutex/~shared_mutex"
+  },
+  {
+    "cppref": "cpp/thread/shared_mutex/try_lock",
+    "cppdoc": "cpp/library/atomic/shared_mutex/try_lock"
+  },
+  {
+    "cppref": "cpp/thread/shared_mutex/shared_mutex",
+    "cppdoc": "cpp/library/atomic/shared_mutex/shared_mutex"
+  },
+  {
+    "cppref": "cpp/thread/shared_mutex/native_handle",
+    "cppdoc": "cpp/library/atomic/shared_mutex/native_handle"
+  },
+  {
+    "cppref": "cpp/thread/shared_mutex/lock_shared",
+    "cppdoc": "cpp/library/atomic/shared_mutex/lock_shared"
+  },
+  {
+    "cppref": "cpp/thread/shared_mutex/try_lock_shared",
+    "cppdoc": "cpp/library/atomic/shared_mutex/try_lock_shared"
+  },
+  {
+    "cppref": "cpp/thread/shared_mutex/unlock",
+    "cppdoc": "cpp/library/atomic/shared_mutex/unlock"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/request_stop",
+    "cppdoc": "cpp/library/atomic/stop_source/request_stop"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/swap2",
+    "cppdoc": "cpp/library/atomic/stop_source/swap2"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/stop_requested",
+    "cppdoc": "cpp/library/atomic/stop_source/stop_requested"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/nostopstate",
+    "cppdoc": "cpp/library/atomic/stop_source/nostopstate"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/swap",
+    "cppdoc": "cpp/library/atomic/stop_source/swap"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/get_token",
+    "cppdoc": "cpp/library/atomic/stop_source/get_token"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/stop_possible",
+    "cppdoc": "cpp/library/atomic/stop_source/stop_possible"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/nostopstate_t",
+    "cppdoc": "cpp/library/atomic/stop_source/nostopstate_t"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/operator_cmp",
+    "cppdoc": "cpp/library/atomic/stop_source/operator_cmp"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/~stop_source",
+    "cppdoc": "cpp/library/atomic/stop_source/~stop_source"
+  },
+  {
+    "cppref": "cpp/thread/stop_source/operator=",
+    "cppdoc": "cpp/library/atomic/stop_source/operator="
+  },
+  {
+    "cppref": "cpp/thread/stop_source/stop_source",
+    "cppdoc": "cpp/library/atomic/stop_source/stop_source"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/unlock_shared",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/unlock_shared"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/try_lock_for",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/try_lock_for"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/try_lock_shared_for",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/try_lock_shared_for"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/shared_timed_mutex",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/shared_timed_mutex"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/try_lock_shared_until",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/try_lock_shared_until"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/lock",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/lock"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/~shared_timed_mutex",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/~shared_timed_mutex"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/try_lock_until",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/try_lock_until"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/try_lock",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/try_lock"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/lock_shared",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/lock_shared"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/try_lock_shared",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/try_lock_shared"
+  },
+  {
+    "cppref": "cpp/thread/shared_timed_mutex/unlock",
+    "cppdoc": "cpp/library/atomic/shared_timed_mutex/unlock"
+  },
+  {
+    "cppref": "cpp/thread/recursive_mutex/recursive_mutex",
+    "cppdoc": "cpp/library/atomic/recursive_mutex/recursive_mutex"
+  },
+  {
+    "cppref": "cpp/thread/recursive_mutex/lock",
+    "cppdoc": "cpp/library/atomic/recursive_mutex/lock"
+  },
+  {
+    "cppref": "cpp/thread/recursive_mutex/~recursive_mutex",
+    "cppdoc": "cpp/library/atomic/recursive_mutex/~recursive_mutex"
+  },
+  {
+    "cppref": "cpp/thread/recursive_mutex/try_lock",
+    "cppdoc": "cpp/library/atomic/recursive_mutex/try_lock"
+  },
+  {
+    "cppref": "cpp/thread/recursive_mutex/native_handle",
+    "cppdoc": "cpp/library/atomic/recursive_mutex/native_handle"
+  },
+  {
+    "cppref": "cpp/thread/recursive_mutex/unlock",
+    "cppdoc": "cpp/library/atomic/recursive_mutex/unlock"
+  },
+  {
+    "cppref": "cpp/thread/future_error/future_error",
+    "cppdoc": "cpp/library/atomic/future_error/future_error"
+  },
+  {
+    "cppref": "cpp/thread/future_error/what",
+    "cppdoc": "cpp/library/atomic/future_error/what"
+  },
+  {
+    "cppref": "cpp/thread/future_error/code",
+    "cppdoc": "cpp/library/atomic/future_error/code"
+  },
+  {
+    "cppref": "cpp/thread/future_error/operator=",
+    "cppdoc": "cpp/library/atomic/future_error/operator="
+  },
+  {
+    "cppref": "cpp/thread/future_errc/make_error_code",
+    "cppdoc": "cpp/library/atomic/future_errc/make_error_code"
+  },
+  {
+    "cppref": "cpp/thread/future_errc/make_error_condition",
+    "cppdoc": "cpp/library/atomic/future_errc/make_error_condition"
+  },
+  {
+    "cppref": "cpp/thread/future_errc/is_error_code_enum",
+    "cppdoc": "cpp/library/atomic/future_errc/is_error_code_enum"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable_any/notify_all",
+    "cppdoc": "cpp/library/atomic/condition_variable_any/notify_all"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable_any/wait_for",
+    "cppdoc": "cpp/library/atomic/condition_variable_any/wait_for"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable_any/notify_one",
+    "cppdoc": "cpp/library/atomic/condition_variable_any/notify_one"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable_any/wait",
+    "cppdoc": "cpp/library/atomic/condition_variable_any/wait"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable_any/~condition_variable_any",
+    "cppdoc": "cpp/library/atomic/condition_variable_any/~condition_variable_any"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable_any/condition_variable_any",
+    "cppdoc": "cpp/library/atomic/condition_variable_any/condition_variable_any"
+  },
+  {
+    "cppref": "cpp/thread/condition_variable_any/wait_until",
+    "cppdoc": "cpp/library/atomic/condition_variable_any/wait_until"
+  },
+  {
+    "cppref": "cpp/symbol_index/rel_ops",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/this_thread",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/ranges",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/placeholders",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/literals",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/filesystem",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/linalg",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/views",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/complex_literals",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/macro",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/string_literals",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/chrono",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/zombie_names",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/execution",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/pmr",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/regex_constants",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/chrono_literals",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/expos",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/symbol_index/numbers",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/io/basic_ifstream",
+    "cppdoc": "cpp/library/io/basic_ifstream"
+  },
+  {
+    "cppref": "cpp/io/streamsize",
+    "cppdoc": "cpp/library/io/streamsize"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf",
+    "cppdoc": "cpp/library/io/strstreambuf"
+  },
+  {
+    "cppref": "cpp/io/basic_ofstream",
+    "cppdoc": "cpp/library/io/basic_ofstream"
+  },
+  {
+    "cppref": "cpp/io/basic_ostringstream",
+    "cppdoc": "cpp/library/io/basic_ostringstream"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf",
+    "cppdoc": "cpp/library/io/basic_filebuf"
+  },
+  {
+    "cppref": "cpp/io/basic_istream",
+    "cppdoc": "cpp/library/io/basic_istream"
+  },
+  {
+    "cppref": "cpp/io/istrstream",
+    "cppdoc": "cpp/library/io/istrstream"
+  },
+  {
+    "cppref": "cpp/io/ios_base",
+    "cppdoc": "cpp/library/io/ios_base"
+  },
+  {
+    "cppref": "cpp/io/basic_ispanstream",
+    "cppdoc": "cpp/library/io/basic_ispanstream"
+  },
+  {
+    "cppref": "cpp/io/basic_iostream",
+    "cppdoc": "cpp/library/io/basic_iostream"
+  },
+  {
+    "cppref": "cpp/io/io_errc",
+    "cppdoc": "cpp/library/io/io_errc"
+  },
+  {
+    "cppref": "cpp/io/basic_ios",
+    "cppdoc": "cpp/library/io/basic_ios"
+  },
+  {
+    "cppref": "cpp/io/iostream_category",
+    "cppdoc": "cpp/library/io/iostream_category"
+  },
+  {
+    "cppref": "cpp/io/basic_ospanstream",
+    "cppdoc": "cpp/library/io/basic_ospanstream"
+  },
+  {
+    "cppref": "cpp/io/println",
+    "cppdoc": "cpp/library/io/println"
+  },
+  {
+    "cppref": "cpp/io/ostrstream",
+    "cppdoc": "cpp/library/io/ostrstream"
+  },
+  {
+    "cppref": "cpp/io/manip",
+    "cppdoc": "cpp/library/io/manip"
+  },
+  {
+    "cppref": "cpp/io/vprint_nonunicode",
+    "cppdoc": "cpp/library/io/vprint_nonunicode"
+  },
+  {
+    "cppref": "cpp/io/basic_stringstream",
+    "cppdoc": "cpp/library/io/basic_stringstream"
+  },
+  {
+    "cppref": "cpp/io/basic_fstream",
+    "cppdoc": "cpp/library/io/basic_fstream"
+  },
+  {
+    "cppref": "cpp/io/cin",
+    "cppdoc": "cpp/library/io/basic_istream/cin"
+  },
+  {
+    "cppref": "cpp/io/basic_spanbuf",
+    "cppdoc": "cpp/library/io/basic_spanbuf"
+  },
+  {
+    "cppref": "cpp/io/c",
+    "cppdoc": "cpp/library/io/c"
+  },
+  {
+    "cppref": "cpp/io/strstream",
+    "cppdoc": "cpp/library/io/strstream"
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf",
+    "cppdoc": "cpp/library/io/basic_syncbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf",
+    "cppdoc": "cpp/library/io/basic_stringbuf"
+  },
+  {
+    "cppref": "cpp/io/print",
+    "cppdoc": "cpp/library/io/print"
+  },
+  {
+    "cppref": "cpp/io/streamoff",
+    "cppdoc": "cpp/library/io/streamoff"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream",
+    "cppdoc": "cpp/library/io/basic_ostream"
+  },
+  {
+    "cppref": "cpp/io/vprint_unicode",
+    "cppdoc": "cpp/library/io/vprint_unicode"
+  },
+  {
+    "cppref": "cpp/io/fpos",
+    "cppdoc": "cpp/library/io/fpos"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf",
+    "cppdoc": "cpp/library/io/basic_streambuf"
+  },
+  {
+    "cppref": "cpp/io/basic_istringstream",
+    "cppdoc": "cpp/library/io/basic_istringstream"
+  },
+  {
+    "cppref": "cpp/io/basic_osyncstream",
+    "cppdoc": "cpp/library/io/basic_osyncstream"
+  },
+  {
+    "cppref": "cpp/io/basic_spanstream",
+    "cppdoc": "cpp/library/io/basic_spanstream"
+  },
+  {
+    "cppref": "cpp/io/basic_stringstream/view",
+    "cppdoc": "cpp/library/io/basic_stringstream/view"
+  },
+  {
+    "cppref": "cpp/io/basic_stringstream/swap2",
+    "cppdoc": "cpp/library/io/basic_stringstream/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_stringstream/swap",
+    "cppdoc": "cpp/library/io/basic_stringstream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_stringstream/str",
+    "cppdoc": "cpp/library/io/basic_stringstream/str"
+  },
+  {
+    "cppref": "cpp/io/basic_stringstream/basic_stringstream",
+    "cppdoc": "cpp/library/io/basic_stringstream/basic_stringstream"
+  },
+  {
+    "cppref": "cpp/io/basic_stringstream/rdbuf",
+    "cppdoc": "cpp/library/io/basic_stringstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_stringstream/operator=",
+    "cppdoc": "cpp/library/io/basic_stringstream/operator="
+  },
+  {
+    "cppref": "cpp/io/ostrstream/ostrstream",
+    "cppdoc": "cpp/library/io/ostrstream/ostrstream"
+  },
+  {
+    "cppref": "cpp/io/ostrstream/pcount",
+    "cppdoc": "cpp/library/io/ostrstream/pcount"
+  },
+  {
+    "cppref": "cpp/io/ostrstream/str",
+    "cppdoc": "cpp/library/io/ostrstream/str"
+  },
+  {
+    "cppref": "cpp/io/ostrstream/freeze",
+    "cppdoc": "cpp/library/io/ostrstream/freeze"
+  },
+  {
+    "cppref": "cpp/io/ostrstream/~ostrstream",
+    "cppdoc": "cpp/library/io/ostrstream/~ostrstream"
+  },
+  {
+    "cppref": "cpp/io/ostrstream/rdbuf",
+    "cppdoc": "cpp/library/io/ostrstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/seekpos",
+    "cppdoc": "cpp/library/io/basic_stringbuf/seekpos"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/view",
+    "cppdoc": "cpp/library/io/basic_stringbuf/view"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/swap2",
+    "cppdoc": "cpp/library/io/basic_stringbuf/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/underflow",
+    "cppdoc": "cpp/library/io/basic_stringbuf/underflow"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/swap",
+    "cppdoc": "cpp/library/io/basic_stringbuf/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/init_buf_ptrs",
+    "cppdoc": "cpp/library/io/basic_stringbuf/init_buf_ptrs"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/str",
+    "cppdoc": "cpp/library/io/basic_stringbuf/str"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/pbackfail",
+    "cppdoc": "cpp/library/io/basic_stringbuf/pbackfail"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/overflow",
+    "cppdoc": "cpp/library/io/basic_stringbuf/overflow"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/setbuf",
+    "cppdoc": "cpp/library/io/basic_stringbuf/setbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/basic_stringbuf",
+    "cppdoc": "cpp/library/io/basic_stringbuf/basic_stringbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/get_allocator",
+    "cppdoc": "cpp/library/io/basic_stringbuf/get_allocator"
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/operator=",
+    "cppdoc": "cpp/library/io/basic_stringbuf/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_stringbuf/seekoff",
+    "cppdoc": "cpp/library/io/basic_stringbuf/seekoff"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/seekpos",
+    "cppdoc": "cpp/library/io/basic_filebuf/seekpos"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/basic_filebuf",
+    "cppdoc": "cpp/library/io/basic_filebuf/basic_filebuf"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/swap2",
+    "cppdoc": "cpp/library/io/basic_filebuf/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/underflow",
+    "cppdoc": "cpp/library/io/basic_filebuf/underflow"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/swap",
+    "cppdoc": "cpp/library/io/basic_filebuf/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/showmanyc",
+    "cppdoc": "cpp/library/io/basic_filebuf/showmanyc"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/pbackfail",
+    "cppdoc": "cpp/library/io/basic_filebuf/pbackfail"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/is_open",
+    "cppdoc": "cpp/library/io/basic_filebuf/is_open"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/overflow",
+    "cppdoc": "cpp/library/io/basic_filebuf/overflow"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/close",
+    "cppdoc": "cpp/library/io/basic_filebuf/close"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/setbuf",
+    "cppdoc": "cpp/library/io/basic_filebuf/setbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/operator=",
+    "cppdoc": "cpp/library/io/basic_filebuf/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/uflow",
+    "cppdoc": "cpp/library/io/basic_filebuf/uflow"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/open",
+    "cppdoc": "cpp/library/io/basic_filebuf/open"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/native_handle",
+    "cppdoc": "cpp/library/io/basic_filebuf/native_handle"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/~basic_filebuf",
+    "cppdoc": "cpp/library/io/basic_filebuf/~basic_filebuf"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/seekoff",
+    "cppdoc": "cpp/library/io/basic_filebuf/seekoff"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/imbue",
+    "cppdoc": "cpp/library/io/basic_filebuf/imbue"
+  },
+  {
+    "cppref": "cpp/io/basic_filebuf/sync",
+    "cppdoc": "cpp/library/io/basic_filebuf/sync"
+  },
+  {
+    "cppref": "cpp/io/io_errc/make_error_code",
+    "cppdoc": "cpp/library/io/io_errc/make_error_code"
+  },
+  {
+    "cppref": "cpp/io/io_errc/make_error_condition",
+    "cppdoc": "cpp/library/io/io_errc/make_error_condition"
+  },
+  {
+    "cppref": "cpp/io/io_errc/is_error_code_enum",
+    "cppdoc": "cpp/library/io/io_errc/is_error_code_enum"
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf/emit",
+    "cppdoc": "cpp/library/io/basic_syncbuf/emit"
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf/get_wrapped",
+    "cppdoc": "cpp/library/io/basic_syncbuf/get_wrapped"
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf/swap2",
+    "cppdoc": "cpp/library/io/basic_syncbuf/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf/swap",
+    "cppdoc": "cpp/library/io/basic_syncbuf/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf/~basic_syncbuf",
+    "cppdoc": "cpp/library/io/basic_syncbuf/~basic_syncbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf/basic_syncbuf",
+    "cppdoc": "cpp/library/io/basic_syncbuf/basic_syncbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf/get_allocator",
+    "cppdoc": "cpp/library/io/basic_syncbuf/get_allocator"
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf/set_emit_on_sync",
+    "cppdoc": "cpp/library/io/basic_syncbuf/set_emit_on_sync"
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf/operator=",
+    "cppdoc": "cpp/library/io/basic_syncbuf/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_syncbuf/sync",
+    "cppdoc": "cpp/library/io/basic_syncbuf/sync"
+  },
+  {
+    "cppref": "cpp/io/fpos/state",
+    "cppdoc": "cpp/library/io/fpos/state"
+  },
+  {
+    "cppref": "cpp/io/strstream/pcount",
+    "cppdoc": "cpp/library/io/strstream/pcount"
+  },
+  {
+    "cppref": "cpp/io/strstream/str",
+    "cppdoc": "cpp/library/io/strstream/str"
+  },
+  {
+    "cppref": "cpp/io/strstream/freeze",
+    "cppdoc": "cpp/library/io/strstream/freeze"
+  },
+  {
+    "cppref": "cpp/io/strstream/strstream",
+    "cppdoc": "cpp/library/io/strstream/strstream"
+  },
+  {
+    "cppref": "cpp/io/strstream/rdbuf",
+    "cppdoc": "cpp/library/io/strstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/strstream/~strstream",
+    "cppdoc": "cpp/library/io/strstream/~strstream"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/pptr",
+    "cppdoc": "cpp/library/io/basic_streambuf/pptr"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/pubseekoff",
+    "cppdoc": "cpp/library/io/basic_streambuf/pubseekoff"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/sgetn",
+    "cppdoc": "cpp/library/io/basic_streambuf/sgetn"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/pubseekpos",
+    "cppdoc": "cpp/library/io/basic_streambuf/pubseekpos"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/getloc",
+    "cppdoc": "cpp/library/io/basic_streambuf/getloc"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/sputbackc",
+    "cppdoc": "cpp/library/io/basic_streambuf/sputbackc"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/~basic_streambuf",
+    "cppdoc": "cpp/library/io/basic_streambuf/~basic_streambuf"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/gptr",
+    "cppdoc": "cpp/library/io/basic_streambuf/gptr"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/sungetc",
+    "cppdoc": "cpp/library/io/basic_streambuf/sungetc"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/setp",
+    "cppdoc": "cpp/library/io/basic_streambuf/setp"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/setg",
+    "cppdoc": "cpp/library/io/basic_streambuf/setg"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/underflow",
+    "cppdoc": "cpp/library/io/basic_streambuf/underflow"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/swap",
+    "cppdoc": "cpp/library/io/basic_streambuf/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/pubimbue",
+    "cppdoc": "cpp/library/io/basic_streambuf/pubimbue"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/showmanyc",
+    "cppdoc": "cpp/library/io/basic_streambuf/showmanyc"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/sputn",
+    "cppdoc": "cpp/library/io/basic_streambuf/sputn"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/pbump",
+    "cppdoc": "cpp/library/io/basic_streambuf/pbump"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/snextc",
+    "cppdoc": "cpp/library/io/basic_streambuf/snextc"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/sgetc",
+    "cppdoc": "cpp/library/io/basic_streambuf/sgetc"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/pbackfail",
+    "cppdoc": "cpp/library/io/basic_streambuf/pbackfail"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/sputc",
+    "cppdoc": "cpp/library/io/basic_streambuf/sputc"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/overflow",
+    "cppdoc": "cpp/library/io/basic_streambuf/overflow"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/in_avail",
+    "cppdoc": "cpp/library/io/basic_streambuf/in_avail"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/sbumpc",
+    "cppdoc": "cpp/library/io/basic_streambuf/sbumpc"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/gbump",
+    "cppdoc": "cpp/library/io/basic_streambuf/gbump"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/basic_streambuf",
+    "cppdoc": "cpp/library/io/basic_streambuf/basic_streambuf"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/pubsetbuf",
+    "cppdoc": "cpp/library/io/basic_streambuf/pubsetbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/operator=",
+    "cppdoc": "cpp/library/io/basic_streambuf/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/uflow",
+    "cppdoc": "cpp/library/io/basic_streambuf/uflow"
+  },
+  {
+    "cppref": "cpp/io/basic_streambuf/pubsync",
+    "cppdoc": "cpp/library/io/basic_streambuf/pubsync"
+  },
+  {
+    "cppref": "cpp/io/istrstream/istrstream",
+    "cppdoc": "cpp/library/io/istrstream/istrstream"
+  },
+  {
+    "cppref": "cpp/io/istrstream/~istrstream",
+    "cppdoc": "cpp/library/io/istrstream/~istrstream"
+  },
+  {
+    "cppref": "cpp/io/istrstream/str",
+    "cppdoc": "cpp/library/io/istrstream/str"
+  },
+  {
+    "cppref": "cpp/io/istrstream/rdbuf",
+    "cppdoc": "cpp/library/io/istrstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_ispanstream/span",
+    "cppdoc": "cpp/library/io/basic_ispanstream/span"
+  },
+  {
+    "cppref": "cpp/io/basic_ispanstream/basic_ispanstream",
+    "cppdoc": "cpp/library/io/basic_ispanstream/basic_ispanstream"
+  },
+  {
+    "cppref": "cpp/io/basic_ispanstream/swap2",
+    "cppdoc": "cpp/library/io/basic_ispanstream/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_ispanstream/swap",
+    "cppdoc": "cpp/library/io/basic_ispanstream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_ispanstream/rdbuf",
+    "cppdoc": "cpp/library/io/basic_ispanstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_ispanstream/operator=",
+    "cppdoc": "cpp/library/io/basic_ispanstream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_ofstream/basic_ofstream",
+    "cppdoc": "cpp/library/io/basic_ofstream/basic_ofstream"
+  },
+  {
+    "cppref": "cpp/io/basic_ofstream/swap2",
+    "cppdoc": "cpp/library/io/basic_ofstream/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_ofstream/swap",
+    "cppdoc": "cpp/library/io/basic_ofstream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_ofstream/is_open",
+    "cppdoc": "cpp/library/io/basic_ofstream/is_open"
+  },
+  {
+    "cppref": "cpp/io/basic_ofstream/close",
+    "cppdoc": "cpp/library/io/basic_ofstream/close"
+  },
+  {
+    "cppref": "cpp/io/basic_ofstream/rdbuf",
+    "cppdoc": "cpp/library/io/basic_ofstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_ofstream/operator=",
+    "cppdoc": "cpp/library/io/basic_ofstream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_ofstream/open",
+    "cppdoc": "cpp/library/io/basic_ofstream/open"
+  },
+  {
+    "cppref": "cpp/io/basic_ofstream/native_handle",
+    "cppdoc": "cpp/library/io/basic_ofstream/native_handle"
+  },
+  {
+    "cppref": "cpp/io/c/fputwc",
+    "cppdoc": "cpp/library/io/c/fputwc"
+  },
+  {
+    "cppref": "cpp/io/c/fread",
+    "cppdoc": "cpp/library/io/c/fread"
+  },
+  {
+    "cppref": "cpp/io/c/fflush",
+    "cppdoc": "cpp/library/io/c/fflush"
+  },
+  {
+    "cppref": "cpp/io/c/remove",
+    "cppdoc": "cpp/library/io/c/remove"
+  },
+  {
+    "cppref": "cpp/io/c/fsetpos",
+    "cppdoc": "cpp/library/io/c/fsetpos"
+  },
+  {
+    "cppref": "cpp/io/c/fscanf",
+    "cppdoc": "cpp/library/io/c/fscanf"
+  },
+  {
+    "cppref": "cpp/io/c/ungetc",
+    "cppdoc": "cpp/library/io/c/ungetc"
+  },
+  {
+    "cppref": "cpp/io/c/fopen",
+    "cppdoc": "cpp/library/io/c/fopen"
+  },
+  {
+    "cppref": "cpp/io/c/getwchar",
+    "cppdoc": "cpp/library/io/c/getwchar"
+  },
+  {
+    "cppref": "cpp/io/c/fwscanf",
+    "cppdoc": "cpp/library/io/c/fwscanf"
+  },
+  {
+    "cppref": "cpp/io/c/fputs",
+    "cppdoc": "cpp/library/io/c/fputs"
+  },
+  {
+    "cppref": "cpp/io/c/gets",
+    "cppdoc": "cpp/library/io/c/gets"
+  },
+  {
+    "cppref": "cpp/io/c/snprintf",
+    "cppdoc": "cpp/library/io/c/snprintf"
+  },
+  {
+    "cppref": "cpp/io/c/clearerr",
+    "cppdoc": "cpp/library/io/c/clearerr"
+  },
+  {
+    "cppref": "cpp/io/c/fwide",
+    "cppdoc": "cpp/library/io/c/fwide"
+  },
+  {
+    "cppref": "cpp/io/c/fputws",
+    "cppdoc": "cpp/library/io/c/fputws"
+  },
+  {
+    "cppref": "cpp/io/c/ferror",
+    "cppdoc": "cpp/library/io/c/ferror"
+  },
+  {
+    "cppref": "cpp/io/c/fgets",
+    "cppdoc": "cpp/library/io/c/fgets"
+  },
+  {
+    "cppref": "cpp/io/c/fgetpos",
+    "cppdoc": "cpp/library/io/c/fgetpos"
+  },
+  {
+    "cppref": "cpp/io/c/tmpnam",
+    "cppdoc": "cpp/library/io/c/tmpnam"
+  },
+  {
+    "cppref": "cpp/io/c/perror",
+    "cppdoc": "cpp/library/io/c/perror"
+  },
+  {
+    "cppref": "cpp/io/c/vfwscanf",
+    "cppdoc": "cpp/library/io/c/vfwscanf"
+  },
+  {
+    "cppref": "cpp/io/c/fclose",
+    "cppdoc": "cpp/library/io/c/fclose"
+  },
+  {
+    "cppref": "cpp/io/c/fprintf",
+    "cppdoc": "cpp/library/io/c/fprintf"
+  },
+  {
+    "cppref": "cpp/io/c/tmpfile",
+    "cppdoc": "cpp/library/io/c/tmpfile"
+  },
+  {
+    "cppref": "cpp/io/c/rename",
+    "cppdoc": "cpp/library/io/c/rename"
+  },
+  {
+    "cppref": "cpp/io/c/fgetc",
+    "cppdoc": "cpp/library/io/c/fgetc"
+  },
+  {
+    "cppref": "cpp/io/c/freopen",
+    "cppdoc": "cpp/library/io/c/freopen"
+  },
+  {
+    "cppref": "cpp/io/c/std_streams",
+    "cppdoc": "cpp/library/io/c/std_streams"
+  },
+  {
+    "cppref": "cpp/io/c/fgetws",
+    "cppdoc": "cpp/library/io/c/fgetws"
+  },
+  {
+    "cppref": "cpp/io/c/fseek",
+    "cppdoc": "cpp/library/io/c/fseek"
+  },
+  {
+    "cppref": "cpp/io/c/FILE",
+    "cppdoc": "cpp/library/io/c/FILE"
+  },
+  {
+    "cppref": "cpp/io/c/getchar",
+    "cppdoc": "cpp/library/io/c/getchar"
+  },
+  {
+    "cppref": "cpp/io/c/fgetwc",
+    "cppdoc": "cpp/library/io/c/fgetwc"
+  },
+  {
+    "cppref": "cpp/io/c/ftell",
+    "cppdoc": "cpp/library/io/c/ftell"
+  },
+  {
+    "cppref": "cpp/io/c/vfwprintf",
+    "cppdoc": "cpp/library/io/c/vfwprintf"
+  },
+  {
+    "cppref": "cpp/io/c/putwchar",
+    "cppdoc": "cpp/library/io/c/putwchar"
+  },
+  {
+    "cppref": "cpp/io/c/fputc",
+    "cppdoc": "cpp/library/io/c/fputc"
+  },
+  {
+    "cppref": "cpp/io/c/setbuf",
+    "cppdoc": "cpp/library/io/c/setbuf"
+  },
+  {
+    "cppref": "cpp/io/c/puts",
+    "cppdoc": "cpp/library/io/c/puts"
+  },
+  {
+    "cppref": "cpp/io/c/printf",
+    "cppdoc": "cpp/library/io/c/printf"
+  },
+  {
+    "cppref": "cpp/io/c/fwprintf",
+    "cppdoc": "cpp/library/io/c/fwprintf"
+  },
+  {
+    "cppref": "cpp/io/c/rewind",
+    "cppdoc": "cpp/library/io/c/rewind"
+  },
+  {
+    "cppref": "cpp/io/c/vfprintf",
+    "cppdoc": "cpp/library/io/c/vfprintf"
+  },
+  {
+    "cppref": "cpp/io/c/fpos_t",
+    "cppdoc": "cpp/library/io/c/fpos_t"
+  },
+  {
+    "cppref": "cpp/io/c/putchar",
+    "cppdoc": "cpp/library/io/c/putchar"
+  },
+  {
+    "cppref": "cpp/io/c/ungetwc",
+    "cppdoc": "cpp/library/io/c/ungetwc"
+  },
+  {
+    "cppref": "cpp/io/c/feof",
+    "cppdoc": "cpp/library/io/c/feof"
+  },
+  {
+    "cppref": "cpp/io/c/fwrite",
+    "cppdoc": "cpp/library/io/c/fwrite"
+  },
+  {
+    "cppref": "cpp/io/c/setvbuf",
+    "cppdoc": "cpp/library/io/c/setvbuf"
+  },
+  {
+    "cppref": "cpp/io/c/scanf",
+    "cppdoc": "cpp/library/io/c/scanf"
+  },
+  {
+    "cppref": "cpp/io/c/vfscanf",
+    "cppdoc": "cpp/library/io/c/vfscanf"
+  },
+  {
+    "cppref": "cpp/io/basic_spanbuf/seekpos",
+    "cppdoc": "cpp/library/io/basic_spanbuf/seekpos"
+  },
+  {
+    "cppref": "cpp/io/basic_spanbuf/span",
+    "cppdoc": "cpp/library/io/basic_spanbuf/span"
+  },
+  {
+    "cppref": "cpp/io/basic_spanbuf/swap2",
+    "cppdoc": "cpp/library/io/basic_spanbuf/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_spanbuf/swap",
+    "cppdoc": "cpp/library/io/basic_spanbuf/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_spanbuf/basic_spanbuf",
+    "cppdoc": "cpp/library/io/basic_spanbuf/basic_spanbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_spanbuf/setbuf",
+    "cppdoc": "cpp/library/io/basic_spanbuf/setbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_spanbuf/operator=",
+    "cppdoc": "cpp/library/io/basic_spanbuf/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_spanbuf/seekoff",
+    "cppdoc": "cpp/library/io/basic_spanbuf/seekoff"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/tie",
+    "cppdoc": "cpp/library/io/basic_ios/tie"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/move",
+    "cppdoc": "cpp/library/io/basic_ios/move"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/~basic_ios",
+    "cppdoc": "cpp/library/io/basic_ios/~basic_ios"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/eof",
+    "cppdoc": "cpp/library/io/basic_ios/eof"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/basic_ios",
+    "cppdoc": "cpp/library/io/basic_ios/basic_ios"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/exceptions",
+    "cppdoc": "cpp/library/io/basic_ios/exceptions"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/swap",
+    "cppdoc": "cpp/library/io/basic_ios/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/set_rdbuf",
+    "cppdoc": "cpp/library/io/basic_ios/set_rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/bad",
+    "cppdoc": "cpp/library/io/basic_ios/bad"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/narrow",
+    "cppdoc": "cpp/library/io/basic_ios/narrow"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/copyfmt",
+    "cppdoc": "cpp/library/io/basic_ios/copyfmt"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/good",
+    "cppdoc": "cpp/library/io/basic_ios/good"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/operator!",
+    "cppdoc": "cpp/library/io/basic_ios/operator!"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/fill",
+    "cppdoc": "cpp/library/io/basic_ios/fill"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/setstate",
+    "cppdoc": "cpp/library/io/basic_ios/setstate"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/rdstate",
+    "cppdoc": "cpp/library/io/basic_ios/rdstate"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/rdbuf",
+    "cppdoc": "cpp/library/io/basic_ios/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/widen",
+    "cppdoc": "cpp/library/io/basic_ios/widen"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/operator_bool",
+    "cppdoc": "cpp/library/io/basic_ios/operator_bool"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/fail",
+    "cppdoc": "cpp/library/io/basic_ios/fail"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/imbue",
+    "cppdoc": "cpp/library/io/basic_ios/imbue"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/init",
+    "cppdoc": "cpp/library/io/basic_ios/init"
+  },
+  {
+    "cppref": "cpp/io/basic_ios/clear",
+    "cppdoc": "cpp/library/io/basic_ios/clear"
+  },
+  {
+    "cppref": "cpp/io/basic_ostringstream/basic_ostringstream",
+    "cppdoc": "cpp/library/io/basic_ostringstream/basic_ostringstream"
+  },
+  {
+    "cppref": "cpp/io/basic_ostringstream/view",
+    "cppdoc": "cpp/library/io/basic_ostringstream/view"
+  },
+  {
+    "cppref": "cpp/io/basic_ostringstream/swap2",
+    "cppdoc": "cpp/library/io/basic_ostringstream/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_ostringstream/swap",
+    "cppdoc": "cpp/library/io/basic_ostringstream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_ostringstream/str",
+    "cppdoc": "cpp/library/io/basic_ostringstream/str"
+  },
+  {
+    "cppref": "cpp/io/basic_ostringstream/rdbuf",
+    "cppdoc": "cpp/library/io/basic_ostringstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_ostringstream/operator=",
+    "cppdoc": "cpp/library/io/basic_ostringstream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_iostream/basic_iostream",
+    "cppdoc": "cpp/library/io/basic_iostream/basic_iostream"
+  },
+  {
+    "cppref": "cpp/io/basic_iostream/swap",
+    "cppdoc": "cpp/library/io/basic_iostream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_iostream/operator=",
+    "cppdoc": "cpp/library/io/basic_iostream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_iostream/~basic_iostream",
+    "cppdoc": "cpp/library/io/basic_iostream/~basic_iostream"
+  },
+  {
+    "cppref": "cpp/io/ios_base/seekdir",
+    "cppdoc": "cpp/library/io/ios_base/seekdir"
+  },
+  {
+    "cppref": "cpp/io/ios_base/register_callback",
+    "cppdoc": "cpp/library/io/ios_base/register_callback"
+  },
+  {
+    "cppref": "cpp/io/ios_base/width",
+    "cppdoc": "cpp/library/io/ios_base/width"
+  },
+  {
+    "cppref": "cpp/io/ios_base/iword",
+    "cppdoc": "cpp/library/io/ios_base/iword"
+  },
+  {
+    "cppref": "cpp/io/ios_base/event_callback",
+    "cppdoc": "cpp/library/io/ios_base/event_callback"
+  },
+  {
+    "cppref": "cpp/io/ios_base/iostate",
+    "cppdoc": "cpp/library/io/ios_base/iostate"
+  },
+  {
+    "cppref": "cpp/io/ios_base/getloc",
+    "cppdoc": "cpp/library/io/ios_base/getloc"
+  },
+  {
+    "cppref": "cpp/io/ios_base/ios_base",
+    "cppdoc": "cpp/library/io/ios_base/ios_base"
+  },
+  {
+    "cppref": "cpp/io/ios_base/setf",
+    "cppdoc": "cpp/library/io/ios_base/setf"
+  },
+  {
+    "cppref": "cpp/io/ios_base/fmtflags",
+    "cppdoc": "cpp/library/io/ios_base/fmtflags"
+  },
+  {
+    "cppref": "cpp/io/ios_base/flags",
+    "cppdoc": "cpp/library/io/ios_base/flags"
+  },
+  {
+    "cppref": "cpp/io/ios_base/~ios_base",
+    "cppdoc": "cpp/library/io/ios_base/~ios_base"
+  },
+  {
+    "cppref": "cpp/io/ios_base/event",
+    "cppdoc": "cpp/library/io/ios_base/event"
+  },
+  {
+    "cppref": "cpp/io/ios_base/Init",
+    "cppdoc": "cpp/library/io/ios_base/Init"
+  },
+  {
+    "cppref": "cpp/io/ios_base/precision",
+    "cppdoc": "cpp/library/io/ios_base/precision"
+  },
+  {
+    "cppref": "cpp/io/ios_base/unsetf",
+    "cppdoc": "cpp/library/io/ios_base/unsetf"
+  },
+  {
+    "cppref": "cpp/io/ios_base/operator=",
+    "cppdoc": "cpp/library/io/ios_base/operator="
+  },
+  {
+    "cppref": "cpp/io/ios_base/xalloc",
+    "cppdoc": "cpp/library/io/ios_base/xalloc"
+  },
+  {
+    "cppref": "cpp/io/ios_base/openmode",
+    "cppdoc": "cpp/library/io/ios_base/openmode"
+  },
+  {
+    "cppref": "cpp/io/ios_base/pword",
+    "cppdoc": "cpp/library/io/ios_base/pword"
+  },
+  {
+    "cppref": "cpp/io/ios_base/imbue",
+    "cppdoc": "cpp/library/io/ios_base/imbue"
+  },
+  {
+    "cppref": "cpp/io/ios_base/sync_with_stdio",
+    "cppdoc": "cpp/library/io/ios_base/sync_with_stdio"
+  },
+  {
+    "cppref": "cpp/io/ios_base/failure",
+    "cppdoc": "cpp/library/io/ios_base/failure"
+  },
+  {
+    "cppref": "cpp/io/basic_ospanstream/span",
+    "cppdoc": "cpp/library/io/basic_ospanstream/span"
+  },
+  {
+    "cppref": "cpp/io/basic_ospanstream/swap2",
+    "cppdoc": "cpp/library/io/basic_ospanstream/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_ospanstream/basic_ospanstream",
+    "cppdoc": "cpp/library/io/basic_ospanstream/basic_ospanstream"
+  },
+  {
+    "cppref": "cpp/io/basic_ospanstream/swap",
+    "cppdoc": "cpp/library/io/basic_ospanstream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_ospanstream/rdbuf",
+    "cppdoc": "cpp/library/io/basic_ospanstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_ospanstream/operator=",
+    "cppdoc": "cpp/library/io/basic_ospanstream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_osyncstream/emit",
+    "cppdoc": "cpp/library/io/basic_osyncstream/emit"
+  },
+  {
+    "cppref": "cpp/io/basic_osyncstream/get_wrapped",
+    "cppdoc": "cpp/library/io/basic_osyncstream/get_wrapped"
+  },
+  {
+    "cppref": "cpp/io/basic_osyncstream/~basic_osyncstream",
+    "cppdoc": "cpp/library/io/basic_osyncstream/~basic_osyncstream"
+  },
+  {
+    "cppref": "cpp/io/basic_osyncstream/rdbuf",
+    "cppdoc": "cpp/library/io/basic_osyncstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_osyncstream/operator=",
+    "cppdoc": "cpp/library/io/basic_osyncstream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_osyncstream/basic_osyncstream",
+    "cppdoc": "cpp/library/io/basic_osyncstream/basic_osyncstream"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/seekpos",
+    "cppdoc": "cpp/library/io/strstreambuf/seekpos"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/strstreambuf",
+    "cppdoc": "cpp/library/io/strstreambuf/strstreambuf"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/underflow",
+    "cppdoc": "cpp/library/io/strstreambuf/underflow"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/pcount",
+    "cppdoc": "cpp/library/io/strstreambuf/pcount"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/str",
+    "cppdoc": "cpp/library/io/strstreambuf/str"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/freeze",
+    "cppdoc": "cpp/library/io/strstreambuf/freeze"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/pbackfail",
+    "cppdoc": "cpp/library/io/strstreambuf/pbackfail"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/overflow",
+    "cppdoc": "cpp/library/io/strstreambuf/overflow"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/setbuf",
+    "cppdoc": "cpp/library/io/strstreambuf/setbuf"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/~strstreambuf",
+    "cppdoc": "cpp/library/io/strstreambuf/~strstreambuf"
+  },
+  {
+    "cppref": "cpp/io/strstreambuf/seekoff",
+    "cppdoc": "cpp/library/io/strstreambuf/seekoff"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/seekp",
+    "cppdoc": "cpp/library/io/basic_ostream/seekp"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/operator_ltlt2",
+    "cppdoc": "cpp/library/io/basic_ostream/operator_ltlt2"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/println",
+    "cppdoc": "cpp/library/io/basic_ostream/println"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/tellp",
+    "cppdoc": "cpp/library/io/basic_ostream/tellp"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/swap",
+    "cppdoc": "cpp/library/io/basic_ostream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/put",
+    "cppdoc": "cpp/library/io/basic_ostream/put"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/sentry",
+    "cppdoc": "cpp/library/io/basic_ostream/sentry"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/vprint_nonunicode",
+    "cppdoc": "cpp/library/io/basic_ostream/vprint_nonunicode"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/~basic_ostream",
+    "cppdoc": "cpp/library/io/basic_ostream/~basic_ostream"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/print",
+    "cppdoc": "cpp/library/io/basic_ostream/print"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/basic_ostream",
+    "cppdoc": "cpp/library/io/basic_ostream/basic_ostream"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/flush",
+    "cppdoc": "cpp/library/io/basic_ostream/flush"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/vprint_unicode",
+    "cppdoc": "cpp/library/io/basic_ostream/vprint_unicode"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/write",
+    "cppdoc": "cpp/library/io/basic_ostream/write"
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/operator=",
+    "cppdoc": "cpp/library/io/basic_ostream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_ostream/operator_ltlt",
+    "cppdoc": "cpp/library/io/basic_ostream/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/unget",
+    "cppdoc": "cpp/library/io/basic_istream/unget"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/basic_istream",
+    "cppdoc": "cpp/library/io/basic_istream/basic_istream"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/putback",
+    "cppdoc": "cpp/library/io/basic_istream/putback"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/tellg",
+    "cppdoc": "cpp/library/io/basic_istream/tellg"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/ignore",
+    "cppdoc": "cpp/library/io/basic_istream/ignore"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/getline",
+    "cppdoc": "cpp/library/io/basic_istream/getline"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/swap",
+    "cppdoc": "cpp/library/io/basic_istream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/sentry",
+    "cppdoc": "cpp/library/io/basic_istream/sentry"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/readsome",
+    "cppdoc": "cpp/library/io/basic_istream/readsome"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/seekg",
+    "cppdoc": "cpp/library/io/basic_istream/seekg"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/operator_gtgt2",
+    "cppdoc": "cpp/library/io/basic_istream/operator_gtgt2"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/gcount",
+    "cppdoc": "cpp/library/io/basic_istream/gcount"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/get",
+    "cppdoc": "cpp/library/io/basic_istream/get"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/peek",
+    "cppdoc": "cpp/library/io/basic_istream/peek"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/~basic_istream",
+    "cppdoc": "cpp/library/io/basic_istream/~basic_istream"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/operator_gtgt",
+    "cppdoc": "cpp/library/io/basic_istream/operator_gtgt"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/operator=",
+    "cppdoc": "cpp/library/io/basic_istream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_istream/sync",
+    "cppdoc": "cpp/library/io/basic_istream/sync"
+  },
+  {
+    "cppref": "cpp/io/basic_istream/read",
+    "cppdoc": "cpp/library/io/basic_istream/read"
+  },
+  {
+    "cppref": "cpp/io/manip/get_time",
+    "cppdoc": "cpp/library/io/manip/get_time"
+  },
+  {
+    "cppref": "cpp/io/manip/left",
+    "cppdoc": "cpp/library/io/manip/left"
+  },
+  {
+    "cppref": "cpp/io/manip/flush_emit",
+    "cppdoc": "cpp/library/io/manip/flush_emit"
+  },
+  {
+    "cppref": "cpp/io/manip/showbase",
+    "cppdoc": "cpp/library/io/manip/showbase"
+  },
+  {
+    "cppref": "cpp/io/manip/resetiosflags",
+    "cppdoc": "cpp/library/io/manip/resetiosflags"
+  },
+  {
+    "cppref": "cpp/io/manip/ws",
+    "cppdoc": "cpp/library/io/manip/ws"
+  },
+  {
+    "cppref": "cpp/io/manip/ends",
+    "cppdoc": "cpp/library/io/manip/ends"
+  },
+  {
+    "cppref": "cpp/io/manip/skipws",
+    "cppdoc": "cpp/library/io/manip/skipws"
+  },
+  {
+    "cppref": "cpp/io/manip/put_money",
+    "cppdoc": "cpp/library/io/manip/put_money"
+  },
+  {
+    "cppref": "cpp/io/manip/showpoint",
+    "cppdoc": "cpp/library/io/manip/showpoint"
+  },
+  {
+    "cppref": "cpp/io/manip/setiosflags",
+    "cppdoc": "cpp/library/io/manip/setiosflags"
+  },
+  {
+    "cppref": "cpp/io/manip/uppercase",
+    "cppdoc": "cpp/library/io/manip/uppercase"
+  },
+  {
+    "cppref": "cpp/io/manip/fixed",
+    "cppdoc": "cpp/library/io/manip/fixed"
+  },
+  {
+    "cppref": "cpp/io/manip/put_time",
+    "cppdoc": "cpp/library/io/manip/put_time"
+  },
+  {
+    "cppref": "cpp/io/manip/setbase",
+    "cppdoc": "cpp/library/io/manip/setbase"
+  },
+  {
+    "cppref": "cpp/io/manip/quoted",
+    "cppdoc": "cpp/library/io/manip/quoted"
+  },
+  {
+    "cppref": "cpp/io/manip/setw",
+    "cppdoc": "cpp/library/io/manip/setw"
+  },
+  {
+    "cppref": "cpp/io/manip/boolalpha",
+    "cppdoc": "cpp/library/io/manip/boolalpha"
+  },
+  {
+    "cppref": "cpp/io/manip/unitbuf",
+    "cppdoc": "cpp/library/io/manip/unitbuf"
+  },
+  {
+    "cppref": "cpp/io/manip/flush",
+    "cppdoc": "cpp/library/io/manip/flush"
+  },
+  {
+    "cppref": "cpp/io/manip/showpos",
+    "cppdoc": "cpp/library/io/manip/showpos"
+  },
+  {
+    "cppref": "cpp/io/manip/setprecision",
+    "cppdoc": "cpp/library/io/manip/setprecision"
+  },
+  {
+    "cppref": "cpp/io/manip/endl",
+    "cppdoc": "cpp/library/io/manip/endl"
+  },
+  {
+    "cppref": "cpp/io/manip/setfill",
+    "cppdoc": "cpp/library/io/manip/setfill"
+  },
+  {
+    "cppref": "cpp/io/manip/get_money",
+    "cppdoc": "cpp/library/io/manip/get_money"
+  },
+  {
+    "cppref": "cpp/io/manip/hex",
+    "cppdoc": "cpp/library/io/manip/hex"
+  },
+  {
+    "cppref": "cpp/io/manip/emit_on_flush",
+    "cppdoc": "cpp/library/io/manip/emit_on_flush"
+  },
+  {
+    "cppref": "cpp/io/basic_fstream/swap2",
+    "cppdoc": "cpp/library/io/basic_fstream/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_fstream/swap",
+    "cppdoc": "cpp/library/io/basic_fstream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_fstream/basic_fstream",
+    "cppdoc": "cpp/library/io/basic_fstream/basic_fstream"
+  },
+  {
+    "cppref": "cpp/io/basic_fstream/is_open",
+    "cppdoc": "cpp/library/io/basic_fstream/is_open"
+  },
+  {
+    "cppref": "cpp/io/basic_fstream/close",
+    "cppdoc": "cpp/library/io/basic_fstream/close"
+  },
+  {
+    "cppref": "cpp/io/basic_fstream/rdbuf",
+    "cppdoc": "cpp/library/io/basic_fstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_fstream/operator=",
+    "cppdoc": "cpp/library/io/basic_fstream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_fstream/open",
+    "cppdoc": "cpp/library/io/basic_fstream/open"
+  },
+  {
+    "cppref": "cpp/io/basic_fstream/native_handle",
+    "cppdoc": "cpp/library/io/basic_fstream/native_handle"
+  },
+  {
+    "cppref": "cpp/io/basic_spanstream/span",
+    "cppdoc": "cpp/library/io/basic_spanstream/span"
+  },
+  {
+    "cppref": "cpp/io/basic_spanstream/swap2",
+    "cppdoc": "cpp/library/io/basic_spanstream/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_spanstream/swap",
+    "cppdoc": "cpp/library/io/basic_spanstream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_spanstream/rdbuf",
+    "cppdoc": "cpp/library/io/basic_spanstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_spanstream/operator=",
+    "cppdoc": "cpp/library/io/basic_spanstream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_spanstream/basic_spanstream",
+    "cppdoc": "cpp/library/io/basic_spanstream/basic_spanstream"
+  },
+  {
+    "cppref": "cpp/io/basic_istringstream/view",
+    "cppdoc": "cpp/library/io/basic_istringstream/view"
+  },
+  {
+    "cppref": "cpp/io/basic_istringstream/swap2",
+    "cppdoc": "cpp/library/io/basic_istringstream/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_istringstream/swap",
+    "cppdoc": "cpp/library/io/basic_istringstream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_istringstream/str",
+    "cppdoc": "cpp/library/io/basic_istringstream/str"
+  },
+  {
+    "cppref": "cpp/io/basic_istringstream/rdbuf",
+    "cppdoc": "cpp/library/io/basic_istringstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_istringstream/basic_istringstream",
+    "cppdoc": "cpp/library/io/basic_istringstream/basic_istringstream"
+  },
+  {
+    "cppref": "cpp/io/basic_istringstream/operator=",
+    "cppdoc": "cpp/library/io/basic_istringstream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_ifstream/basic_ifstream",
+    "cppdoc": "cpp/library/io/basic_ifstream/basic_ifstream"
+  },
+  {
+    "cppref": "cpp/io/basic_ifstream/swap2",
+    "cppdoc": "cpp/library/io/basic_ifstream/swap2"
+  },
+  {
+    "cppref": "cpp/io/basic_ifstream/swap",
+    "cppdoc": "cpp/library/io/basic_ifstream/swap"
+  },
+  {
+    "cppref": "cpp/io/basic_ifstream/is_open",
+    "cppdoc": "cpp/library/io/basic_ifstream/is_open"
+  },
+  {
+    "cppref": "cpp/io/basic_ifstream/close",
+    "cppdoc": "cpp/library/io/basic_ifstream/close"
+  },
+  {
+    "cppref": "cpp/io/basic_ifstream/rdbuf",
+    "cppdoc": "cpp/library/io/basic_ifstream/rdbuf"
+  },
+  {
+    "cppref": "cpp/io/basic_ifstream/operator=",
+    "cppdoc": "cpp/library/io/basic_ifstream/operator="
+  },
+  {
+    "cppref": "cpp/io/basic_ifstream/open",
+    "cppdoc": "cpp/library/io/basic_ifstream/open"
+  },
+  {
+    "cppref": "cpp/io/basic_ifstream/native_handle",
+    "cppdoc": "cpp/library/io/basic_ifstream/native_handle"
+  },
+  {
+    "cppref": "cpp/experimental/promise",
+    "cppdoc": "cpp/library/experimental/promise"
+  },
+  {
+    "cppref": "cpp/experimental/ranges",
+    "cppdoc": "cpp/library/experimental/ranges"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions_2",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions_3",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions",
+    "cppdoc": "cpp/library/experimental/special_functions"
+  },
+  {
+    "cppref": "cpp/experimental/void_t",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/void_t"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions",
+    "cppdoc": "cpp/library/experimental/lib_extensions"
+  },
+  {
+    "cppref": "cpp/experimental/not_fn",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/not_fn"
+  },
+  {
+    "cppref": "cpp/experimental/source_location",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/source_location"
+  },
+  {
+    "cppref": "cpp/experimental/scope_exit",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_exit"
+  },
+  {
+    "cppref": "cpp/experimental/scope_success",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_success"
+  },
+  {
+    "cppref": "cpp/experimental/lcm",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/lcm"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/packaged_task",
+    "cppdoc": "cpp/library/experimental/packaged_task"
+  },
+  {
+    "cppref": "cpp/experimental/parallelism",
+    "cppdoc": "cpp/library/experimental/parallelism"
+  },
+  {
+    "cppref": "cpp/experimental/nonesuch",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/nonesuch"
+  },
+  {
+    "cppref": "cpp/experimental/reseed",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/reseed"
+  },
+  {
+    "cppref": "cpp/experimental/to_array",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/to_array"
+  },
+  {
+    "cppref": "cpp/experimental/networking",
+    "cppdoc": "cpp/library/experimental/networking"
+  },
+  {
+    "cppref": "cpp/experimental/execution_policy_tag",
+    "cppdoc": "cpp/library/experimental/parallelism/execution_policy_tag"
+  },
+  {
+    "cppref": "cpp/experimental/concurrency",
+    "cppdoc": "cpp/library/experimental/concurrency"
+  },
+  {
+    "cppref": "cpp/experimental/make_array",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/make_array"
+  },
+  {
+    "cppref": "cpp/experimental/negation",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/negation"
+  },
+  {
+    "cppref": "cpp/experimental/constraints",
+    "cppdoc": "cpp/library/experimental/constraints"
+  },
+  {
+    "cppref": "cpp/experimental/execution_policy_tag_t",
+    "cppdoc": "cpp/library/experimental/parallelism/execution_policy_tag_t"
+  },
+  {
+    "cppref": "cpp/experimental/special_math",
+    "cppdoc": "cpp/library/experimental/special_math"
+  },
+  {
+    "cppref": "cpp/experimental/memory",
+    "cppdoc": "cpp/library/experimental/memory"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_shared_ptr",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_shared_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/is_execution_policy",
+    "cppdoc": "cpp/library/experimental/parallelism/is_execution_policy"
+  },
+  {
+    "cppref": "cpp/experimental/reduce",
+    "cppdoc": "cpp/library/experimental/parallelism/reduce"
+  },
+  {
+    "cppref": "cpp/experimental/function",
+    "cppdoc": "cpp/library/experimental/memory/function"
+  },
+  {
+    "cppref": "cpp/experimental/shuffle",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/shuffle"
+  },
+  {
+    "cppref": "cpp/experimental/is_detected",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/is_detected"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_weak_ptr",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_weak_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/parallelism_2",
+    "cppdoc": "cpp/library/experimental/parallelism_2"
+  },
+  {
+    "cppref": "cpp/experimental/randint",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/randint"
+  },
+  {
+    "cppref": "cpp/experimental/apply",
+    "cppdoc": "cpp/library/experimental/memory/apply"
+  },
+  {
+    "cppref": "cpp/experimental/conjunction",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/conjunction"
+  },
+  {
+    "cppref": "cpp/experimental/gcd",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/gcd"
+  },
+  {
+    "cppref": "cpp/experimental/execution",
+    "cppdoc": "cpp/library/experimental/execution"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const"
+  },
+  {
+    "cppref": "cpp/experimental/scope_fail",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_fail"
+  },
+  {
+    "cppref": "cpp/experimental/reflect",
+    "cppdoc": "cpp/library/experimental/reflect"
+  },
+  {
+    "cppref": "cpp/experimental/invocation_type",
+    "cppdoc": "cpp/library/experimental/memory/invocation_type"
+  },
+  {
+    "cppref": "cpp/experimental/fs",
+    "cppdoc": "cpp/library/experimental/fs"
+  },
+  {
+    "cppref": "cpp/experimental/flex_barrier",
+    "cppdoc": "cpp/library/experimental/concurrency/flex_barrier"
+  },
+  {
+    "cppref": "cpp/experimental/optional",
+    "cppdoc": "cpp/library/experimental/memory/optional"
+  },
+  {
+    "cppref": "cpp/experimental/make_ready_future",
+    "cppdoc": "cpp/library/experimental/concurrency/make_ready_future"
+  },
+  {
+    "cppref": "cpp/experimental/disjunction",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/disjunction"
+  },
+  {
+    "cppref": "cpp/experimental/erased_type",
+    "cppdoc": "cpp/library/experimental/memory/erased_type"
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource"
+  },
+  {
+    "cppref": "cpp/experimental/when_any",
+    "cppdoc": "cpp/library/experimental/concurrency/when_any"
+  },
+  {
+    "cppref": "cpp/experimental/synchronized_pool_resource",
+    "cppdoc": "cpp/library/experimental/memory/synchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/experimental/when_all",
+    "cppdoc": "cpp/library/experimental/concurrency/when_all"
+  },
+  {
+    "cppref": "cpp/experimental/null_memory_resource",
+    "cppdoc": "cpp/library/experimental/memory/null_memory_resource"
+  },
+  {
+    "cppref": "cpp/experimental/memory_resource",
+    "cppdoc": "cpp/library/experimental/memory/../memory_resource"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/promise",
+    "cppdoc": "cpp/library/experimental/memory/promise"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/packaged_task",
+    "cppdoc": "cpp/library/experimental/memory/packaged_task"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/pmr_container",
+    "cppdoc": "cpp/library/experimental/memory/pmr_container"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/promise/promise",
+    "cppdoc": "cpp/library/experimental/memory/promise"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/promise/get_memory_resource",
+    "cppdoc": "cpp/library/experimental/memory/get_memory_resource"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/promise/swap2",
+    "cppdoc": "cpp/library/experimental/memory/swap2"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/promise/uses_allocator",
+    "cppdoc": "cpp/library/experimental/memory/uses_allocator"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/packaged_task/get_memory_resource",
+    "cppdoc": "cpp/library/experimental/memory/get_memory_resource"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/packaged_task/packaged_task",
+    "cppdoc": "cpp/library/experimental/memory/packaged_task"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/packaged_task/swap2",
+    "cppdoc": "cpp/library/experimental/memory/swap2"
+  },
+  {
+    "cppref": "cpp/experimental/lib_extensions/packaged_task/uses_allocator",
+    "cppdoc": "cpp/library/experimental/memory/uses_allocator"
+  },
+  {
+    "cppref": "cpp/experimental/unordered_map/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/scope_fail/deduction_guides",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_fail/deduction_guides"
+  },
+  {
+    "cppref": "cpp/experimental/scope_fail/release",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_fail/release"
+  },
+  {
+    "cppref": "cpp/experimental/scope_fail/scope_fail",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_fail/scope_fail"
+  },
+  {
+    "cppref": "cpp/experimental/scope_fail/~scope_fail",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_fail/~scope_fail"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Expression",
+    "cppdoc": "cpp/library/experimental/reflect/Expression"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Scope",
+    "cppdoc": "cpp/library/experimental/reflect/Scope"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/FunctionalTypeConversion",
+    "cppdoc": "cpp/library/experimental/reflect/FunctionalTypeConversion"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Object",
+    "cppdoc": "cpp/library/experimental/reflect/Object"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Lambda",
+    "cppdoc": "cpp/library/experimental/reflect/Lambda"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/FunctionParameter",
+    "cppdoc": "cpp/library/experimental/reflect/FunctionParameter"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/get_source_line",
+    "cppdoc": "cpp/library/experimental/reflect/get_source_line"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/ParenthesizedExpression",
+    "cppdoc": "cpp/library/experimental/reflect/ParenthesizedExpression"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/LambdaCapture",
+    "cppdoc": "cpp/library/experimental/reflect/LambdaCapture"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Enumerator",
+    "cppdoc": "cpp/library/experimental/reflect/Enumerator"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Enum",
+    "cppdoc": "cpp/library/experimental/reflect/Enum"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Destructor",
+    "cppdoc": "cpp/library/experimental/reflect/Destructor"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Variable",
+    "cppdoc": "cpp/library/experimental/reflect/Variable"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Named",
+    "cppdoc": "cpp/library/experimental/reflect/Named"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/get_source_column",
+    "cppdoc": "cpp/library/experimental/reflect/get_source_column"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/RecordMember",
+    "cppdoc": "cpp/library/experimental/reflect/RecordMember"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Callable",
+    "cppdoc": "cpp/library/experimental/reflect/Callable"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Constant",
+    "cppdoc": "cpp/library/experimental/reflect/Constant"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Typed",
+    "cppdoc": "cpp/library/experimental/reflect/Typed"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/SpecialMemberFunction",
+    "cppdoc": "cpp/library/experimental/reflect/SpecialMemberFunction"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/ScopeMember",
+    "cppdoc": "cpp/library/experimental/reflect/ScopeMember"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Type",
+    "cppdoc": "cpp/library/experimental/reflect/Type"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Function",
+    "cppdoc": "cpp/library/experimental/reflect/Function"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Class",
+    "cppdoc": "cpp/library/experimental/reflect/Class"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Constructor",
+    "cppdoc": "cpp/library/experimental/reflect/Constructor"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/MemberFunction",
+    "cppdoc": "cpp/library/experimental/reflect/MemberFunction"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/FunctionCallExpression",
+    "cppdoc": "cpp/library/experimental/reflect/FunctionCallExpression"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Base",
+    "cppdoc": "cpp/library/experimental/reflect/Base"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/ObjectSequence",
+    "cppdoc": "cpp/library/experimental/reflect/ObjectSequence"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Namespace",
+    "cppdoc": "cpp/library/experimental/reflect/Namespace"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Record",
+    "cppdoc": "cpp/library/experimental/reflect/Record"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/GlobalScope",
+    "cppdoc": "cpp/library/experimental/reflect/GlobalScope"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Alias",
+    "cppdoc": "cpp/library/experimental/reflect/Alias"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/Operator",
+    "cppdoc": "cpp/library/experimental/reflect/Operator"
+  },
+  {
+    "cppref": "cpp/experimental/reflect/ConversionOperator",
+    "cppdoc": "cpp/library/experimental/reflect/ConversionOperator"
+  },
+  {
+    "cppref": "cpp/experimental/fs/copy_file",
+    "cppdoc": "cpp/library/experimental/fs/copy_file"
+  },
+  {
+    "cppref": "cpp/experimental/fs/create_symlink",
+    "cppdoc": "cpp/library/experimental/fs/create_symlink"
+  },
+  {
+    "cppref": "cpp/experimental/fs/copy_options",
+    "cppdoc": "cpp/library/experimental/fs/copy_options"
+  },
+  {
+    "cppref": "cpp/experimental/fs/read_symlink",
+    "cppdoc": "cpp/library/experimental/fs/read_symlink"
+  },
+  {
+    "cppref": "cpp/experimental/fs/remove",
+    "cppdoc": "cpp/library/experimental/fs/remove"
+  },
+  {
+    "cppref": "cpp/experimental/fs/file_type",
+    "cppdoc": "cpp/library/experimental/fs/file_type"
+  },
+  {
+    "cppref": "cpp/experimental/fs/is_directory",
+    "cppdoc": "cpp/library/experimental/fs/is_directory"
+  },
+  {
+    "cppref": "cpp/experimental/fs/current_path",
+    "cppdoc": "cpp/library/experimental/fs/current_path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_options",
+    "cppdoc": "cpp/library/experimental/fs/directory_options"
+  },
+  {
+    "cppref": "cpp/experimental/fs/permissions",
+    "cppdoc": "cpp/library/experimental/fs/permissions"
+  },
+  {
+    "cppref": "cpp/experimental/fs/resize_file",
+    "cppdoc": "cpp/library/experimental/fs/resize_file"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_iterator",
+    "cppdoc": "cpp/library/experimental/fs/directory_iterator"
+  },
+  {
+    "cppref": "cpp/experimental/fs/copy",
+    "cppdoc": "cpp/library/experimental/fs/copy"
+  },
+  {
+    "cppref": "cpp/experimental/fs/is_character_file",
+    "cppdoc": "cpp/library/experimental/fs/is_character_file"
+  },
+  {
+    "cppref": "cpp/experimental/fs/canonical",
+    "cppdoc": "cpp/library/experimental/fs/canonical"
+  },
+  {
+    "cppref": "cpp/experimental/fs/create_directory",
+    "cppdoc": "cpp/library/experimental/fs/create_directory"
+  },
+  {
+    "cppref": "cpp/experimental/fs/is_socket",
+    "cppdoc": "cpp/library/experimental/fs/is_socket"
+  },
+  {
+    "cppref": "cpp/experimental/fs/rename",
+    "cppdoc": "cpp/library/experimental/fs/rename"
+  },
+  {
+    "cppref": "cpp/experimental/fs/status",
+    "cppdoc": "cpp/library/experimental/fs/status"
+  },
+  {
+    "cppref": "cpp/experimental/fs/copy_symlink",
+    "cppdoc": "cpp/library/experimental/fs/copy_symlink"
+  },
+  {
+    "cppref": "cpp/experimental/fs/temp_directory_path",
+    "cppdoc": "cpp/library/experimental/fs/temp_directory_path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/file_status",
+    "cppdoc": "cpp/library/experimental/fs/file_status"
+  },
+  {
+    "cppref": "cpp/experimental/fs/create_hard_link",
+    "cppdoc": "cpp/library/experimental/fs/create_hard_link"
+  },
+  {
+    "cppref": "cpp/experimental/fs/space",
+    "cppdoc": "cpp/library/experimental/fs/space"
+  },
+  {
+    "cppref": "cpp/experimental/fs/file_time_type",
+    "cppdoc": "cpp/library/experimental/fs/file_time_type"
+  },
+  {
+    "cppref": "cpp/experimental/fs/last_write_time",
+    "cppdoc": "cpp/library/experimental/fs/last_write_time"
+  },
+  {
+    "cppref": "cpp/experimental/fs/hard_link_count",
+    "cppdoc": "cpp/library/experimental/fs/hard_link_count"
+  },
+  {
+    "cppref": "cpp/experimental/fs/is_regular_file",
+    "cppdoc": "cpp/library/experimental/fs/is_regular_file"
+  },
+  {
+    "cppref": "cpp/experimental/fs/absolute",
+    "cppdoc": "cpp/library/experimental/fs/absolute"
+  },
+  {
+    "cppref": "cpp/experimental/fs/perms",
+    "cppdoc": "cpp/library/experimental/fs/perms"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path",
+    "cppdoc": "cpp/library/experimental/fs/path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/is_other",
+    "cppdoc": "cpp/library/experimental/fs/is_other"
+  },
+  {
+    "cppref": "cpp/experimental/fs/is_empty",
+    "cppdoc": "cpp/library/experimental/fs/is_empty"
+  },
+  {
+    "cppref": "cpp/experimental/fs/space_info",
+    "cppdoc": "cpp/library/experimental/fs/space_info"
+  },
+  {
+    "cppref": "cpp/experimental/fs/file_size",
+    "cppdoc": "cpp/library/experimental/fs/file_size"
+  },
+  {
+    "cppref": "cpp/experimental/fs/is_symlink",
+    "cppdoc": "cpp/library/experimental/fs/is_symlink"
+  },
+  {
+    "cppref": "cpp/experimental/fs/status_known",
+    "cppdoc": "cpp/library/experimental/fs/status_known"
+  },
+  {
+    "cppref": "cpp/experimental/fs/is_block_file",
+    "cppdoc": "cpp/library/experimental/fs/is_block_file"
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator"
+  },
+  {
+    "cppref": "cpp/experimental/fs/is_fifo",
+    "cppdoc": "cpp/library/experimental/fs/is_fifo"
+  },
+  {
+    "cppref": "cpp/experimental/fs/equivalent",
+    "cppdoc": "cpp/library/experimental/fs/equivalent"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_entry",
+    "cppdoc": "cpp/library/experimental/fs/directory_entry"
+  },
+  {
+    "cppref": "cpp/experimental/fs/exists",
+    "cppdoc": "cpp/library/experimental/fs/exists"
+  },
+  {
+    "cppref": "cpp/experimental/fs/filesystem_error",
+    "cppdoc": "cpp/library/experimental/fs/filesystem_error"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_entry/assign",
+    "cppdoc": "cpp/library/experimental/fs/directory_entry/assign"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_entry/replace_filename",
+    "cppdoc": "cpp/library/experimental/fs/directory_entry/replace_filename"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_entry/status",
+    "cppdoc": "cpp/library/experimental/fs/directory_entry/status"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_entry/operator_cmp",
+    "cppdoc": "cpp/library/experimental/fs/directory_entry/operator_cmp"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_entry/path",
+    "cppdoc": "cpp/library/experimental/fs/directory_entry/path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_entry/operator=",
+    "cppdoc": "cpp/library/experimental/fs/directory_entry/operator="
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_entry/directory_entry",
+    "cppdoc": "cpp/library/experimental/fs/directory_entry/directory_entry"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_iterator/directory_iterator",
+    "cppdoc": "cpp/library/experimental/fs/directory_iterator/directory_iterator"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_iterator/begin",
+    "cppdoc": "cpp/library/experimental/fs/directory_iterator/begin"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_iterator/operator_star_",
+    "cppdoc": "cpp/library/experimental/fs/directory_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_iterator/operator=",
+    "cppdoc": "cpp/library/experimental/fs/directory_iterator/operator="
+  },
+  {
+    "cppref": "cpp/experimental/fs/directory_iterator/increment",
+    "cppdoc": "cpp/library/experimental/fs/directory_iterator/increment"
+  },
+  {
+    "cppref": "cpp/experimental/fs/file_status/permissions",
+    "cppdoc": "cpp/library/experimental/fs/file_status/permissions"
+  },
+  {
+    "cppref": "cpp/experimental/fs/file_status/file_status",
+    "cppdoc": "cpp/library/experimental/fs/file_status/file_status"
+  },
+  {
+    "cppref": "cpp/experimental/fs/file_status/type",
+    "cppdoc": "cpp/library/experimental/fs/file_status/type"
+  },
+  {
+    "cppref": "cpp/experimental/fs/file_status/operator=",
+    "cppdoc": "cpp/library/experimental/fs/file_status/operator="
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/stem",
+    "cppdoc": "cpp/library/experimental/fs/path/stem"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/assign",
+    "cppdoc": "cpp/library/experimental/fs/path/assign"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/remove_filename",
+    "cppdoc": "cpp/library/experimental/fs/path/remove_filename"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/root_path",
+    "cppdoc": "cpp/library/experimental/fs/path/root_path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/replace_filename",
+    "cppdoc": "cpp/library/experimental/fs/path/replace_filename"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/has_path",
+    "cppdoc": "cpp/library/experimental/fs/path/has_path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/empty",
+    "cppdoc": "cpp/library/experimental/fs/path/empty"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/operator_slash",
+    "cppdoc": "cpp/library/experimental/fs/path/operator_slash"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/relative_path",
+    "cppdoc": "cpp/library/experimental/fs/path/relative_path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/root_directory",
+    "cppdoc": "cpp/library/experimental/fs/path/root_directory"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/operator_ltltgtgt",
+    "cppdoc": "cpp/library/experimental/fs/path/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/swap2",
+    "cppdoc": "cpp/library/experimental/fs/path/swap2"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/native",
+    "cppdoc": "cpp/library/experimental/fs/path/native"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/begin",
+    "cppdoc": "cpp/library/experimental/fs/path/begin"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/root_name",
+    "cppdoc": "cpp/library/experimental/fs/path/root_name"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/extension",
+    "cppdoc": "cpp/library/experimental/fs/path/extension"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/string",
+    "cppdoc": "cpp/library/experimental/fs/path/string"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/generic_string",
+    "cppdoc": "cpp/library/experimental/fs/path/generic_string"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/filename",
+    "cppdoc": "cpp/library/experimental/fs/path/filename"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/swap",
+    "cppdoc": "cpp/library/experimental/fs/path/swap"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/compare",
+    "cppdoc": "cpp/library/experimental/fs/path/compare"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/append",
+    "cppdoc": "cpp/library/experimental/fs/path/append"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/operator_cmp",
+    "cppdoc": "cpp/library/experimental/fs/path/operator_cmp"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/path",
+    "cppdoc": "cpp/library/experimental/fs/path/path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/replace_extension",
+    "cppdoc": "cpp/library/experimental/fs/path/replace_extension"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/~path",
+    "cppdoc": "cpp/library/experimental/fs/path/~path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/concat",
+    "cppdoc": "cpp/library/experimental/fs/path/concat"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/is_absrel",
+    "cppdoc": "cpp/library/experimental/fs/path/is_absrel"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/operator=",
+    "cppdoc": "cpp/library/experimental/fs/path/operator="
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/parent_path",
+    "cppdoc": "cpp/library/experimental/fs/path/parent_path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/make_preferred",
+    "cppdoc": "cpp/library/experimental/fs/path/make_preferred"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/u8path",
+    "cppdoc": "cpp/library/experimental/fs/path/u8path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/path/clear",
+    "cppdoc": "cpp/library/experimental/fs/path/clear"
+  },
+  {
+    "cppref": "cpp/experimental/fs/filesystem_error/what",
+    "cppdoc": "cpp/library/experimental/fs/filesystem_error/what"
+  },
+  {
+    "cppref": "cpp/experimental/fs/filesystem_error/path",
+    "cppdoc": "cpp/library/experimental/fs/filesystem_error/path"
+  },
+  {
+    "cppref": "cpp/experimental/fs/filesystem_error/filesystem_error",
+    "cppdoc": "cpp/library/experimental/fs/filesystem_error/filesystem_error"
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator/recursion_pending",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator/recursion_pending"
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator/begin",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator/begin"
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator/depth",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator/depth"
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator/operator_star_",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator/options",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator/options"
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator/disable_recursion_pending",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator/disable_recursion_pending"
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator/operator=",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator/operator="
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator/pop",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator/pop"
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator/recursive_directory_iterator",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator/recursive_directory_iterator"
+  },
+  {
+    "cppref": "cpp/experimental/fs/recursive_directory_iterator/increment",
+    "cppdoc": "cpp/library/experimental/fs/recursive_directory_iterator/increment"
+  },
+  {
+    "cppref": "cpp/experimental/unordered_set/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/memory_resource/do_is_equal",
+    "cppdoc": "cpp/library/experimental/memory/../memory_resource/do_is_equal"
+  },
+  {
+    "cppref": "cpp/experimental/memory_resource/operator_eq",
+    "cppdoc": "cpp/library/experimental/memory/../memory_resource/operator_eq"
+  },
+  {
+    "cppref": "cpp/experimental/memory_resource/allocate",
+    "cppdoc": "cpp/library/experimental/memory/../memory_resource/allocate"
+  },
+  {
+    "cppref": "cpp/experimental/memory_resource/deallocate",
+    "cppdoc": "cpp/library/experimental/memory/../memory_resource/deallocate"
+  },
+  {
+    "cppref": "cpp/experimental/memory_resource/do_deallocate",
+    "cppdoc": "cpp/library/experimental/memory/../memory_resource/do_deallocate"
+  },
+  {
+    "cppref": "cpp/experimental/memory_resource/do_allocate",
+    "cppdoc": "cpp/library/experimental/memory/../memory_resource/do_allocate"
+  },
+  {
+    "cppref": "cpp/experimental/memory_resource/is_equal",
+    "cppdoc": "cpp/library/experimental/memory/../memory_resource/is_equal"
+  },
+  {
+    "cppref": "cpp/experimental/memory_resource/memory_resource",
+    "cppdoc": "cpp/library/experimental/memory/../memory_resource/memory_resource"
+  },
+  {
+    "cppref": "cpp/experimental/flex_barrier/arrive_and_wait",
+    "cppdoc": "cpp/library/experimental/concurrency/flex_barrier/arrive_and_wait"
+  },
+  {
+    "cppref": "cpp/experimental/flex_barrier/~flex_barrier",
+    "cppdoc": "cpp/library/experimental/concurrency/flex_barrier/~flex_barrier"
+  },
+  {
+    "cppref": "cpp/experimental/flex_barrier/arrive_and_drop",
+    "cppdoc": "cpp/library/experimental/concurrency/flex_barrier/arrive_and_drop"
+  },
+  {
+    "cppref": "cpp/experimental/flex_barrier/flex_barrier",
+    "cppdoc": "cpp/library/experimental/concurrency/flex_barrier/flex_barrier"
+  },
+  {
+    "cppref": "cpp/experimental/unordered_multimap/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/scope_exit/scope_exit",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_exit/scope_exit"
+  },
+  {
+    "cppref": "cpp/experimental/scope_exit/deduction_guides",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_exit/deduction_guides"
+  },
+  {
+    "cppref": "cpp/experimental/scope_exit/~scope_exit",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_exit/~scope_exit"
+  },
+  {
+    "cppref": "cpp/experimental/scope_exit/release",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_exit/release"
+  },
+  {
+    "cppref": "cpp/experimental/set/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/parallelism/existing",
+    "cppdoc": "cpp/library/experimental/parallelism/existing"
+  },
+  {
+    "cppref": "cpp/experimental/forward_list/erase",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase"
+  },
+  {
+    "cppref": "cpp/experimental/forward_list/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string/erase",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/map/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Semiregular",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Semiregular"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/StrictWeakOrder",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/StrictWeakOrder"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/WeaklyEqualityComparableWith",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/WeaklyEqualityComparableWith"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Boolean",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Boolean"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/CopyConstructible",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/CopyConstructible"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/ConvertibleTo",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/ConvertibleTo"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/CommonReference",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/CommonReference"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/EqualityComparable",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/EqualityComparable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Destructible",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Destructible"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/UniformRandomNumberGenerator",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/UniformRandomNumberGenerator"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Predicate",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Predicate"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Same",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Same"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Integral",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Integral"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Invocable",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Invocable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Movable",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Movable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Assignable",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Assignable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/DerivedFrom",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/DerivedFrom"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Copyable",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Copyable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Regular",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Regular"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Swappable",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Swappable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/MoveConstructible",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/MoveConstructible"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Constructible",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Constructible"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/DefaultConstructible",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/DefaultConstructible"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/UnsignedIntegral",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/UnsignedIntegral"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Common",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Common"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/SignedIntegral",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/SignedIntegral"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/StrictTotallyOrdered",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/StrictTotallyOrdered"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/concepts/Relation",
+    "cppdoc": "cpp/library/experimental/ranges/concepts/Relation"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/type_traits/is_swappable",
+    "cppdoc": "cpp/library/experimental/ranges/type_traits/is_swappable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/type_traits/common_type",
+    "cppdoc": "cpp/library/experimental/ranges/type_traits/common_type"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/type_traits/common_reference",
+    "cppdoc": "cpp/library/experimental/ranges/type_traits/common_reference"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/adjacent_find",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/adjacent_find"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/find",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/find"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/search",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/search"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/all_any_none_of",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/all_any_none_of"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/copy",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/copy"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/for_each",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/for_each"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/find_end",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/find_end"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/tags",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/tags"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/search_n",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/search_n"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/mismatch",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/mismatch"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/count",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/count"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/equal",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/equal"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/sort",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/sort"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/find_first_of",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/find_first_of"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/lexicographical_compare",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/lexicographical_compare"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/algorithm/is_permutation",
+    "cppdoc": "cpp/library/experimental/ranges/algorithm/is_permutation"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/range/BidirectionalRange",
+    "cppdoc": "cpp/library/experimental/ranges/range/BidirectionalRange"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/range/BoundedRange",
+    "cppdoc": "cpp/library/experimental/ranges/range/BoundedRange"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/range/Range",
+    "cppdoc": "cpp/library/experimental/ranges/range/Range"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/range/ForwardRange",
+    "cppdoc": "cpp/library/experimental/ranges/range/ForwardRange"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/range/RandomAccessRange",
+    "cppdoc": "cpp/library/experimental/ranges/range/RandomAccessRange"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/range/iterator_t",
+    "cppdoc": "cpp/library/experimental/ranges/range/iterator_t"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/range/SizedRange",
+    "cppdoc": "cpp/library/experimental/ranges/range/SizedRange"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/range/InputRange",
+    "cppdoc": "cpp/library/experimental/ranges/range/InputRange"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/range/View",
+    "cppdoc": "cpp/library/experimental/ranges/range/View"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/range/OutputRange",
+    "cppdoc": "cpp/library/experimental/ranges/range/OutputRange"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/Permutable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/Permutable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/value_type",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/value_type"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/BidirectionalIterator",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/BidirectionalIterator"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/ForwardIterator",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/ForwardIterator"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/indirect_result_of",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/indirect_result_of"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/prev",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/prev"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/next",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/next"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/reference_t",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/reference_t"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/projected",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/projected"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/Sentinel",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/Sentinel"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/IndirectlyCopyable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/IndirectlyCopyable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/Incrementable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/Incrementable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/IndirectlyMovableStorable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/IndirectlyMovableStorable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/IndirectStrictWeakOrder",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/IndirectStrictWeakOrder"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/Sortable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/Sortable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/IndirectlySwappable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/IndirectlySwappable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/RandomAccessIterator",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/RandomAccessIterator"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/Mergeable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/Mergeable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/IndirectUnaryPredicate",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/IndirectUnaryPredicate"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/IndirectRelation",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/IndirectRelation"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/IndirectlyCopyableStorable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/IndirectlyCopyableStorable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/Readable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/Readable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/iterator_tags",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/iterator_tags"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/SizedSentinel",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/SizedSentinel"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/IndirectlyComparable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/IndirectlyComparable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/WeaklyIncrementable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/WeaklyIncrementable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/IndirectlyMovable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/IndirectlyMovable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/Writable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/Writable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/distance",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/distance"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/InputIterator",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/InputIterator"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/difference_type",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/difference_type"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/Iterator",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/Iterator"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/OutputIterator",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/OutputIterator"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/dangling",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/dangling"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/IndirectUnaryInvocable",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/IndirectUnaryInvocable"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/advance",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/advance"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/iterator/iterator_category",
+    "cppdoc": "cpp/library/experimental/ranges/iterator/iterator_category"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/tagged_pair",
+    "cppdoc": "cpp/library/experimental/ranges/utility/tagged_pair"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/exchange",
+    "cppdoc": "cpp/library/experimental/ranges/utility/exchange"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/make_tagged_tuple",
+    "cppdoc": "cpp/library/experimental/ranges/utility/make_tagged_tuple"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/tagged",
+    "cppdoc": "cpp/library/experimental/ranges/utility/tagged"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/TagSpecifier",
+    "cppdoc": "cpp/library/experimental/ranges/utility/TagSpecifier"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/swap",
+    "cppdoc": "cpp/library/experimental/ranges/utility/swap"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/tagged_tuple",
+    "cppdoc": "cpp/library/experimental/ranges/utility/tagged_tuple"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/make_tagged_pair",
+    "cppdoc": "cpp/library/experimental/ranges/utility/make_tagged_pair"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/TaggedType",
+    "cppdoc": "cpp/library/experimental/ranges/utility/TaggedType"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/tagged/swap2",
+    "cppdoc": "cpp/library/experimental/ranges/utility/tagged/swap2"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/tagged/tagged",
+    "cppdoc": "cpp/library/experimental/ranges/utility/tagged/tagged"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/tagged/swap",
+    "cppdoc": "cpp/library/experimental/ranges/utility/tagged/swap"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/tagged/tuple_size",
+    "cppdoc": "cpp/library/experimental/ranges/utility/tagged/tuple_size"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/tagged/tuple_element",
+    "cppdoc": "cpp/library/experimental/ranges/utility/tagged/tuple_element"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/utility/tagged/operator=",
+    "cppdoc": "cpp/library/experimental/ranges/utility/tagged/operator="
+  },
+  {
+    "cppref": "cpp/experimental/ranges/functional/invoke",
+    "cppdoc": "cpp/library/experimental/ranges/functional/invoke"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/functional/not_equal_to",
+    "cppdoc": "cpp/library/experimental/ranges/functional/not_equal_to"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/functional/equal_to",
+    "cppdoc": "cpp/library/experimental/ranges/functional/equal_to"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/functional/less",
+    "cppdoc": "cpp/library/experimental/ranges/functional/less"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/functional/identity",
+    "cppdoc": "cpp/library/experimental/ranges/functional/identity"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/functional/greater_equal",
+    "cppdoc": "cpp/library/experimental/ranges/functional/greater_equal"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/functional/less_equal",
+    "cppdoc": "cpp/library/experimental/ranges/functional/less_equal"
+  },
+  {
+    "cppref": "cpp/experimental/ranges/functional/greater",
+    "cppdoc": "cpp/library/experimental/ranges/functional/greater"
+  },
+  {
+    "cppref": "cpp/experimental/source_location/file_name",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/source_location/file_name"
+  },
+  {
+    "cppref": "cpp/experimental/source_location/source_location",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/source_location/source_location"
+  },
+  {
+    "cppref": "cpp/experimental/source_location/line",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/source_location/line"
+  },
+  {
+    "cppref": "cpp/experimental/source_location/current",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/source_location/current"
+  },
+  {
+    "cppref": "cpp/experimental/source_location/function_name",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/source_location/function_name"
+  },
+  {
+    "cppref": "cpp/experimental/source_location/column",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/source_location/column"
+  },
+  {
+    "cppref": "cpp/experimental/multiset/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/hermite",
+    "cppdoc": "cpp/library/experimental/special_math/hermite"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/comp_ellint_2",
+    "cppdoc": "cpp/library/experimental/special_math/comp_ellint_2"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/assoc_legendre",
+    "cppdoc": "cpp/library/experimental/special_math/assoc_legendre"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/beta",
+    "cppdoc": "cpp/library/experimental/special_math/beta"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/assoc_laguerre",
+    "cppdoc": "cpp/library/experimental/special_math/assoc_laguerre"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/riemann_zeta",
+    "cppdoc": "cpp/library/experimental/special_math/riemann_zeta"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/comp_ellint_1",
+    "cppdoc": "cpp/library/experimental/special_math/comp_ellint_1"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/legendre",
+    "cppdoc": "cpp/library/experimental/special_math/legendre"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/laguerre",
+    "cppdoc": "cpp/library/experimental/special_math/laguerre"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/comp_ellint_3",
+    "cppdoc": "cpp/library/experimental/special_math/comp_ellint_3"
+  },
+  {
+    "cppref": "cpp/experimental/special_functions/expint",
+    "cppdoc": "cpp/library/experimental/special_math/expint"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_weak_ptr/exchange",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_weak_ptr/exchange"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_weak_ptr/operator_weak_ptr",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_weak_ptr/operator_weak_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_weak_ptr/compare_exchange",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_weak_ptr/compare_exchange"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_weak_ptr/is_lock_free",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_weak_ptr/is_lock_free"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_weak_ptr/atomic_weak_ptr",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_weak_ptr/atomic_weak_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_weak_ptr/operator=",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_weak_ptr/operator="
+  },
+  {
+    "cppref": "cpp/experimental/atomic_weak_ptr/store",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_weak_ptr/store"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_weak_ptr/load",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_weak_ptr/load"
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource/get_deleter",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource/get_deleter"
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource/deduction_guides",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource/deduction_guides"
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource/reset",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource/reset"
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource/operator_star_",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource/operator_star_"
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource/release",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource/release"
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource/~unique_resource",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource/~unique_resource"
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource/get",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource/get"
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource/make_unique_resource_checked",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource/make_unique_resource_checked"
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource/operator=",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource/operator="
+  },
+  {
+    "cppref": "cpp/experimental/unique_resource/unique_resource",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/unique_resource/unique_resource"
+  },
+  {
+    "cppref": "cpp/experimental/function/get_memory_resource",
+    "cppdoc": "cpp/library/experimental/memory/get_memory_resource"
+  },
+  {
+    "cppref": "cpp/experimental/function/swap2",
+    "cppdoc": "cpp/library/experimental/memory/swap2"
+  },
+  {
+    "cppref": "cpp/experimental/function/swap",
+    "cppdoc": "cpp/library/experimental/memory/swap"
+  },
+  {
+    "cppref": "cpp/experimental/function/function",
+    "cppdoc": "cpp/library/experimental/memory/function"
+  },
+  {
+    "cppref": "cpp/experimental/function/operator_cmp",
+    "cppdoc": "cpp/library/experimental/memory/operator_cmp"
+  },
+  {
+    "cppref": "cpp/experimental/function/get_allocator",
+    "cppdoc": "cpp/library/experimental/memory/get_allocator"
+  },
+  {
+    "cppref": "cpp/experimental/function/operator=",
+    "cppdoc": "cpp/library/experimental/memory/operator="
+  },
+  {
+    "cppref": "cpp/experimental/function/uses_allocator",
+    "cppdoc": "cpp/library/experimental/memory/uses_allocator"
+  },
+  {
+    "cppref": "cpp/experimental/concurrency/promise",
+    "cppdoc": "cpp/library/experimental/concurrency/promise"
+  },
+  {
+    "cppref": "cpp/experimental/concurrency/packaged_task",
+    "cppdoc": "cpp/library/experimental/concurrency/packaged_task"
+  },
+  {
+    "cppref": "cpp/experimental/deque/erase",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase"
+  },
+  {
+    "cppref": "cpp/experimental/deque/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/scope_success/scope_success",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_success/scope_success"
+  },
+  {
+    "cppref": "cpp/experimental/scope_success/deduction_guides",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_success/deduction_guides"
+  },
+  {
+    "cppref": "cpp/experimental/scope_success/release",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_success/release"
+  },
+  {
+    "cppref": "cpp/experimental/scope_success/~scope_success",
+    "cppdoc": "cpp/library/experimental/lib_extensions_3/scope_success/~scope_success"
+  },
+  {
+    "cppref": "cpp/experimental/list/erase",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase"
+  },
+  {
+    "cppref": "cpp/experimental/list/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/vector/erase",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase"
+  },
+  {
+    "cppref": "cpp/experimental/vector/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/multimap/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/experimental/optional/make_optional",
+    "cppdoc": "cpp/library/experimental/memory/optional/make_optional"
+  },
+  {
+    "cppref": "cpp/experimental/optional/nullopt_t",
+    "cppdoc": "cpp/library/experimental/memory/optional/nullopt_t"
+  },
+  {
+    "cppref": "cpp/experimental/optional/emplace",
+    "cppdoc": "cpp/library/experimental/memory/optional/emplace"
+  },
+  {
+    "cppref": "cpp/experimental/optional/value_or",
+    "cppdoc": "cpp/library/experimental/memory/optional/value_or"
+  },
+  {
+    "cppref": "cpp/experimental/optional/hash",
+    "cppdoc": "cpp/library/experimental/memory/optional/hash"
+  },
+  {
+    "cppref": "cpp/experimental/optional/nullopt",
+    "cppdoc": "cpp/library/experimental/memory/optional/nullopt"
+  },
+  {
+    "cppref": "cpp/experimental/optional/swap2",
+    "cppdoc": "cpp/library/experimental/memory/optional/swap2"
+  },
+  {
+    "cppref": "cpp/experimental/optional/bad_optional_access",
+    "cppdoc": "cpp/library/experimental/memory/optional/bad_optional_access"
+  },
+  {
+    "cppref": "cpp/experimental/optional/in_place",
+    "cppdoc": "cpp/library/experimental/memory/optional/in_place"
+  },
+  {
+    "cppref": "cpp/experimental/optional/~optional",
+    "cppdoc": "cpp/library/experimental/memory/optional/~optional"
+  },
+  {
+    "cppref": "cpp/experimental/optional/swap",
+    "cppdoc": "cpp/library/experimental/memory/optional/swap"
+  },
+  {
+    "cppref": "cpp/experimental/optional/value",
+    "cppdoc": "cpp/library/experimental/memory/optional/value"
+  },
+  {
+    "cppref": "cpp/experimental/optional/operator_star_",
+    "cppdoc": "cpp/library/experimental/memory/optional/operator_star_"
+  },
+  {
+    "cppref": "cpp/experimental/optional/in_place_t",
+    "cppdoc": "cpp/library/experimental/memory/optional/in_place_t"
+  },
+  {
+    "cppref": "cpp/experimental/optional/operator_cmp",
+    "cppdoc": "cpp/library/experimental/memory/optional/operator_cmp"
+  },
+  {
+    "cppref": "cpp/experimental/optional/operator_bool",
+    "cppdoc": "cpp/library/experimental/memory/optional/operator_bool"
+  },
+  {
+    "cppref": "cpp/experimental/optional/operator=",
+    "cppdoc": "cpp/library/experimental/memory/optional/operator="
+  },
+  {
+    "cppref": "cpp/experimental/optional/optional",
+    "cppdoc": "cpp/library/experimental/memory/optional/optional"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_shared_ptr/exchange",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_shared_ptr/exchange"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_shared_ptr/compare_exchange",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_shared_ptr/compare_exchange"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_shared_ptr/atomic_shared_ptr",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_shared_ptr/atomic_shared_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_shared_ptr/is_lock_free",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_shared_ptr/is_lock_free"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_shared_ptr/operator_shared_ptr",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_shared_ptr/operator_shared_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_shared_ptr/operator=",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_shared_ptr/operator="
+  },
+  {
+    "cppref": "cpp/experimental/atomic_shared_ptr/store",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_shared_ptr/store"
+  },
+  {
+    "cppref": "cpp/experimental/atomic_shared_ptr/load",
+    "cppdoc": "cpp/library/experimental/concurrency/atomic_shared_ptr/load"
+  },
+  {
+    "cppref": "cpp/experimental/synchronized_pool_resource/do_is_equal",
+    "cppdoc": "cpp/library/experimental/memory/synchronized_pool_resource/do_is_equal"
+  },
+  {
+    "cppref": "cpp/experimental/synchronized_pool_resource/do_deallocate",
+    "cppdoc": "cpp/library/experimental/memory/synchronized_pool_resource/do_deallocate"
+  },
+  {
+    "cppref": "cpp/experimental/synchronized_pool_resource/do_allocate",
+    "cppdoc": "cpp/library/experimental/memory/synchronized_pool_resource/do_allocate"
+  },
+  {
+    "cppref": "cpp/experimental/synchronized_pool_resource/options",
+    "cppdoc": "cpp/library/experimental/memory/synchronized_pool_resource/options"
+  },
+  {
+    "cppref": "cpp/experimental/synchronized_pool_resource/release",
+    "cppdoc": "cpp/library/experimental/memory/synchronized_pool_resource/release"
+  },
+  {
+    "cppref": "cpp/experimental/synchronized_pool_resource/~synchronized_pool_resource",
+    "cppdoc": "cpp/library/experimental/memory/synchronized_pool_resource/~synchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/experimental/synchronized_pool_resource/synchronized_pool_resource",
+    "cppdoc": "cpp/library/experimental/memory/synchronized_pool_resource/synchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/experimental/synchronized_pool_resource/upstream_resource",
+    "cppdoc": "cpp/library/experimental/memory/synchronized_pool_resource/upstream_resource"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/hash",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/hash"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/cmp_func",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/cmp_func"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/swap2",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/swap2"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/swap",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/swap"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/operator_star_",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/operator_star_"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/get",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/get"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/operator_cmp",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/operator_cmp"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/propagate_const",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/propagate_const"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/operator_bool",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/operator_bool"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/operator=",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/operator="
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/get_underlying",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/get_underlying"
+  },
+  {
+    "cppref": "cpp/experimental/propagate_const/operator_element_type_star_",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/propagate_const/operator_element_type_star_"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/remove_prefix",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/remove_prefix"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/operator_at",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/operator_at"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/at",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/at"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/back",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/back"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/npos",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/npos"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/empty",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/empty"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/find",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/find"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/hash",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/hash"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/max_size",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/max_size"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/size",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/size"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/copy",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/copy"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/find_first_not_of",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/find_first_not_of"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/to_string",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/to_string"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/end",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/end"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/rend",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/rend"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/begin",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/begin"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/substr",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/substr"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/find_last_not_of",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/find_last_not_of"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/swap",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/swap"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/front",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/front"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/rfind",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/rfind"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/rbegin",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/rbegin"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/compare",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/compare"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/basic_string_view",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/basic_string_view"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/operator_cmp",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/operator_cmp"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/find_last_of",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/find_last_of"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/find_first_of",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/find_first_of"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/operator=",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/operator="
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/data",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/data"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/operator_ltlt",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/experimental/basic_string_view/remove_suffix",
+    "cppdoc": "cpp/library/experimental/memory/basic_string_view/remove_suffix"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/make_observer",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/make_observer"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/hash",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/hash"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/operator_pointer",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/operator_pointer"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/observer_ptr",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/observer_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/swap2",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/swap2"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/reset",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/reset"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/swap",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/swap"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/operator_star_",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/operator_star_"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/release",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/release"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/get",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/get"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/operator_cmp",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/operator_cmp"
+  },
+  {
+    "cppref": "cpp/experimental/observer_ptr/operator_bool",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/observer_ptr/operator_bool"
+  },
+  {
+    "cppref": "cpp/experimental/unordered_multiset/erase_if",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/erase_if"
+  },
+  {
+    "cppref": "cpp/error/get_unexpected",
+    "cppdoc": "cpp/library/error/get_unexpected"
+  },
+  {
+    "cppref": "cpp/error/make_exception_ptr",
+    "cppdoc": "cpp/library/error/make_exception_ptr"
+  },
+  {
+    "cppref": "cpp/error/nested_exception",
+    "cppdoc": "cpp/library/error/nested_exception"
+  },
+  {
+    "cppref": "cpp/error/length_error",
+    "cppdoc": "cpp/library/error/length_error"
+  },
+  {
+    "cppref": "cpp/error/set_unexpected",
+    "cppdoc": "cpp/library/error/set_unexpected"
+  },
+  {
+    "cppref": "cpp/error/get_terminate",
+    "cppdoc": "cpp/library/error/get_terminate"
+  },
+  {
+    "cppref": "cpp/error/system_category",
+    "cppdoc": "cpp/library/error/system_category"
+  },
+  {
+    "cppref": "cpp/error/tx_exception",
+    "cppdoc": "cpp/library/error/tx_exception"
+  },
+  {
+    "cppref": "cpp/error/assert",
+    "cppdoc": "cpp/library/error/assert"
+  },
+  {
+    "cppref": "cpp/error/range_error",
+    "cppdoc": "cpp/library/error/range_error"
+  },
+  {
+    "cppref": "cpp/error/invalid_argument",
+    "cppdoc": "cpp/library/error/invalid_argument"
+  },
+  {
+    "cppref": "cpp/error/throw_with_nested",
+    "cppdoc": "cpp/library/error/throw_with_nested"
+  },
+  {
+    "cppref": "cpp/error/error_condition",
+    "cppdoc": "cpp/library/error/error_condition"
+  },
+  {
+    "cppref": "cpp/error/error_code",
+    "cppdoc": "cpp/library/error/error_code"
+  },
+  {
+    "cppref": "cpp/error/errno_macros",
+    "cppdoc": "cpp/library/error/errno_macros"
+  },
+  {
+    "cppref": "cpp/error/exception_ptr",
+    "cppdoc": "cpp/library/error/exception_ptr"
+  },
+  {
+    "cppref": "cpp/error/domain_error",
+    "cppdoc": "cpp/library/error/domain_error"
+  },
+  {
+    "cppref": "cpp/error/bad_exception",
+    "cppdoc": "cpp/library/error/bad_exception"
+  },
+  {
+    "cppref": "cpp/error/terminate",
+    "cppdoc": "cpp/library/error/terminate"
+  },
+  {
+    "cppref": "cpp/error/underflow_error",
+    "cppdoc": "cpp/library/error/underflow_error"
+  },
+  {
+    "cppref": "cpp/error/unexpected",
+    "cppdoc": "cpp/library/error/unexpected"
+  },
+  {
+    "cppref": "cpp/error/errno",
+    "cppdoc": "cpp/library/error/errno"
+  },
+  {
+    "cppref": "cpp/error/rethrow_exception",
+    "cppdoc": "cpp/library/error/rethrow_exception"
+  },
+  {
+    "cppref": "cpp/error/logic_error",
+    "cppdoc": "cpp/library/error/logic_error"
+  },
+  {
+    "cppref": "cpp/error/current_exception",
+    "cppdoc": "cpp/library/error/current_exception"
+  },
+  {
+    "cppref": "cpp/error/exception",
+    "cppdoc": "cpp/library/error/exception"
+  },
+  {
+    "cppref": "cpp/error/runtime_error",
+    "cppdoc": "cpp/library/error/runtime_error"
+  },
+  {
+    "cppref": "cpp/error/set_terminate",
+    "cppdoc": "cpp/library/error/set_terminate"
+  },
+  {
+    "cppref": "cpp/error/uncaught_exception",
+    "cppdoc": "cpp/library/error/uncaught_exception"
+  },
+  {
+    "cppref": "cpp/error/system_error",
+    "cppdoc": "cpp/library/error/system_error"
+  },
+  {
+    "cppref": "cpp/error/generic_category",
+    "cppdoc": "cpp/library/error/generic_category"
+  },
+  {
+    "cppref": "cpp/error/out_of_range",
+    "cppdoc": "cpp/library/error/out_of_range"
+  },
+  {
+    "cppref": "cpp/error/errc",
+    "cppdoc": "cpp/library/error/errc"
+  },
+  {
+    "cppref": "cpp/error/rethrow_if_nested",
+    "cppdoc": "cpp/library/error/rethrow_if_nested"
+  },
+  {
+    "cppref": "cpp/error/error_category",
+    "cppdoc": "cpp/library/error/error_category"
+  },
+  {
+    "cppref": "cpp/error/overflow_error",
+    "cppdoc": "cpp/library/error/overflow_error"
+  },
+  {
+    "cppref": "cpp/error/unexpected_handler",
+    "cppdoc": "cpp/library/error/unexpected_handler"
+  },
+  {
+    "cppref": "cpp/error/terminate_handler",
+    "cppdoc": "cpp/library/error/terminate_handler"
+  },
+  {
+    "cppref": "cpp/error/bad_exception/bad_exception",
+    "cppdoc": "cpp/library/error/bad_exception/bad_exception"
+  },
+  {
+    "cppref": "cpp/error/bad_exception/what",
+    "cppdoc": "cpp/library/error/bad_exception/what"
+  },
+  {
+    "cppref": "cpp/error/bad_exception/operator=",
+    "cppdoc": "cpp/library/error/bad_exception/operator="
+  },
+  {
+    "cppref": "cpp/error/system_error/what",
+    "cppdoc": "cpp/library/error/system_error/what"
+  },
+  {
+    "cppref": "cpp/error/system_error/code",
+    "cppdoc": "cpp/library/error/system_error/code"
+  },
+  {
+    "cppref": "cpp/error/system_error/system_error",
+    "cppdoc": "cpp/library/error/system_error/system_error"
+  },
+  {
+    "cppref": "cpp/error/system_error/operator=",
+    "cppdoc": "cpp/library/error/system_error/operator="
+  },
+  {
+    "cppref": "cpp/error/exception/get_unexpected",
+    "cppdoc": "cpp/library/error/exception/get_unexpected"
+  },
+  {
+    "cppref": "cpp/error/exception/set_unexpected",
+    "cppdoc": "cpp/library/error/exception/set_unexpected"
+  },
+  {
+    "cppref": "cpp/error/exception/~exception",
+    "cppdoc": "cpp/library/error/exception/~exception"
+  },
+  {
+    "cppref": "cpp/error/exception/what",
+    "cppdoc": "cpp/library/error/exception/what"
+  },
+  {
+    "cppref": "cpp/error/exception/exception",
+    "cppdoc": "cpp/library/error/exception/exception"
+  },
+  {
+    "cppref": "cpp/error/exception/uncaught_exception",
+    "cppdoc": "cpp/library/error/exception/uncaught_exception"
+  },
+  {
+    "cppref": "cpp/error/exception/operator=",
+    "cppdoc": "cpp/library/error/exception/operator="
+  },
+  {
+    "cppref": "cpp/error/exception/unexpected_handler",
+    "cppdoc": "cpp/library/error/exception/unexpected_handler"
+  },
+  {
+    "cppref": "cpp/error/errc/is_error_condition_enum",
+    "cppdoc": "cpp/library/error/errc/is_error_condition_enum"
+  },
+  {
+    "cppref": "cpp/error/errc/make_error_code",
+    "cppdoc": "cpp/library/error/errc/make_error_code"
+  },
+  {
+    "cppref": "cpp/error/errc/make_error_condition",
+    "cppdoc": "cpp/library/error/errc/make_error_condition"
+  },
+  {
+    "cppref": "cpp/error/error_category/~error_category",
+    "cppdoc": "cpp/library/error/error_category/~error_category"
+  },
+  {
+    "cppref": "cpp/error/error_category/default_error_condition",
+    "cppdoc": "cpp/library/error/error_category/default_error_condition"
+  },
+  {
+    "cppref": "cpp/error/error_category/name",
+    "cppdoc": "cpp/library/error/error_category/name"
+  },
+  {
+    "cppref": "cpp/error/error_category/operator_cmp",
+    "cppdoc": "cpp/library/error/error_category/operator_cmp"
+  },
+  {
+    "cppref": "cpp/error/error_category/message",
+    "cppdoc": "cpp/library/error/error_category/message"
+  },
+  {
+    "cppref": "cpp/error/error_category/equivalent",
+    "cppdoc": "cpp/library/error/error_category/equivalent"
+  },
+  {
+    "cppref": "cpp/error/error_category/error_category",
+    "cppdoc": "cpp/library/error/error_category/error_category"
+  },
+  {
+    "cppref": "cpp/error/error_condition/assign",
+    "cppdoc": "cpp/library/error/error_condition/assign"
+  },
+  {
+    "cppref": "cpp/error/error_condition/category",
+    "cppdoc": "cpp/library/error/error_condition/category"
+  },
+  {
+    "cppref": "cpp/error/error_condition/hash",
+    "cppdoc": "cpp/library/error/error_condition/hash"
+  },
+  {
+    "cppref": "cpp/error/error_condition/is_error_condition_enum",
+    "cppdoc": "cpp/library/error/error_condition/is_error_condition_enum"
+  },
+  {
+    "cppref": "cpp/error/error_condition/error_condition",
+    "cppdoc": "cpp/library/error/error_condition/error_condition"
+  },
+  {
+    "cppref": "cpp/error/error_condition/value",
+    "cppdoc": "cpp/library/error/error_condition/value"
+  },
+  {
+    "cppref": "cpp/error/error_condition/operator_cmp",
+    "cppdoc": "cpp/library/error/error_condition/operator_cmp"
+  },
+  {
+    "cppref": "cpp/error/error_condition/message",
+    "cppdoc": "cpp/library/error/error_condition/message"
+  },
+  {
+    "cppref": "cpp/error/error_condition/operator_bool",
+    "cppdoc": "cpp/library/error/error_condition/operator_bool"
+  },
+  {
+    "cppref": "cpp/error/error_condition/operator=",
+    "cppdoc": "cpp/library/error/error_condition/operator="
+  },
+  {
+    "cppref": "cpp/error/error_condition/clear",
+    "cppdoc": "cpp/library/error/error_condition/clear"
+  },
+  {
+    "cppref": "cpp/error/nested_exception/nested_exception",
+    "cppdoc": "cpp/library/error/nested_exception/nested_exception"
+  },
+  {
+    "cppref": "cpp/error/nested_exception/~nested_exception",
+    "cppdoc": "cpp/library/error/nested_exception/~nested_exception"
+  },
+  {
+    "cppref": "cpp/error/nested_exception/nested_ptr",
+    "cppdoc": "cpp/library/error/nested_exception/nested_ptr"
+  },
+  {
+    "cppref": "cpp/error/nested_exception/operator=",
+    "cppdoc": "cpp/library/error/nested_exception/operator="
+  },
+  {
+    "cppref": "cpp/error/nested_exception/rethrow_nested",
+    "cppdoc": "cpp/library/error/nested_exception/rethrow_nested"
+  },
+  {
+    "cppref": "cpp/error/error_code/assign",
+    "cppdoc": "cpp/library/error/error_code/assign"
+  },
+  {
+    "cppref": "cpp/error/error_code/category",
+    "cppdoc": "cpp/library/error/error_code/category"
+  },
+  {
+    "cppref": "cpp/error/error_code/hash",
+    "cppdoc": "cpp/library/error/error_code/hash"
+  },
+  {
+    "cppref": "cpp/error/error_code/default_error_condition",
+    "cppdoc": "cpp/library/error/error_code/default_error_condition"
+  },
+  {
+    "cppref": "cpp/error/error_code/error_code",
+    "cppdoc": "cpp/library/error/error_code/error_code"
+  },
+  {
+    "cppref": "cpp/error/error_code/value",
+    "cppdoc": "cpp/library/error/error_code/value"
+  },
+  {
+    "cppref": "cpp/error/error_code/operator_cmp",
+    "cppdoc": "cpp/library/error/error_code/operator_cmp"
+  },
+  {
+    "cppref": "cpp/error/error_code/message",
+    "cppdoc": "cpp/library/error/error_code/message"
+  },
+  {
+    "cppref": "cpp/error/error_code/operator_bool",
+    "cppdoc": "cpp/library/error/error_code/operator_bool"
+  },
+  {
+    "cppref": "cpp/error/error_code/operator=",
+    "cppdoc": "cpp/library/error/error_code/operator="
+  },
+  {
+    "cppref": "cpp/error/error_code/operator_ltlt",
+    "cppdoc": "cpp/library/error/error_code/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/error/error_code/is_error_code_enum",
+    "cppdoc": "cpp/library/error/error_code/is_error_code_enum"
+  },
+  {
+    "cppref": "cpp/error/error_code/clear",
+    "cppdoc": "cpp/library/error/error_code/clear"
+  },
+  {
+    "cppref": "cpp/types/is_trivially_copyable",
+    "cppdoc": "cpp/library/meta/is_trivially_copyable"
+  },
+  {
+    "cppref": "cpp/types/alignment_of",
+    "cppdoc": "cpp/library/meta/alignment_of"
+  },
+  {
+    "cppref": "cpp/types/extent",
+    "cppdoc": "cpp/library/meta/extent"
+  },
+  {
+    "cppref": "cpp/types/is_member_function_pointer",
+    "cppdoc": "cpp/library/meta/is_member_function_pointer"
+  },
+  {
+    "cppref": "cpp/types/reference_converts_from_temporary",
+    "cppdoc": "cpp/library/meta/reference_converts_from_temporary"
+  },
+  {
+    "cppref": "cpp/types/decay",
+    "cppdoc": "cpp/library/meta/decay"
+  },
+  {
+    "cppref": "cpp/types/remove_pointer",
+    "cppdoc": "cpp/library/meta/remove_pointer"
+  },
+  {
+    "cppref": "cpp/types/is_final",
+    "cppdoc": "cpp/library/meta/is_final"
+  },
+  {
+    "cppref": "cpp/types/is_standard_layout",
+    "cppdoc": "cpp/library/meta/is_standard_layout"
+  },
+  {
+    "cppref": "cpp/types/is_lvalue_reference",
+    "cppdoc": "cpp/library/meta/is_lvalue_reference"
+  },
+  {
+    "cppref": "cpp/types/void_t",
+    "cppdoc": "cpp/library/meta/void_t"
+  },
+  {
+    "cppref": "cpp/types/is_object",
+    "cppdoc": "cpp/library/meta/is_object"
+  },
+  {
+    "cppref": "cpp/types/conditional",
+    "cppdoc": "cpp/library/meta/conditional"
+  },
+  {
+    "cppref": "cpp/types/is_trivial",
+    "cppdoc": "cpp/library/meta/is_trivial"
+  },
+  {
+    "cppref": "cpp/types/make_unsigned",
+    "cppdoc": "cpp/library/meta/make_unsigned"
+  },
+  {
+    "cppref": "cpp/types/is_move_constructible",
+    "cppdoc": "cpp/library/meta/is_move_constructible"
+  },
+  {
+    "cppref": "cpp/types/enable_if",
+    "cppdoc": "cpp/library/meta/enable_if"
+  },
+  {
+    "cppref": "cpp/types/is_rvalue_reference",
+    "cppdoc": "cpp/library/meta/is_rvalue_reference"
+  },
+  {
+    "cppref": "cpp/types/is_pointer",
+    "cppdoc": "cpp/library/meta/is_pointer"
+  },
+  {
+    "cppref": "cpp/types/is_assignable",
+    "cppdoc": "cpp/library/meta/is_assignable"
+  },
+  {
+    "cppref": "cpp/types/is_const",
+    "cppdoc": "cpp/library/meta/is_const"
+  },
+  {
+    "cppref": "cpp/types/add_cv",
+    "cppdoc": "cpp/library/meta/add_cv"
+  },
+  {
+    "cppref": "cpp/types/is_pointer_interconvertible_with_class",
+    "cppdoc": "cpp/library/meta/is_pointer_interconvertible_with_class"
+  },
+  {
+    "cppref": "cpp/types/type_identity",
+    "cppdoc": "cpp/library/meta/type_identity"
+  },
+  {
+    "cppref": "cpp/types/is_polymorphic",
+    "cppdoc": "cpp/library/meta/is_polymorphic"
+  },
+  {
+    "cppref": "cpp/types/remove_all_extents",
+    "cppdoc": "cpp/library/meta/remove_all_extents"
+  },
+  {
+    "cppref": "cpp/types/is_copy_assignable",
+    "cppdoc": "cpp/library/meta/is_copy_assignable"
+  },
+  {
+    "cppref": "cpp/types/is_signed",
+    "cppdoc": "cpp/library/meta/is_signed"
+  },
+  {
+    "cppref": "cpp/types/is_default_constructible",
+    "cppdoc": "cpp/library/meta/is_default_constructible"
+  },
+  {
+    "cppref": "cpp/types/add_reference",
+    "cppdoc": "cpp/library/meta/add_reference"
+  },
+  {
+    "cppref": "cpp/types/is_convertible",
+    "cppdoc": "cpp/library/meta/is_convertible"
+  },
+  {
+    "cppref": "cpp/types/is_fundamental",
+    "cppdoc": "cpp/library/meta/is_fundamental"
+  },
+  {
+    "cppref": "cpp/types/result_of",
+    "cppdoc": "cpp/library/meta/result_of"
+  },
+  {
+    "cppref": "cpp/types/is_floating_point",
+    "cppdoc": "cpp/library/meta/is_floating_point"
+  },
+  {
+    "cppref": "cpp/types/negation",
+    "cppdoc": "cpp/library/meta/negation"
+  },
+  {
+    "cppref": "cpp/types/is_reference",
+    "cppdoc": "cpp/library/meta/is_reference"
+  },
+  {
+    "cppref": "cpp/types/is_move_assignable",
+    "cppdoc": "cpp/library/meta/is_move_assignable"
+  },
+  {
+    "cppref": "cpp/types/is_pointer_interconvertible_base_of",
+    "cppdoc": "cpp/library/meta/is_pointer_interconvertible_base_of"
+  },
+  {
+    "cppref": "cpp/types/has_virtual_destructor",
+    "cppdoc": "cpp/library/meta/has_virtual_destructor"
+  },
+  {
+    "cppref": "cpp/types/is_aggregate",
+    "cppdoc": "cpp/library/meta/is_aggregate"
+  },
+  {
+    "cppref": "cpp/types/is_abstract",
+    "cppdoc": "cpp/library/meta/is_abstract"
+  },
+  {
+    "cppref": "cpp/types/is_base_of",
+    "cppdoc": "cpp/library/meta/is_base_of"
+  },
+  {
+    "cppref": "cpp/types/is_member_pointer",
+    "cppdoc": "cpp/library/meta/is_member_pointer"
+  },
+  {
+    "cppref": "cpp/types/has_unique_object_representations",
+    "cppdoc": "cpp/library/meta/has_unique_object_representations"
+  },
+  {
+    "cppref": "cpp/types/is_within_lifetime",
+    "cppdoc": "cpp/library/utility/is_within_lifetime"
+  },
+  {
+    "cppref": "cpp/types/is_scoped_enum",
+    "cppdoc": "cpp/library/meta/is_scoped_enum"
+  },
+  {
+    "cppref": "cpp/types/is_null_pointer",
+    "cppdoc": "cpp/library/meta/is_null_pointer"
+  },
+  {
+    "cppref": "cpp/types/remove_cvref",
+    "cppdoc": "cpp/library/meta/remove_cvref"
+  },
+  {
+    "cppref": "cpp/types/is_compound",
+    "cppdoc": "cpp/library/meta/is_compound"
+  },
+  {
+    "cppref": "cpp/types/is_enum",
+    "cppdoc": "cpp/library/meta/is_enum"
+  },
+  {
+    "cppref": "cpp/types/underlying_type",
+    "cppdoc": "cpp/library/meta/underlying_type"
+  },
+  {
+    "cppref": "cpp/types/is_swappable",
+    "cppdoc": "cpp/library/meta/is_swappable"
+  },
+  {
+    "cppref": "cpp/types/is_unsigned",
+    "cppdoc": "cpp/library/meta/is_unsigned"
+  },
+  {
+    "cppref": "cpp/types/is_member_object_pointer",
+    "cppdoc": "cpp/library/meta/is_member_object_pointer"
+  },
+  {
+    "cppref": "cpp/types/common_type",
+    "cppdoc": "cpp/library/meta/common_type"
+  },
+  {
+    "cppref": "cpp/types/make_signed",
+    "cppdoc": "cpp/library/meta/make_signed"
+  },
+  {
+    "cppref": "cpp/types/is_layout_compatible",
+    "cppdoc": "cpp/library/meta/is_layout_compatible"
+  },
+  {
+    "cppref": "cpp/types/is_same",
+    "cppdoc": "cpp/library/meta/is_same"
+  },
+  {
+    "cppref": "cpp/types/is_copy_constructible",
+    "cppdoc": "cpp/library/meta/is_copy_constructible"
+  },
+  {
+    "cppref": "cpp/types/remove_reference",
+    "cppdoc": "cpp/library/meta/remove_reference"
+  },
+  {
+    "cppref": "cpp/types/is_class",
+    "cppdoc": "cpp/library/meta/is_class"
+  },
+  {
+    "cppref": "cpp/types/is_unbounded_array",
+    "cppdoc": "cpp/library/meta/is_unbounded_array"
+  },
+  {
+    "cppref": "cpp/types/is_scalar",
+    "cppdoc": "cpp/library/meta/is_scalar"
+  },
+  {
+    "cppref": "cpp/types/endian",
+    "cppdoc": "cpp/library/utility/bit/endian"
+  },
+  {
+    "cppref": "cpp/types/conjunction",
+    "cppdoc": "cpp/library/meta/conjunction"
+  },
+  {
+    "cppref": "cpp/types/is_empty",
+    "cppdoc": "cpp/library/meta/is_empty"
+  },
+  {
+    "cppref": "cpp/types/is_union",
+    "cppdoc": "cpp/library/meta/is_union"
+  },
+  {
+    "cppref": "cpp/types/is_bounded_array",
+    "cppdoc": "cpp/library/meta/is_bounded_array"
+  },
+  {
+    "cppref": "cpp/types/is_destructible",
+    "cppdoc": "cpp/library/meta/is_destructible"
+  },
+  {
+    "cppref": "cpp/types/is_function",
+    "cppdoc": "cpp/library/meta/is_function"
+  },
+  {
+    "cppref": "cpp/types/integral_constant",
+    "cppdoc": "cpp/library/meta/integral_constant"
+  },
+  {
+    "cppref": "cpp/types/is_void",
+    "cppdoc": "cpp/library/meta/is_void"
+  },
+  {
+    "cppref": "cpp/types/remove_extent",
+    "cppdoc": "cpp/library/meta/remove_extent"
+  },
+  {
+    "cppref": "cpp/types/is_implicit_lifetime",
+    "cppdoc": "cpp/library/meta/is_implicit_lifetime"
+  },
+  {
+    "cppref": "cpp/types/is_constant_evaluated",
+    "cppdoc": "cpp/library/utility/is_constant_evaluated"
+  },
+  {
+    "cppref": "cpp/types/is_arithmetic",
+    "cppdoc": "cpp/library/meta/is_arithmetic"
+  },
+  {
+    "cppref": "cpp/types/is_literal_type",
+    "cppdoc": "cpp/library/meta/is_literal_type"
+  },
+  {
+    "cppref": "cpp/types/is_integral",
+    "cppdoc": "cpp/library/meta/is_integral"
+  },
+  {
+    "cppref": "cpp/types/is_array",
+    "cppdoc": "cpp/library/meta/is_array"
+  },
+  {
+    "cppref": "cpp/types/remove_cv",
+    "cppdoc": "cpp/library/meta/remove_cv"
+  },
+  {
+    "cppref": "cpp/types/common_reference",
+    "cppdoc": "cpp/library/meta/common_reference"
+  },
+  {
+    "cppref": "cpp/types/add_pointer",
+    "cppdoc": "cpp/library/meta/add_pointer"
+  },
+  {
+    "cppref": "cpp/types/is_volatile",
+    "cppdoc": "cpp/library/meta/is_volatile"
+  },
+  {
+    "cppref": "cpp/types/is_pod",
+    "cppdoc": "cpp/library/meta/is_pod"
+  },
+  {
+    "cppref": "cpp/types/is_virtual_base_of",
+    "cppdoc": "cpp/library/meta/is_virtual_base_of"
+  },
+  {
+    "cppref": "cpp/types/disjunction",
+    "cppdoc": "cpp/library/meta/disjunction"
+  },
+  {
+    "cppref": "cpp/types/rank",
+    "cppdoc": "cpp/library/meta/rank"
+  },
+  {
+    "cppref": "cpp/types/is_constructible",
+    "cppdoc": "cpp/library/meta/is_constructible"
+  },
+  {
+    "cppref": "cpp/types/aligned_storage",
+    "cppdoc": "cpp/library/meta/aligned_storage"
+  },
+  {
+    "cppref": "cpp/types/is_corresponding_member",
+    "cppdoc": "cpp/library/meta/is_corresponding_member"
+  },
+  {
+    "cppref": "cpp/types/reference_constructs_from_temporary",
+    "cppdoc": "cpp/library/meta/reference_constructs_from_temporary"
+  },
+  {
+    "cppref": "cpp/types/aligned_union",
+    "cppdoc": "cpp/library/meta/aligned_union"
+  },
+  {
+    "cppref": "cpp/types/is_invocable",
+    "cppdoc": "cpp/library/meta/is_invocable"
+  },
+  {
+    "cppref": "cpp/compiler_support/vendors",
+    "cppdoc": "cpp/library/compiler_support/vendors"
+  },
+  {
+    "cppref": "cpp/compiler_support/11",
+    "cppdoc": "cpp/library/compiler_support/11"
+  },
+  {
+    "cppref": "cpp/compiler_support/17",
+    "cppdoc": "cpp/library/compiler_support/17"
+  },
+  {
+    "cppref": "cpp/compiler_support/26",
+    "cppdoc": "cpp/library/compiler_support/26"
+  },
+  {
+    "cppref": "cpp/compiler_support/20",
+    "cppdoc": "cpp/library/compiler_support/20"
+  },
+  {
+    "cppref": "cpp/compiler_support/23",
+    "cppdoc": "cpp/library/compiler_support/23"
+  },
+  {
+    "cppref": "cpp/compiler_support/14",
+    "cppdoc": "cpp/library/compiler_support/14"
+  },
+  {
+    "cppref": "cpp/coroutine/generator",
+    "cppdoc": "cpp/library/ranges/generator"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/end",
+    "cppdoc": "cpp/library/ranges/generator/end"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/begin",
+    "cppdoc": "cpp/library/ranges/generator/begin"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/generator",
+    "cppdoc": "cpp/library/ranges/generator/generator"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/promise_type",
+    "cppdoc": "cpp/library/ranges/generator/promise_type"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/iterator",
+    "cppdoc": "cpp/library/ranges/generator/iterator"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/~generator",
+    "cppdoc": "cpp/library/ranges/generator/~generator"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/operator=",
+    "cppdoc": "cpp/library/ranges/generator/operator="
+  },
+  {
+    "cppref": "cpp/coroutine/generator/promise_type/operator_new",
+    "cppdoc": "cpp/library/ranges/generator/promise_type/operator_new"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/promise_type/yield_value",
+    "cppdoc": "cpp/library/ranges/generator/promise_type/yield_value"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/promise_type/unhandled_exception",
+    "cppdoc": "cpp/library/ranges/generator/promise_type/unhandled_exception"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/promise_type/get_return_object",
+    "cppdoc": "cpp/library/ranges/generator/promise_type/get_return_object"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/promise_type/final_suspend",
+    "cppdoc": "cpp/library/ranges/generator/promise_type/final_suspend"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/promise_type/initial_suspend",
+    "cppdoc": "cpp/library/ranges/generator/promise_type/initial_suspend"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/promise_type/return_void",
+    "cppdoc": "cpp/library/ranges/generator/promise_type/return_void"
+  },
+  {
+    "cppref": "cpp/coroutine/generator/promise_type/operator_delete",
+    "cppdoc": "cpp/library/ranges/generator/promise_type/operator_delete"
+  },
+  {
+    "cppref": "cpp/container/stack",
+    "cppdoc": "cpp/library/container/stack"
+  },
+  {
+    "cppref": "cpp/container/span",
+    "cppdoc": "cpp/library/container/span"
+  },
+  {
+    "cppref": "cpp/container/unordered_set",
+    "cppdoc": "cpp/library/container/unordered_set"
+  },
+  {
+    "cppref": "cpp/container/unordered_map",
+    "cppdoc": "cpp/library/container/unordered_map"
+  },
+  {
+    "cppref": "cpp/container/mdspan",
+    "cppdoc": "cpp/library/container/mdspan"
+  },
+  {
+    "cppref": "cpp/container/vector_bool",
+    "cppdoc": "cpp/library/container/vector_bool"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap",
+    "cppdoc": "cpp/library/container/unordered_multimap"
+  },
+  {
+    "cppref": "cpp/container/priority_queue",
+    "cppdoc": "cpp/library/container/priority_queue"
+  },
+  {
+    "cppref": "cpp/container/sorted_equivalent",
+    "cppdoc": "cpp/library/container/sorted_equivalent"
+  },
+  {
+    "cppref": "cpp/container/list",
+    "cppdoc": "cpp/library/container/list"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset",
+    "cppdoc": "cpp/library/container/unordered_multiset"
+  },
+  {
+    "cppref": "cpp/container/multiset",
+    "cppdoc": "cpp/library/container/multiset"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector",
+    "cppdoc": "cpp/library/container/inplace_vector"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap",
+    "cppdoc": "cpp/library/container/flat_multimap"
+  },
+  {
+    "cppref": "cpp/container/sorted_unique",
+    "cppdoc": "cpp/library/container/sorted_unique"
+  },
+  {
+    "cppref": "cpp/container/queue",
+    "cppdoc": "cpp/library/container/queue"
+  },
+  {
+    "cppref": "cpp/container/flat_set",
+    "cppdoc": "cpp/library/container/flat_set"
+  },
+  {
+    "cppref": "cpp/container/array",
+    "cppdoc": "cpp/library/container/array"
+  },
+  {
+    "cppref": "cpp/container/deque",
+    "cppdoc": "cpp/library/container/deque"
+  },
+  {
+    "cppref": "cpp/container/map",
+    "cppdoc": "cpp/library/container/map"
+  },
+  {
+    "cppref": "cpp/container/multimap",
+    "cppdoc": "cpp/library/container/multimap"
+  },
+  {
+    "cppref": "cpp/container/forward_list",
+    "cppdoc": "cpp/library/container/forward_list"
+  },
+  {
+    "cppref": "cpp/container/node_handle",
+    "cppdoc": "cpp/library/container/node_handle"
+  },
+  {
+    "cppref": "cpp/container/set",
+    "cppdoc": "cpp/library/container/set"
+  },
+  {
+    "cppref": "cpp/container/flat_map",
+    "cppdoc": "cpp/library/container/flat_map"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset",
+    "cppdoc": "cpp/library/container/flat_multiset"
+  },
+  {
+    "cppref": "cpp/container/vector",
+    "cppdoc": "cpp/library/container/vector"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/bucket_count",
+    "cppdoc": "cpp/library/container/unordered_map/bucket_count"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/operator_at",
+    "cppdoc": "cpp/library/container/unordered_map/operator_at"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/end2",
+    "cppdoc": "cpp/library/container/unordered_map/end2"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/at",
+    "cppdoc": "cpp/library/container/unordered_map/at"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/try_emplace",
+    "cppdoc": "cpp/library/container/unordered_map/try_emplace"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/unordered_map",
+    "cppdoc": "cpp/library/container/unordered_map/unordered_map"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/extract",
+    "cppdoc": "cpp/library/container/unordered_map/extract"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/insert",
+    "cppdoc": "cpp/library/container/unordered_map/insert"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/emplace",
+    "cppdoc": "cpp/library/container/unordered_map/emplace"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/empty",
+    "cppdoc": "cpp/library/container/unordered_map/empty"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/find",
+    "cppdoc": "cpp/library/container/unordered_map/find"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/equal_range",
+    "cppdoc": "cpp/library/container/unordered_map/equal_range"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/max_size",
+    "cppdoc": "cpp/library/container/unordered_map/max_size"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/size",
+    "cppdoc": "cpp/library/container/unordered_map/size"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/~unordered_map",
+    "cppdoc": "cpp/library/container/unordered_map/~unordered_map"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/swap2",
+    "cppdoc": "cpp/library/container/unordered_map/swap2"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/end",
+    "cppdoc": "cpp/library/container/unordered_map/end"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/load_factor",
+    "cppdoc": "cpp/library/container/unordered_map/load_factor"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/rehash",
+    "cppdoc": "cpp/library/container/unordered_map/rehash"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/begin2",
+    "cppdoc": "cpp/library/container/unordered_map/begin2"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/begin",
+    "cppdoc": "cpp/library/container/unordered_map/begin"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/deduction_guides",
+    "cppdoc": "cpp/library/container/unordered_map/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/max_bucket_count",
+    "cppdoc": "cpp/library/container/unordered_map/max_bucket_count"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/swap",
+    "cppdoc": "cpp/library/container/unordered_map/swap"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/reserve",
+    "cppdoc": "cpp/library/container/unordered_map/reserve"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/count",
+    "cppdoc": "cpp/library/container/unordered_map/count"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/erase",
+    "cppdoc": "cpp/library/container/unordered_map/erase"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/operator_cmp",
+    "cppdoc": "cpp/library/container/unordered_map/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/get_allocator",
+    "cppdoc": "cpp/library/container/unordered_map/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/contains",
+    "cppdoc": "cpp/library/container/unordered_map/contains"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/merge",
+    "cppdoc": "cpp/library/container/unordered_map/merge"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/erase_if",
+    "cppdoc": "cpp/library/container/unordered_map/erase_if"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/insert_range",
+    "cppdoc": "cpp/library/container/unordered_map/insert_range"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/key_eq",
+    "cppdoc": "cpp/library/container/unordered_map/key_eq"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/bucket",
+    "cppdoc": "cpp/library/container/unordered_map/bucket"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/emplace_hint",
+    "cppdoc": "cpp/library/container/unordered_map/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/hash_function",
+    "cppdoc": "cpp/library/container/unordered_map/hash_function"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/insert_or_assign",
+    "cppdoc": "cpp/library/container/unordered_map/insert_or_assign"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/operator=",
+    "cppdoc": "cpp/library/container/unordered_map/operator="
+  },
+  {
+    "cppref": "cpp/container/unordered_map/max_load_factor",
+    "cppdoc": "cpp/library/container/unordered_map/max_load_factor"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/bucket_size",
+    "cppdoc": "cpp/library/container/unordered_map/bucket_size"
+  },
+  {
+    "cppref": "cpp/container/unordered_map/clear",
+    "cppdoc": "cpp/library/container/unordered_map/clear"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/bucket_count",
+    "cppdoc": "cpp/library/container/unordered_set/bucket_count"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/end2",
+    "cppdoc": "cpp/library/container/unordered_set/end2"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/unordered_set",
+    "cppdoc": "cpp/library/container/unordered_set/unordered_set"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/extract",
+    "cppdoc": "cpp/library/container/unordered_set/extract"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/insert",
+    "cppdoc": "cpp/library/container/unordered_set/insert"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/emplace",
+    "cppdoc": "cpp/library/container/unordered_set/emplace"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/empty",
+    "cppdoc": "cpp/library/container/unordered_set/empty"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/find",
+    "cppdoc": "cpp/library/container/unordered_set/find"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/~unordered_set",
+    "cppdoc": "cpp/library/container/unordered_set/~unordered_set"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/equal_range",
+    "cppdoc": "cpp/library/container/unordered_set/equal_range"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/max_size",
+    "cppdoc": "cpp/library/container/unordered_set/max_size"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/size",
+    "cppdoc": "cpp/library/container/unordered_set/size"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/swap2",
+    "cppdoc": "cpp/library/container/unordered_set/swap2"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/end",
+    "cppdoc": "cpp/library/container/unordered_set/end"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/load_factor",
+    "cppdoc": "cpp/library/container/unordered_set/load_factor"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/rehash",
+    "cppdoc": "cpp/library/container/unordered_set/rehash"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/begin2",
+    "cppdoc": "cpp/library/container/unordered_set/begin2"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/begin",
+    "cppdoc": "cpp/library/container/unordered_set/begin"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/deduction_guides",
+    "cppdoc": "cpp/library/container/unordered_set/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/max_bucket_count",
+    "cppdoc": "cpp/library/container/unordered_set/max_bucket_count"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/swap",
+    "cppdoc": "cpp/library/container/unordered_set/swap"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/reserve",
+    "cppdoc": "cpp/library/container/unordered_set/reserve"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/count",
+    "cppdoc": "cpp/library/container/unordered_set/count"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/erase",
+    "cppdoc": "cpp/library/container/unordered_set/erase"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/operator_cmp",
+    "cppdoc": "cpp/library/container/unordered_set/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/get_allocator",
+    "cppdoc": "cpp/library/container/unordered_set/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/contains",
+    "cppdoc": "cpp/library/container/unordered_set/contains"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/merge",
+    "cppdoc": "cpp/library/container/unordered_set/merge"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/erase_if",
+    "cppdoc": "cpp/library/container/unordered_set/erase_if"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/insert_range",
+    "cppdoc": "cpp/library/container/unordered_set/insert_range"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/key_eq",
+    "cppdoc": "cpp/library/container/unordered_set/key_eq"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/bucket",
+    "cppdoc": "cpp/library/container/unordered_set/bucket"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/emplace_hint",
+    "cppdoc": "cpp/library/container/unordered_set/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/hash_function",
+    "cppdoc": "cpp/library/container/unordered_set/hash_function"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/operator=",
+    "cppdoc": "cpp/library/container/unordered_set/operator="
+  },
+  {
+    "cppref": "cpp/container/unordered_set/max_load_factor",
+    "cppdoc": "cpp/library/container/unordered_set/max_load_factor"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/bucket_size",
+    "cppdoc": "cpp/library/container/unordered_set/bucket_size"
+  },
+  {
+    "cppref": "cpp/container/unordered_set/clear",
+    "cppdoc": "cpp/library/container/unordered_set/clear"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/replace",
+    "cppdoc": "cpp/library/container/flat_multimap/replace"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/extract",
+    "cppdoc": "cpp/library/container/flat_multimap/extract"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/insert",
+    "cppdoc": "cpp/library/container/flat_multimap/insert"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/emplace",
+    "cppdoc": "cpp/library/container/flat_multimap/emplace"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/empty",
+    "cppdoc": "cpp/library/container/flat_multimap/empty"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/find",
+    "cppdoc": "cpp/library/container/flat_multimap/find"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/equal_range",
+    "cppdoc": "cpp/library/container/flat_multimap/equal_range"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/max_size",
+    "cppdoc": "cpp/library/container/flat_multimap/max_size"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/size",
+    "cppdoc": "cpp/library/container/flat_multimap/size"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/swap2",
+    "cppdoc": "cpp/library/container/flat_multimap/swap2"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/end",
+    "cppdoc": "cpp/library/container/flat_multimap/end"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/value_compare",
+    "cppdoc": "cpp/library/container/flat_multimap/value_compare"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/rend",
+    "cppdoc": "cpp/library/container/flat_multimap/rend"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/begin",
+    "cppdoc": "cpp/library/container/flat_multimap/begin"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/deduction_guides",
+    "cppdoc": "cpp/library/container/flat_multimap/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/value_comp",
+    "cppdoc": "cpp/library/container/flat_multimap/value_comp"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/flat_multimap",
+    "cppdoc": "cpp/library/container/flat_multimap/flat_multimap"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/swap",
+    "cppdoc": "cpp/library/container/flat_multimap/swap"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/upper_bound",
+    "cppdoc": "cpp/library/container/flat_multimap/upper_bound"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/rbegin",
+    "cppdoc": "cpp/library/container/flat_multimap/rbegin"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/lower_bound",
+    "cppdoc": "cpp/library/container/flat_multimap/lower_bound"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/count",
+    "cppdoc": "cpp/library/container/flat_multimap/count"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/erase",
+    "cppdoc": "cpp/library/container/flat_multimap/erase"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/operator_cmp",
+    "cppdoc": "cpp/library/container/flat_multimap/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/contains",
+    "cppdoc": "cpp/library/container/flat_multimap/contains"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/erase_if",
+    "cppdoc": "cpp/library/container/flat_multimap/erase_if"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/insert_range",
+    "cppdoc": "cpp/library/container/flat_multimap/insert_range"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/values",
+    "cppdoc": "cpp/library/container/flat_multimap/values"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/emplace_hint",
+    "cppdoc": "cpp/library/container/flat_multimap/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/key_comp",
+    "cppdoc": "cpp/library/container/flat_multimap/key_comp"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/operator=",
+    "cppdoc": "cpp/library/container/flat_multimap/operator="
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/keys",
+    "cppdoc": "cpp/library/container/flat_multimap/keys"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/clear",
+    "cppdoc": "cpp/library/container/flat_multimap/clear"
+  },
+  {
+    "cppref": "cpp/container/flat_multimap/uses_allocator",
+    "cppdoc": "cpp/library/container/flat_multimap/uses_allocator"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/bucket_count",
+    "cppdoc": "cpp/library/container/unordered_multimap/bucket_count"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/end2",
+    "cppdoc": "cpp/library/container/unordered_multimap/end2"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/extract",
+    "cppdoc": "cpp/library/container/unordered_multimap/extract"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/insert",
+    "cppdoc": "cpp/library/container/unordered_multimap/insert"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/emplace",
+    "cppdoc": "cpp/library/container/unordered_multimap/emplace"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/empty",
+    "cppdoc": "cpp/library/container/unordered_multimap/empty"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/find",
+    "cppdoc": "cpp/library/container/unordered_multimap/find"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/equal_range",
+    "cppdoc": "cpp/library/container/unordered_multimap/equal_range"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/max_size",
+    "cppdoc": "cpp/library/container/unordered_multimap/max_size"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/unordered_multimap",
+    "cppdoc": "cpp/library/container/unordered_multimap/unordered_multimap"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/size",
+    "cppdoc": "cpp/library/container/unordered_multimap/size"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/swap2",
+    "cppdoc": "cpp/library/container/unordered_multimap/swap2"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/end",
+    "cppdoc": "cpp/library/container/unordered_multimap/end"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/load_factor",
+    "cppdoc": "cpp/library/container/unordered_multimap/load_factor"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/~unordered_multimap",
+    "cppdoc": "cpp/library/container/unordered_multimap/~unordered_multimap"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/rehash",
+    "cppdoc": "cpp/library/container/unordered_multimap/rehash"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/begin2",
+    "cppdoc": "cpp/library/container/unordered_multimap/begin2"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/begin",
+    "cppdoc": "cpp/library/container/unordered_multimap/begin"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/deduction_guides",
+    "cppdoc": "cpp/library/container/unordered_multimap/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/max_bucket_count",
+    "cppdoc": "cpp/library/container/unordered_multimap/max_bucket_count"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/swap",
+    "cppdoc": "cpp/library/container/unordered_multimap/swap"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/reserve",
+    "cppdoc": "cpp/library/container/unordered_multimap/reserve"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/count",
+    "cppdoc": "cpp/library/container/unordered_multimap/count"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/erase",
+    "cppdoc": "cpp/library/container/unordered_multimap/erase"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/operator_cmp",
+    "cppdoc": "cpp/library/container/unordered_multimap/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/get_allocator",
+    "cppdoc": "cpp/library/container/unordered_multimap/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/contains",
+    "cppdoc": "cpp/library/container/unordered_multimap/contains"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/merge",
+    "cppdoc": "cpp/library/container/unordered_multimap/merge"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/erase_if",
+    "cppdoc": "cpp/library/container/unordered_multimap/erase_if"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/insert_range",
+    "cppdoc": "cpp/library/container/unordered_multimap/insert_range"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/key_eq",
+    "cppdoc": "cpp/library/container/unordered_multimap/key_eq"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/bucket",
+    "cppdoc": "cpp/library/container/unordered_multimap/bucket"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/emplace_hint",
+    "cppdoc": "cpp/library/container/unordered_multimap/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/hash_function",
+    "cppdoc": "cpp/library/container/unordered_multimap/hash_function"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/operator=",
+    "cppdoc": "cpp/library/container/unordered_multimap/operator="
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/max_load_factor",
+    "cppdoc": "cpp/library/container/unordered_multimap/max_load_factor"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/bucket_size",
+    "cppdoc": "cpp/library/container/unordered_multimap/bucket_size"
+  },
+  {
+    "cppref": "cpp/container/unordered_multimap/clear",
+    "cppdoc": "cpp/library/container/unordered_multimap/clear"
+  },
+  {
+    "cppref": "cpp/container/flat_map/operator_at",
+    "cppdoc": "cpp/library/container/flat_map/operator_at"
+  },
+  {
+    "cppref": "cpp/container/flat_map/replace",
+    "cppdoc": "cpp/library/container/flat_map/replace"
+  },
+  {
+    "cppref": "cpp/container/flat_map/at",
+    "cppdoc": "cpp/library/container/flat_map/at"
+  },
+  {
+    "cppref": "cpp/container/flat_map/try_emplace",
+    "cppdoc": "cpp/library/container/flat_map/try_emplace"
+  },
+  {
+    "cppref": "cpp/container/flat_map/extract",
+    "cppdoc": "cpp/library/container/flat_map/extract"
+  },
+  {
+    "cppref": "cpp/container/flat_map/insert",
+    "cppdoc": "cpp/library/container/flat_map/insert"
+  },
+  {
+    "cppref": "cpp/container/flat_map/emplace",
+    "cppdoc": "cpp/library/container/flat_map/emplace"
+  },
+  {
+    "cppref": "cpp/container/flat_map/empty",
+    "cppdoc": "cpp/library/container/flat_map/empty"
+  },
+  {
+    "cppref": "cpp/container/flat_map/find",
+    "cppdoc": "cpp/library/container/flat_map/find"
+  },
+  {
+    "cppref": "cpp/container/flat_map/equal_range",
+    "cppdoc": "cpp/library/container/flat_map/equal_range"
+  },
+  {
+    "cppref": "cpp/container/flat_map/max_size",
+    "cppdoc": "cpp/library/container/flat_map/max_size"
+  },
+  {
+    "cppref": "cpp/container/flat_map/size",
+    "cppdoc": "cpp/library/container/flat_map/size"
+  },
+  {
+    "cppref": "cpp/container/flat_map/swap2",
+    "cppdoc": "cpp/library/container/flat_map/swap2"
+  },
+  {
+    "cppref": "cpp/container/flat_map/end",
+    "cppdoc": "cpp/library/container/flat_map/end"
+  },
+  {
+    "cppref": "cpp/container/flat_map/value_compare",
+    "cppdoc": "cpp/library/container/flat_map/value_compare"
+  },
+  {
+    "cppref": "cpp/container/flat_map/rend",
+    "cppdoc": "cpp/library/container/flat_map/rend"
+  },
+  {
+    "cppref": "cpp/container/flat_map/begin",
+    "cppdoc": "cpp/library/container/flat_map/begin"
+  },
+  {
+    "cppref": "cpp/container/flat_map/deduction_guides",
+    "cppdoc": "cpp/library/container/flat_map/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/flat_map/value_comp",
+    "cppdoc": "cpp/library/container/flat_map/value_comp"
+  },
+  {
+    "cppref": "cpp/container/flat_map/swap",
+    "cppdoc": "cpp/library/container/flat_map/swap"
+  },
+  {
+    "cppref": "cpp/container/flat_map/upper_bound",
+    "cppdoc": "cpp/library/container/flat_map/upper_bound"
+  },
+  {
+    "cppref": "cpp/container/flat_map/rbegin",
+    "cppdoc": "cpp/library/container/flat_map/rbegin"
+  },
+  {
+    "cppref": "cpp/container/flat_map/lower_bound",
+    "cppdoc": "cpp/library/container/flat_map/lower_bound"
+  },
+  {
+    "cppref": "cpp/container/flat_map/count",
+    "cppdoc": "cpp/library/container/flat_map/count"
+  },
+  {
+    "cppref": "cpp/container/flat_map/erase",
+    "cppdoc": "cpp/library/container/flat_map/erase"
+  },
+  {
+    "cppref": "cpp/container/flat_map/operator_cmp",
+    "cppdoc": "cpp/library/container/flat_map/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/flat_map/contains",
+    "cppdoc": "cpp/library/container/flat_map/contains"
+  },
+  {
+    "cppref": "cpp/container/flat_map/erase_if",
+    "cppdoc": "cpp/library/container/flat_map/erase_if"
+  },
+  {
+    "cppref": "cpp/container/flat_map/insert_range",
+    "cppdoc": "cpp/library/container/flat_map/insert_range"
+  },
+  {
+    "cppref": "cpp/container/flat_map/values",
+    "cppdoc": "cpp/library/container/flat_map/values"
+  },
+  {
+    "cppref": "cpp/container/flat_map/emplace_hint",
+    "cppdoc": "cpp/library/container/flat_map/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/flat_map/insert_or_assign",
+    "cppdoc": "cpp/library/container/flat_map/insert_or_assign"
+  },
+  {
+    "cppref": "cpp/container/flat_map/key_comp",
+    "cppdoc": "cpp/library/container/flat_map/key_comp"
+  },
+  {
+    "cppref": "cpp/container/flat_map/operator=",
+    "cppdoc": "cpp/library/container/flat_map/operator="
+  },
+  {
+    "cppref": "cpp/container/flat_map/keys",
+    "cppdoc": "cpp/library/container/flat_map/keys"
+  },
+  {
+    "cppref": "cpp/container/flat_map/flat_map",
+    "cppdoc": "cpp/library/container/flat_map/flat_map"
+  },
+  {
+    "cppref": "cpp/container/flat_map/clear",
+    "cppdoc": "cpp/library/container/flat_map/clear"
+  },
+  {
+    "cppref": "cpp/container/flat_map/uses_allocator",
+    "cppdoc": "cpp/library/container/flat_map/uses_allocator"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extent",
+    "cppdoc": "cpp/library/container/mdspan/extent"
+  },
+  {
+    "cppref": "cpp/container/mdspan/operator_at",
+    "cppdoc": "cpp/library/container/mdspan/operator_at"
+  },
+  {
+    "cppref": "cpp/container/mdspan/mapping",
+    "cppdoc": "cpp/library/container/mdspan/mapping"
+  },
+  {
+    "cppref": "cpp/container/mdspan/mdspan",
+    "cppdoc": "cpp/library/container/mdspan/mdspan"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents_mfun",
+    "cppdoc": "cpp/library/container/mdspan/extents_mfun"
+  },
+  {
+    "cppref": "cpp/container/mdspan/default_accessor",
+    "cppdoc": "cpp/library/container/mdspan/default_accessor"
+  },
+  {
+    "cppref": "cpp/container/mdspan/empty",
+    "cppdoc": "cpp/library/container/mdspan/empty"
+  },
+  {
+    "cppref": "cpp/container/mdspan/full_extent",
+    "cppdoc": "cpp/library/container/mdspan/full_extent"
+  },
+  {
+    "cppref": "cpp/container/mdspan/stride",
+    "cppdoc": "cpp/library/container/mdspan/stride"
+  },
+  {
+    "cppref": "cpp/container/mdspan/size",
+    "cppdoc": "cpp/library/container/mdspan/size"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_stride",
+    "cppdoc": "cpp/library/container/mdspan/layout_stride"
+  },
+  {
+    "cppref": "cpp/container/mdspan/submdspan_mapping_result",
+    "cppdoc": "cpp/library/container/mdspan/submdspan_mapping_result"
+  },
+  {
+    "cppref": "cpp/container/mdspan/swap2",
+    "cppdoc": "cpp/library/container/mdspan/swap2"
+  },
+  {
+    "cppref": "cpp/container/mdspan/accessor",
+    "cppdoc": "cpp/library/container/mdspan/accessor"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_right_padded",
+    "cppdoc": "cpp/library/container/mdspan/layout_right_padded"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents",
+    "cppdoc": "cpp/library/container/mdspan/extents"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_left",
+    "cppdoc": "cpp/library/container/mdspan/layout_left"
+  },
+  {
+    "cppref": "cpp/container/mdspan/data_handle",
+    "cppdoc": "cpp/library/container/mdspan/data_handle"
+  },
+  {
+    "cppref": "cpp/container/mdspan/deduction_guides",
+    "cppdoc": "cpp/library/container/mdspan/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/mdspan/rank_dynamic",
+    "cppdoc": "cpp/library/container/mdspan/rank_dynamic"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_left_padded",
+    "cppdoc": "cpp/library/container/mdspan/layout_left_padded"
+  },
+  {
+    "cppref": "cpp/container/mdspan/static_extent",
+    "cppdoc": "cpp/library/container/mdspan/static_extent"
+  },
+  {
+    "cppref": "cpp/container/mdspan/mapping_traits",
+    "cppdoc": "cpp/library/container/mdspan/mapping_traits"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_right",
+    "cppdoc": "cpp/library/container/mdspan/layout_right"
+  },
+  {
+    "cppref": "cpp/container/mdspan/operator=",
+    "cppdoc": "cpp/library/container/mdspan/operator="
+  },
+  {
+    "cppref": "cpp/container/mdspan/rank",
+    "cppdoc": "cpp/library/container/mdspan/rank"
+  },
+  {
+    "cppref": "cpp/container/mdspan/strided_slice",
+    "cppdoc": "cpp/library/container/mdspan/strided_slice"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_right/mapping",
+    "cppdoc": "cpp/library/container/mdspan/layout_right/mapping"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_right/mapping/operator==",
+    "cppdoc": "cpp/library/container/mdspan/layout_right/mapping/operator=="
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_right/mapping/stride",
+    "cppdoc": "cpp/library/container/mdspan/layout_right/mapping/stride"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_right/mapping/extents",
+    "cppdoc": "cpp/library/container/mdspan/layout_right/mapping/extents"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_right/mapping/required_span_size",
+    "cppdoc": "cpp/library/container/mdspan/layout_right/mapping/required_span_size"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_right/mapping/operator()",
+    "cppdoc": "cpp/library/container/mdspan/layout_right/mapping/operator()"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_right/mapping/mapping_traits",
+    "cppdoc": "cpp/library/container/mdspan/layout_right/mapping/mapping_traits"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_stride/mapping",
+    "cppdoc": "cpp/library/container/mdspan/layout_stride/mapping"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_stride/mapping/operator==",
+    "cppdoc": "cpp/library/container/mdspan/layout_stride/mapping/operator=="
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_stride/mapping/stride",
+    "cppdoc": "cpp/library/container/mdspan/layout_stride/mapping/stride"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_stride/mapping/extents",
+    "cppdoc": "cpp/library/container/mdspan/layout_stride/mapping/extents"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_stride/mapping/required_span_size",
+    "cppdoc": "cpp/library/container/mdspan/layout_stride/mapping/required_span_size"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_stride/mapping/strides",
+    "cppdoc": "cpp/library/container/mdspan/layout_stride/mapping/strides"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_stride/mapping/operator()",
+    "cppdoc": "cpp/library/container/mdspan/layout_stride/mapping/operator()"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_stride/mapping/mapping_traits",
+    "cppdoc": "cpp/library/container/mdspan/layout_stride/mapping/mapping_traits"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/extent",
+    "cppdoc": "cpp/library/container/mdspan/extents/extent"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/operator==",
+    "cppdoc": "cpp/library/container/mdspan/extents/operator=="
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/dynamic-index",
+    "cppdoc": "cpp/library/container/mdspan/extents/dynamic-index"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/index-cast",
+    "cppdoc": "cpp/library/container/mdspan/extents/index-cast"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/extents",
+    "cppdoc": "cpp/library/container/mdspan/extents/extents"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/rev-prod-of-extents",
+    "cppdoc": "cpp/library/container/mdspan/extents/rev-prod-of-extents"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/deduction_guides",
+    "cppdoc": "cpp/library/container/mdspan/extents/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/fwd-prod-of-extents",
+    "cppdoc": "cpp/library/container/mdspan/extents/fwd-prod-of-extents"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/rank_dynamic",
+    "cppdoc": "cpp/library/container/mdspan/extents/rank_dynamic"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/static_extent",
+    "cppdoc": "cpp/library/container/mdspan/extents/static_extent"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/dynamic-index-inv",
+    "cppdoc": "cpp/library/container/mdspan/extents/dynamic-index-inv"
+  },
+  {
+    "cppref": "cpp/container/mdspan/extents/rank",
+    "cppdoc": "cpp/library/container/mdspan/extents/rank"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_left/mapping",
+    "cppdoc": "cpp/library/container/mdspan/layout_left/mapping"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_left/mapping/operator==",
+    "cppdoc": "cpp/library/container/mdspan/layout_left/mapping/operator=="
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_left/mapping/stride",
+    "cppdoc": "cpp/library/container/mdspan/layout_left/mapping/stride"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_left/mapping/extents",
+    "cppdoc": "cpp/library/container/mdspan/layout_left/mapping/extents"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_left/mapping/required_span_size",
+    "cppdoc": "cpp/library/container/mdspan/layout_left/mapping/required_span_size"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_left/mapping/operator()",
+    "cppdoc": "cpp/library/container/mdspan/layout_left/mapping/operator()"
+  },
+  {
+    "cppref": "cpp/container/mdspan/layout_left/mapping/mapping_traits",
+    "cppdoc": "cpp/library/container/mdspan/layout_left/mapping/mapping_traits"
+  },
+  {
+    "cppref": "cpp/container/set/extract",
+    "cppdoc": "cpp/library/container/set/extract"
+  },
+  {
+    "cppref": "cpp/container/set/insert",
+    "cppdoc": "cpp/library/container/set/insert"
+  },
+  {
+    "cppref": "cpp/container/set/emplace",
+    "cppdoc": "cpp/library/container/set/emplace"
+  },
+  {
+    "cppref": "cpp/container/set/empty",
+    "cppdoc": "cpp/library/container/set/empty"
+  },
+  {
+    "cppref": "cpp/container/set/find",
+    "cppdoc": "cpp/library/container/set/find"
+  },
+  {
+    "cppref": "cpp/container/set/equal_range",
+    "cppdoc": "cpp/library/container/set/equal_range"
+  },
+  {
+    "cppref": "cpp/container/set/max_size",
+    "cppdoc": "cpp/library/container/set/max_size"
+  },
+  {
+    "cppref": "cpp/container/set/size",
+    "cppdoc": "cpp/library/container/set/size"
+  },
+  {
+    "cppref": "cpp/container/set/swap2",
+    "cppdoc": "cpp/library/container/set/swap2"
+  },
+  {
+    "cppref": "cpp/container/set/end",
+    "cppdoc": "cpp/library/container/set/end"
+  },
+  {
+    "cppref": "cpp/container/set/rend",
+    "cppdoc": "cpp/library/container/set/rend"
+  },
+  {
+    "cppref": "cpp/container/set/~set",
+    "cppdoc": "cpp/library/container/set/~set"
+  },
+  {
+    "cppref": "cpp/container/set/begin",
+    "cppdoc": "cpp/library/container/set/begin"
+  },
+  {
+    "cppref": "cpp/container/set/deduction_guides",
+    "cppdoc": "cpp/library/container/set/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/set/value_comp",
+    "cppdoc": "cpp/library/container/set/value_comp"
+  },
+  {
+    "cppref": "cpp/container/set/swap",
+    "cppdoc": "cpp/library/container/set/swap"
+  },
+  {
+    "cppref": "cpp/container/set/upper_bound",
+    "cppdoc": "cpp/library/container/set/upper_bound"
+  },
+  {
+    "cppref": "cpp/container/set/rbegin",
+    "cppdoc": "cpp/library/container/set/rbegin"
+  },
+  {
+    "cppref": "cpp/container/set/lower_bound",
+    "cppdoc": "cpp/library/container/set/lower_bound"
+  },
+  {
+    "cppref": "cpp/container/set/count",
+    "cppdoc": "cpp/library/container/set/count"
+  },
+  {
+    "cppref": "cpp/container/set/erase",
+    "cppdoc": "cpp/library/container/set/erase"
+  },
+  {
+    "cppref": "cpp/container/set/operator_cmp",
+    "cppdoc": "cpp/library/container/set/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/set/get_allocator",
+    "cppdoc": "cpp/library/container/set/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/set/contains",
+    "cppdoc": "cpp/library/container/set/contains"
+  },
+  {
+    "cppref": "cpp/container/set/merge",
+    "cppdoc": "cpp/library/container/set/merge"
+  },
+  {
+    "cppref": "cpp/container/set/erase_if",
+    "cppdoc": "cpp/library/container/set/erase_if"
+  },
+  {
+    "cppref": "cpp/container/set/insert_range",
+    "cppdoc": "cpp/library/container/set/insert_range"
+  },
+  {
+    "cppref": "cpp/container/set/emplace_hint",
+    "cppdoc": "cpp/library/container/set/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/set/key_comp",
+    "cppdoc": "cpp/library/container/set/key_comp"
+  },
+  {
+    "cppref": "cpp/container/set/operator=",
+    "cppdoc": "cpp/library/container/set/operator="
+  },
+  {
+    "cppref": "cpp/container/set/set",
+    "cppdoc": "cpp/library/container/set/set"
+  },
+  {
+    "cppref": "cpp/container/set/clear",
+    "cppdoc": "cpp/library/container/set/clear"
+  },
+  {
+    "cppref": "cpp/container/array/operator_at",
+    "cppdoc": "cpp/library/container/array/operator_at"
+  },
+  {
+    "cppref": "cpp/container/array/at",
+    "cppdoc": "cpp/library/container/array/at"
+  },
+  {
+    "cppref": "cpp/container/array/back",
+    "cppdoc": "cpp/library/container/array/back"
+  },
+  {
+    "cppref": "cpp/container/array/empty",
+    "cppdoc": "cpp/library/container/array/empty"
+  },
+  {
+    "cppref": "cpp/container/array/max_size",
+    "cppdoc": "cpp/library/container/array/max_size"
+  },
+  {
+    "cppref": "cpp/container/array/size",
+    "cppdoc": "cpp/library/container/array/size"
+  },
+  {
+    "cppref": "cpp/container/array/swap2",
+    "cppdoc": "cpp/library/container/array/swap2"
+  },
+  {
+    "cppref": "cpp/container/array/end",
+    "cppdoc": "cpp/library/container/array/end"
+  },
+  {
+    "cppref": "cpp/container/array/rend",
+    "cppdoc": "cpp/library/container/array/rend"
+  },
+  {
+    "cppref": "cpp/container/array/to_array",
+    "cppdoc": "cpp/library/container/array/to_array"
+  },
+  {
+    "cppref": "cpp/container/array/begin",
+    "cppdoc": "cpp/library/container/array/begin"
+  },
+  {
+    "cppref": "cpp/container/array/deduction_guides",
+    "cppdoc": "cpp/library/container/array/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/array/swap",
+    "cppdoc": "cpp/library/container/array/swap"
+  },
+  {
+    "cppref": "cpp/container/array/front",
+    "cppdoc": "cpp/library/container/array/front"
+  },
+  {
+    "cppref": "cpp/container/array/rbegin",
+    "cppdoc": "cpp/library/container/array/rbegin"
+  },
+  {
+    "cppref": "cpp/container/array/tuple_size",
+    "cppdoc": "cpp/library/container/array/tuple_size"
+  },
+  {
+    "cppref": "cpp/container/array/get",
+    "cppdoc": "cpp/library/container/array/get"
+  },
+  {
+    "cppref": "cpp/container/array/operator_cmp",
+    "cppdoc": "cpp/library/container/array/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/array/fill",
+    "cppdoc": "cpp/library/container/array/fill"
+  },
+  {
+    "cppref": "cpp/container/array/tuple_element",
+    "cppdoc": "cpp/library/container/array/tuple_element"
+  },
+  {
+    "cppref": "cpp/container/array/data",
+    "cppdoc": "cpp/library/container/array/data"
+  },
+  {
+    "cppref": "cpp/container/forward_list/remove",
+    "cppdoc": "cpp/library/container/forward_list/remove"
+  },
+  {
+    "cppref": "cpp/container/forward_list/assign",
+    "cppdoc": "cpp/library/container/forward_list/assign"
+  },
+  {
+    "cppref": "cpp/container/forward_list/empty",
+    "cppdoc": "cpp/library/container/forward_list/empty"
+  },
+  {
+    "cppref": "cpp/container/forward_list/erase_after",
+    "cppdoc": "cpp/library/container/forward_list/erase_after"
+  },
+  {
+    "cppref": "cpp/container/forward_list/max_size",
+    "cppdoc": "cpp/library/container/forward_list/max_size"
+  },
+  {
+    "cppref": "cpp/container/forward_list/emplace_after",
+    "cppdoc": "cpp/library/container/forward_list/emplace_after"
+  },
+  {
+    "cppref": "cpp/container/forward_list/~forward_list",
+    "cppdoc": "cpp/library/container/forward_list/~forward_list"
+  },
+  {
+    "cppref": "cpp/container/forward_list/insert_after",
+    "cppdoc": "cpp/library/container/forward_list/insert_after"
+  },
+  {
+    "cppref": "cpp/container/forward_list/emplace_front",
+    "cppdoc": "cpp/library/container/forward_list/emplace_front"
+  },
+  {
+    "cppref": "cpp/container/forward_list/swap2",
+    "cppdoc": "cpp/library/container/forward_list/swap2"
+  },
+  {
+    "cppref": "cpp/container/forward_list/end",
+    "cppdoc": "cpp/library/container/forward_list/end"
+  },
+  {
+    "cppref": "cpp/container/forward_list/begin",
+    "cppdoc": "cpp/library/container/forward_list/begin"
+  },
+  {
+    "cppref": "cpp/container/forward_list/deduction_guides",
+    "cppdoc": "cpp/library/container/forward_list/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/forward_list/assign_range",
+    "cppdoc": "cpp/library/container/forward_list/assign_range"
+  },
+  {
+    "cppref": "cpp/container/forward_list/swap",
+    "cppdoc": "cpp/library/container/forward_list/swap"
+  },
+  {
+    "cppref": "cpp/container/forward_list/front",
+    "cppdoc": "cpp/library/container/forward_list/front"
+  },
+  {
+    "cppref": "cpp/container/forward_list/resize",
+    "cppdoc": "cpp/library/container/forward_list/resize"
+  },
+  {
+    "cppref": "cpp/container/forward_list/pop_front",
+    "cppdoc": "cpp/library/container/forward_list/pop_front"
+  },
+  {
+    "cppref": "cpp/container/forward_list/operator_cmp",
+    "cppdoc": "cpp/library/container/forward_list/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/forward_list/get_allocator",
+    "cppdoc": "cpp/library/container/forward_list/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/forward_list/merge",
+    "cppdoc": "cpp/library/container/forward_list/merge"
+  },
+  {
+    "cppref": "cpp/container/forward_list/unique",
+    "cppdoc": "cpp/library/container/forward_list/unique"
+  },
+  {
+    "cppref": "cpp/container/forward_list/splice_after",
+    "cppdoc": "cpp/library/container/forward_list/splice_after"
+  },
+  {
+    "cppref": "cpp/container/forward_list/erase2",
+    "cppdoc": "cpp/library/container/forward_list/erase2"
+  },
+  {
+    "cppref": "cpp/container/forward_list/sort",
+    "cppdoc": "cpp/library/container/forward_list/sort"
+  },
+  {
+    "cppref": "cpp/container/forward_list/forward_list",
+    "cppdoc": "cpp/library/container/forward_list/forward_list"
+  },
+  {
+    "cppref": "cpp/container/forward_list/push_front",
+    "cppdoc": "cpp/library/container/forward_list/push_front"
+  },
+  {
+    "cppref": "cpp/container/forward_list/insert_range_after",
+    "cppdoc": "cpp/library/container/forward_list/insert_range_after"
+  },
+  {
+    "cppref": "cpp/container/forward_list/operator=",
+    "cppdoc": "cpp/library/container/forward_list/operator="
+  },
+  {
+    "cppref": "cpp/container/forward_list/before_begin",
+    "cppdoc": "cpp/library/container/forward_list/before_begin"
+  },
+  {
+    "cppref": "cpp/container/forward_list/prepend_range",
+    "cppdoc": "cpp/library/container/forward_list/prepend_range"
+  },
+  {
+    "cppref": "cpp/container/forward_list/clear",
+    "cppdoc": "cpp/library/container/forward_list/clear"
+  },
+  {
+    "cppref": "cpp/container/forward_list/reverse",
+    "cppdoc": "cpp/library/container/forward_list/reverse"
+  },
+  {
+    "cppref": "cpp/container/map/operator_at",
+    "cppdoc": "cpp/library/container/map/operator_at"
+  },
+  {
+    "cppref": "cpp/container/map/at",
+    "cppdoc": "cpp/library/container/map/at"
+  },
+  {
+    "cppref": "cpp/container/map/try_emplace",
+    "cppdoc": "cpp/library/container/map/try_emplace"
+  },
+  {
+    "cppref": "cpp/container/map/extract",
+    "cppdoc": "cpp/library/container/map/extract"
+  },
+  {
+    "cppref": "cpp/container/map/insert",
+    "cppdoc": "cpp/library/container/map/insert"
+  },
+  {
+    "cppref": "cpp/container/map/emplace",
+    "cppdoc": "cpp/library/container/map/emplace"
+  },
+  {
+    "cppref": "cpp/container/map/empty",
+    "cppdoc": "cpp/library/container/map/empty"
+  },
+  {
+    "cppref": "cpp/container/map/find",
+    "cppdoc": "cpp/library/container/map/find"
+  },
+  {
+    "cppref": "cpp/container/map/equal_range",
+    "cppdoc": "cpp/library/container/map/equal_range"
+  },
+  {
+    "cppref": "cpp/container/map/max_size",
+    "cppdoc": "cpp/library/container/map/max_size"
+  },
+  {
+    "cppref": "cpp/container/map/size",
+    "cppdoc": "cpp/library/container/map/size"
+  },
+  {
+    "cppref": "cpp/container/map/swap2",
+    "cppdoc": "cpp/library/container/map/swap2"
+  },
+  {
+    "cppref": "cpp/container/map/end",
+    "cppdoc": "cpp/library/container/map/end"
+  },
+  {
+    "cppref": "cpp/container/map/value_compare",
+    "cppdoc": "cpp/library/container/map/value_compare"
+  },
+  {
+    "cppref": "cpp/container/map/rend",
+    "cppdoc": "cpp/library/container/map/rend"
+  },
+  {
+    "cppref": "cpp/container/map/begin",
+    "cppdoc": "cpp/library/container/map/begin"
+  },
+  {
+    "cppref": "cpp/container/map/deduction_guides",
+    "cppdoc": "cpp/library/container/map/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/map/value_comp",
+    "cppdoc": "cpp/library/container/map/value_comp"
+  },
+  {
+    "cppref": "cpp/container/map/swap",
+    "cppdoc": "cpp/library/container/map/swap"
+  },
+  {
+    "cppref": "cpp/container/map/upper_bound",
+    "cppdoc": "cpp/library/container/map/upper_bound"
+  },
+  {
+    "cppref": "cpp/container/map/rbegin",
+    "cppdoc": "cpp/library/container/map/rbegin"
+  },
+  {
+    "cppref": "cpp/container/map/lower_bound",
+    "cppdoc": "cpp/library/container/map/lower_bound"
+  },
+  {
+    "cppref": "cpp/container/map/count",
+    "cppdoc": "cpp/library/container/map/count"
+  },
+  {
+    "cppref": "cpp/container/map/erase",
+    "cppdoc": "cpp/library/container/map/erase"
+  },
+  {
+    "cppref": "cpp/container/map/operator_cmp",
+    "cppdoc": "cpp/library/container/map/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/map/get_allocator",
+    "cppdoc": "cpp/library/container/map/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/map/contains",
+    "cppdoc": "cpp/library/container/map/contains"
+  },
+  {
+    "cppref": "cpp/container/map/merge",
+    "cppdoc": "cpp/library/container/map/merge"
+  },
+  {
+    "cppref": "cpp/container/map/erase_if",
+    "cppdoc": "cpp/library/container/map/erase_if"
+  },
+  {
+    "cppref": "cpp/container/map/~map",
+    "cppdoc": "cpp/library/container/map/~map"
+  },
+  {
+    "cppref": "cpp/container/map/insert_range",
+    "cppdoc": "cpp/library/container/map/insert_range"
+  },
+  {
+    "cppref": "cpp/container/map/map",
+    "cppdoc": "cpp/library/container/map/map"
+  },
+  {
+    "cppref": "cpp/container/map/emplace_hint",
+    "cppdoc": "cpp/library/container/map/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/map/insert_or_assign",
+    "cppdoc": "cpp/library/container/map/insert_or_assign"
+  },
+  {
+    "cppref": "cpp/container/map/key_comp",
+    "cppdoc": "cpp/library/container/map/key_comp"
+  },
+  {
+    "cppref": "cpp/container/map/operator=",
+    "cppdoc": "cpp/library/container/map/operator="
+  },
+  {
+    "cppref": "cpp/container/map/clear",
+    "cppdoc": "cpp/library/container/map/clear"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/operator_at",
+    "cppdoc": "cpp/library/container/inplace_vector/operator_at"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/at",
+    "cppdoc": "cpp/library/container/inplace_vector/at"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/back",
+    "cppdoc": "cpp/library/container/inplace_vector/back"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/assign",
+    "cppdoc": "cpp/library/container/inplace_vector/assign"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/emplace_back",
+    "cppdoc": "cpp/library/container/inplace_vector/emplace_back"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/unchecked_emplace_back",
+    "cppdoc": "cpp/library/container/inplace_vector/unchecked_emplace_back"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/insert",
+    "cppdoc": "cpp/library/container/inplace_vector/insert"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/emplace",
+    "cppdoc": "cpp/library/container/inplace_vector/emplace"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/empty",
+    "cppdoc": "cpp/library/container/inplace_vector/empty"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/max_size",
+    "cppdoc": "cpp/library/container/inplace_vector/max_size"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/size",
+    "cppdoc": "cpp/library/container/inplace_vector/size"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/try_push_back",
+    "cppdoc": "cpp/library/container/inplace_vector/try_push_back"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/swap2",
+    "cppdoc": "cpp/library/container/inplace_vector/swap2"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/try_emplace_back",
+    "cppdoc": "cpp/library/container/inplace_vector/try_emplace_back"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/end",
+    "cppdoc": "cpp/library/container/inplace_vector/end"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/rend",
+    "cppdoc": "cpp/library/container/inplace_vector/rend"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/begin",
+    "cppdoc": "cpp/library/container/inplace_vector/begin"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/pop_back",
+    "cppdoc": "cpp/library/container/inplace_vector/pop_back"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/inplace_vector",
+    "cppdoc": "cpp/library/container/inplace_vector/inplace_vector"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/assign_range",
+    "cppdoc": "cpp/library/container/inplace_vector/assign_range"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/swap",
+    "cppdoc": "cpp/library/container/inplace_vector/swap"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/front",
+    "cppdoc": "cpp/library/container/inplace_vector/front"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/~inplace_vector",
+    "cppdoc": "cpp/library/container/inplace_vector/~inplace_vector"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/resize",
+    "cppdoc": "cpp/library/container/inplace_vector/resize"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/rbegin",
+    "cppdoc": "cpp/library/container/inplace_vector/rbegin"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/reserve",
+    "cppdoc": "cpp/library/container/inplace_vector/reserve"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/erase",
+    "cppdoc": "cpp/library/container/inplace_vector/erase"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/operator_cmp",
+    "cppdoc": "cpp/library/container/inplace_vector/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/insert_range",
+    "cppdoc": "cpp/library/container/inplace_vector/insert_range"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/erase2",
+    "cppdoc": "cpp/library/container/inplace_vector/erase2"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/unchecked_push_back",
+    "cppdoc": "cpp/library/container/inplace_vector/unchecked_push_back"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/capacity",
+    "cppdoc": "cpp/library/container/inplace_vector/capacity"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/operator=",
+    "cppdoc": "cpp/library/container/inplace_vector/operator="
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/data",
+    "cppdoc": "cpp/library/container/inplace_vector/data"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/push_back",
+    "cppdoc": "cpp/library/container/inplace_vector/push_back"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/shrink_to_fit",
+    "cppdoc": "cpp/library/container/inplace_vector/shrink_to_fit"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/try_append_range",
+    "cppdoc": "cpp/library/container/inplace_vector/try_append_range"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/append_range",
+    "cppdoc": "cpp/library/container/inplace_vector/append_range"
+  },
+  {
+    "cppref": "cpp/container/inplace_vector/clear",
+    "cppdoc": "cpp/library/container/inplace_vector/clear"
+  },
+  {
+    "cppref": "cpp/container/multiset/extract",
+    "cppdoc": "cpp/library/container/multiset/extract"
+  },
+  {
+    "cppref": "cpp/container/multiset/insert",
+    "cppdoc": "cpp/library/container/multiset/insert"
+  },
+  {
+    "cppref": "cpp/container/multiset/emplace",
+    "cppdoc": "cpp/library/container/multiset/emplace"
+  },
+  {
+    "cppref": "cpp/container/multiset/empty",
+    "cppdoc": "cpp/library/container/multiset/empty"
+  },
+  {
+    "cppref": "cpp/container/multiset/find",
+    "cppdoc": "cpp/library/container/multiset/find"
+  },
+  {
+    "cppref": "cpp/container/multiset/equal_range",
+    "cppdoc": "cpp/library/container/multiset/equal_range"
+  },
+  {
+    "cppref": "cpp/container/multiset/max_size",
+    "cppdoc": "cpp/library/container/multiset/max_size"
+  },
+  {
+    "cppref": "cpp/container/multiset/size",
+    "cppdoc": "cpp/library/container/multiset/size"
+  },
+  {
+    "cppref": "cpp/container/multiset/swap2",
+    "cppdoc": "cpp/library/container/multiset/swap2"
+  },
+  {
+    "cppref": "cpp/container/multiset/end",
+    "cppdoc": "cpp/library/container/multiset/end"
+  },
+  {
+    "cppref": "cpp/container/multiset/rend",
+    "cppdoc": "cpp/library/container/multiset/rend"
+  },
+  {
+    "cppref": "cpp/container/multiset/begin",
+    "cppdoc": "cpp/library/container/multiset/begin"
+  },
+  {
+    "cppref": "cpp/container/multiset/deduction_guides",
+    "cppdoc": "cpp/library/container/multiset/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/multiset/multiset",
+    "cppdoc": "cpp/library/container/multiset/multiset"
+  },
+  {
+    "cppref": "cpp/container/multiset/value_comp",
+    "cppdoc": "cpp/library/container/multiset/value_comp"
+  },
+  {
+    "cppref": "cpp/container/multiset/swap",
+    "cppdoc": "cpp/library/container/multiset/swap"
+  },
+  {
+    "cppref": "cpp/container/multiset/upper_bound",
+    "cppdoc": "cpp/library/container/multiset/upper_bound"
+  },
+  {
+    "cppref": "cpp/container/multiset/rbegin",
+    "cppdoc": "cpp/library/container/multiset/rbegin"
+  },
+  {
+    "cppref": "cpp/container/multiset/lower_bound",
+    "cppdoc": "cpp/library/container/multiset/lower_bound"
+  },
+  {
+    "cppref": "cpp/container/multiset/count",
+    "cppdoc": "cpp/library/container/multiset/count"
+  },
+  {
+    "cppref": "cpp/container/multiset/erase",
+    "cppdoc": "cpp/library/container/multiset/erase"
+  },
+  {
+    "cppref": "cpp/container/multiset/operator_cmp",
+    "cppdoc": "cpp/library/container/multiset/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/multiset/get_allocator",
+    "cppdoc": "cpp/library/container/multiset/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/multiset/contains",
+    "cppdoc": "cpp/library/container/multiset/contains"
+  },
+  {
+    "cppref": "cpp/container/multiset/merge",
+    "cppdoc": "cpp/library/container/multiset/merge"
+  },
+  {
+    "cppref": "cpp/container/multiset/erase_if",
+    "cppdoc": "cpp/library/container/multiset/erase_if"
+  },
+  {
+    "cppref": "cpp/container/multiset/insert_range",
+    "cppdoc": "cpp/library/container/multiset/insert_range"
+  },
+  {
+    "cppref": "cpp/container/multiset/emplace_hint",
+    "cppdoc": "cpp/library/container/multiset/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/multiset/key_comp",
+    "cppdoc": "cpp/library/container/multiset/key_comp"
+  },
+  {
+    "cppref": "cpp/container/multiset/operator=",
+    "cppdoc": "cpp/library/container/multiset/operator="
+  },
+  {
+    "cppref": "cpp/container/multiset/~multiset",
+    "cppdoc": "cpp/library/container/multiset/~multiset"
+  },
+  {
+    "cppref": "cpp/container/multiset/clear",
+    "cppdoc": "cpp/library/container/multiset/clear"
+  },
+  {
+    "cppref": "cpp/container/queue/back",
+    "cppdoc": "cpp/library/container/queue/back"
+  },
+  {
+    "cppref": "cpp/container/queue/push",
+    "cppdoc": "cpp/library/container/queue/push"
+  },
+  {
+    "cppref": "cpp/container/queue/emplace",
+    "cppdoc": "cpp/library/container/queue/emplace"
+  },
+  {
+    "cppref": "cpp/container/queue/empty",
+    "cppdoc": "cpp/library/container/queue/empty"
+  },
+  {
+    "cppref": "cpp/container/queue/size",
+    "cppdoc": "cpp/library/container/queue/size"
+  },
+  {
+    "cppref": "cpp/container/queue/swap2",
+    "cppdoc": "cpp/library/container/queue/swap2"
+  },
+  {
+    "cppref": "cpp/container/queue/formatter",
+    "cppdoc": "cpp/library/container/queue/formatter"
+  },
+  {
+    "cppref": "cpp/container/queue/deduction_guides",
+    "cppdoc": "cpp/library/container/queue/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/queue/swap",
+    "cppdoc": "cpp/library/container/queue/swap"
+  },
+  {
+    "cppref": "cpp/container/queue/queue",
+    "cppdoc": "cpp/library/container/queue/queue"
+  },
+  {
+    "cppref": "cpp/container/queue/front",
+    "cppdoc": "cpp/library/container/queue/front"
+  },
+  {
+    "cppref": "cpp/container/queue/push_range",
+    "cppdoc": "cpp/library/container/queue/push_range"
+  },
+  {
+    "cppref": "cpp/container/queue/operator_cmp",
+    "cppdoc": "cpp/library/container/queue/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/queue/operator=",
+    "cppdoc": "cpp/library/container/queue/operator="
+  },
+  {
+    "cppref": "cpp/container/queue/pop",
+    "cppdoc": "cpp/library/container/queue/pop"
+  },
+  {
+    "cppref": "cpp/container/queue/~queue",
+    "cppdoc": "cpp/library/container/queue/~queue"
+  },
+  {
+    "cppref": "cpp/container/queue/uses_allocator",
+    "cppdoc": "cpp/library/container/queue/uses_allocator"
+  },
+  {
+    "cppref": "cpp/container/vector_bool/hash",
+    "cppdoc": "cpp/library/container/vector_bool/hash"
+  },
+  {
+    "cppref": "cpp/container/vector_bool/swap",
+    "cppdoc": "cpp/library/container/vector_bool/swap"
+  },
+  {
+    "cppref": "cpp/container/vector_bool/flip",
+    "cppdoc": "cpp/library/container/vector_bool/flip"
+  },
+  {
+    "cppref": "cpp/container/vector_bool/reference",
+    "cppdoc": "cpp/library/container/vector_bool/reference"
+  },
+  {
+    "cppref": "cpp/container/span/span",
+    "cppdoc": "cpp/library/container/span/span"
+  },
+  {
+    "cppref": "cpp/container/span/operator_at",
+    "cppdoc": "cpp/library/container/span/operator_at"
+  },
+  {
+    "cppref": "cpp/container/span/at",
+    "cppdoc": "cpp/library/container/span/at"
+  },
+  {
+    "cppref": "cpp/container/span/back",
+    "cppdoc": "cpp/library/container/span/back"
+  },
+  {
+    "cppref": "cpp/container/span/first",
+    "cppdoc": "cpp/library/container/span/first"
+  },
+  {
+    "cppref": "cpp/container/span/empty",
+    "cppdoc": "cpp/library/container/span/empty"
+  },
+  {
+    "cppref": "cpp/container/span/size",
+    "cppdoc": "cpp/library/container/span/size"
+  },
+  {
+    "cppref": "cpp/container/span/size_bytes",
+    "cppdoc": "cpp/library/container/span/size_bytes"
+  },
+  {
+    "cppref": "cpp/container/span/end",
+    "cppdoc": "cpp/library/container/span/end"
+  },
+  {
+    "cppref": "cpp/container/span/rend",
+    "cppdoc": "cpp/library/container/span/rend"
+  },
+  {
+    "cppref": "cpp/container/span/begin",
+    "cppdoc": "cpp/library/container/span/begin"
+  },
+  {
+    "cppref": "cpp/container/span/deduction_guides",
+    "cppdoc": "cpp/library/container/span/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/span/front",
+    "cppdoc": "cpp/library/container/span/front"
+  },
+  {
+    "cppref": "cpp/container/span/rbegin",
+    "cppdoc": "cpp/library/container/span/rbegin"
+  },
+  {
+    "cppref": "cpp/container/span/last",
+    "cppdoc": "cpp/library/container/span/last"
+  },
+  {
+    "cppref": "cpp/container/span/as_bytes",
+    "cppdoc": "cpp/library/container/span/as_bytes"
+  },
+  {
+    "cppref": "cpp/container/span/subspan",
+    "cppdoc": "cpp/library/container/span/subspan"
+  },
+  {
+    "cppref": "cpp/container/span/dynamic_extent",
+    "cppdoc": "cpp/library/container/span/dynamic_extent"
+  },
+  {
+    "cppref": "cpp/container/span/operator=",
+    "cppdoc": "cpp/library/container/span/operator="
+  },
+  {
+    "cppref": "cpp/container/span/data",
+    "cppdoc": "cpp/library/container/span/data"
+  },
+  {
+    "cppref": "cpp/container/deque/operator_at",
+    "cppdoc": "cpp/library/container/deque/operator_at"
+  },
+  {
+    "cppref": "cpp/container/deque/at",
+    "cppdoc": "cpp/library/container/deque/at"
+  },
+  {
+    "cppref": "cpp/container/deque/back",
+    "cppdoc": "cpp/library/container/deque/back"
+  },
+  {
+    "cppref": "cpp/container/deque/assign",
+    "cppdoc": "cpp/library/container/deque/assign"
+  },
+  {
+    "cppref": "cpp/container/deque/emplace_back",
+    "cppdoc": "cpp/library/container/deque/emplace_back"
+  },
+  {
+    "cppref": "cpp/container/deque/insert",
+    "cppdoc": "cpp/library/container/deque/insert"
+  },
+  {
+    "cppref": "cpp/container/deque/emplace",
+    "cppdoc": "cpp/library/container/deque/emplace"
+  },
+  {
+    "cppref": "cpp/container/deque/empty",
+    "cppdoc": "cpp/library/container/deque/empty"
+  },
+  {
+    "cppref": "cpp/container/deque/max_size",
+    "cppdoc": "cpp/library/container/deque/max_size"
+  },
+  {
+    "cppref": "cpp/container/deque/size",
+    "cppdoc": "cpp/library/container/deque/size"
+  },
+  {
+    "cppref": "cpp/container/deque/emplace_front",
+    "cppdoc": "cpp/library/container/deque/emplace_front"
+  },
+  {
+    "cppref": "cpp/container/deque/swap2",
+    "cppdoc": "cpp/library/container/deque/swap2"
+  },
+  {
+    "cppref": "cpp/container/deque/end",
+    "cppdoc": "cpp/library/container/deque/end"
+  },
+  {
+    "cppref": "cpp/container/deque/rend",
+    "cppdoc": "cpp/library/container/deque/rend"
+  },
+  {
+    "cppref": "cpp/container/deque/begin",
+    "cppdoc": "cpp/library/container/deque/begin"
+  },
+  {
+    "cppref": "cpp/container/deque/~deque",
+    "cppdoc": "cpp/library/container/deque/~deque"
+  },
+  {
+    "cppref": "cpp/container/deque/deduction_guides",
+    "cppdoc": "cpp/library/container/deque/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/deque/pop_back",
+    "cppdoc": "cpp/library/container/deque/pop_back"
+  },
+  {
+    "cppref": "cpp/container/deque/assign_range",
+    "cppdoc": "cpp/library/container/deque/assign_range"
+  },
+  {
+    "cppref": "cpp/container/deque/swap",
+    "cppdoc": "cpp/library/container/deque/swap"
+  },
+  {
+    "cppref": "cpp/container/deque/front",
+    "cppdoc": "cpp/library/container/deque/front"
+  },
+  {
+    "cppref": "cpp/container/deque/resize",
+    "cppdoc": "cpp/library/container/deque/resize"
+  },
+  {
+    "cppref": "cpp/container/deque/rbegin",
+    "cppdoc": "cpp/library/container/deque/rbegin"
+  },
+  {
+    "cppref": "cpp/container/deque/erase",
+    "cppdoc": "cpp/library/container/deque/erase"
+  },
+  {
+    "cppref": "cpp/container/deque/pop_front",
+    "cppdoc": "cpp/library/container/deque/pop_front"
+  },
+  {
+    "cppref": "cpp/container/deque/operator_cmp",
+    "cppdoc": "cpp/library/container/deque/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/deque/get_allocator",
+    "cppdoc": "cpp/library/container/deque/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/deque/deque",
+    "cppdoc": "cpp/library/container/deque/deque"
+  },
+  {
+    "cppref": "cpp/container/deque/insert_range",
+    "cppdoc": "cpp/library/container/deque/insert_range"
+  },
+  {
+    "cppref": "cpp/container/deque/erase2",
+    "cppdoc": "cpp/library/container/deque/erase2"
+  },
+  {
+    "cppref": "cpp/container/deque/push_front",
+    "cppdoc": "cpp/library/container/deque/push_front"
+  },
+  {
+    "cppref": "cpp/container/deque/operator=",
+    "cppdoc": "cpp/library/container/deque/operator="
+  },
+  {
+    "cppref": "cpp/container/deque/push_back",
+    "cppdoc": "cpp/library/container/deque/push_back"
+  },
+  {
+    "cppref": "cpp/container/deque/shrink_to_fit",
+    "cppdoc": "cpp/library/container/deque/shrink_to_fit"
+  },
+  {
+    "cppref": "cpp/container/deque/prepend_range",
+    "cppdoc": "cpp/library/container/deque/prepend_range"
+  },
+  {
+    "cppref": "cpp/container/deque/append_range",
+    "cppdoc": "cpp/library/container/deque/append_range"
+  },
+  {
+    "cppref": "cpp/container/deque/clear",
+    "cppdoc": "cpp/library/container/deque/clear"
+  },
+  {
+    "cppref": "cpp/container/list/back",
+    "cppdoc": "cpp/library/container/list/back"
+  },
+  {
+    "cppref": "cpp/container/list/remove",
+    "cppdoc": "cpp/library/container/list/remove"
+  },
+  {
+    "cppref": "cpp/container/list/assign",
+    "cppdoc": "cpp/library/container/list/assign"
+  },
+  {
+    "cppref": "cpp/container/list/emplace_back",
+    "cppdoc": "cpp/library/container/list/emplace_back"
+  },
+  {
+    "cppref": "cpp/container/list/insert",
+    "cppdoc": "cpp/library/container/list/insert"
+  },
+  {
+    "cppref": "cpp/container/list/emplace",
+    "cppdoc": "cpp/library/container/list/emplace"
+  },
+  {
+    "cppref": "cpp/container/list/empty",
+    "cppdoc": "cpp/library/container/list/empty"
+  },
+  {
+    "cppref": "cpp/container/list/max_size",
+    "cppdoc": "cpp/library/container/list/max_size"
+  },
+  {
+    "cppref": "cpp/container/list/size",
+    "cppdoc": "cpp/library/container/list/size"
+  },
+  {
+    "cppref": "cpp/container/list/emplace_front",
+    "cppdoc": "cpp/library/container/list/emplace_front"
+  },
+  {
+    "cppref": "cpp/container/list/swap2",
+    "cppdoc": "cpp/library/container/list/swap2"
+  },
+  {
+    "cppref": "cpp/container/list/end",
+    "cppdoc": "cpp/library/container/list/end"
+  },
+  {
+    "cppref": "cpp/container/list/list",
+    "cppdoc": "cpp/library/container/list/list"
+  },
+  {
+    "cppref": "cpp/container/list/rend",
+    "cppdoc": "cpp/library/container/list/rend"
+  },
+  {
+    "cppref": "cpp/container/list/splice",
+    "cppdoc": "cpp/library/container/list/splice"
+  },
+  {
+    "cppref": "cpp/container/list/begin",
+    "cppdoc": "cpp/library/container/list/begin"
+  },
+  {
+    "cppref": "cpp/container/list/deduction_guides",
+    "cppdoc": "cpp/library/container/list/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/list/pop_back",
+    "cppdoc": "cpp/library/container/list/pop_back"
+  },
+  {
+    "cppref": "cpp/container/list/assign_range",
+    "cppdoc": "cpp/library/container/list/assign_range"
+  },
+  {
+    "cppref": "cpp/container/list/swap",
+    "cppdoc": "cpp/library/container/list/swap"
+  },
+  {
+    "cppref": "cpp/container/list/front",
+    "cppdoc": "cpp/library/container/list/front"
+  },
+  {
+    "cppref": "cpp/container/list/resize",
+    "cppdoc": "cpp/library/container/list/resize"
+  },
+  {
+    "cppref": "cpp/container/list/rbegin",
+    "cppdoc": "cpp/library/container/list/rbegin"
+  },
+  {
+    "cppref": "cpp/container/list/erase",
+    "cppdoc": "cpp/library/container/list/erase"
+  },
+  {
+    "cppref": "cpp/container/list/pop_front",
+    "cppdoc": "cpp/library/container/list/pop_front"
+  },
+  {
+    "cppref": "cpp/container/list/operator_cmp",
+    "cppdoc": "cpp/library/container/list/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/list/get_allocator",
+    "cppdoc": "cpp/library/container/list/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/list/~list",
+    "cppdoc": "cpp/library/container/list/~list"
+  },
+  {
+    "cppref": "cpp/container/list/merge",
+    "cppdoc": "cpp/library/container/list/merge"
+  },
+  {
+    "cppref": "cpp/container/list/unique",
+    "cppdoc": "cpp/library/container/list/unique"
+  },
+  {
+    "cppref": "cpp/container/list/insert_range",
+    "cppdoc": "cpp/library/container/list/insert_range"
+  },
+  {
+    "cppref": "cpp/container/list/erase2",
+    "cppdoc": "cpp/library/container/list/erase2"
+  },
+  {
+    "cppref": "cpp/container/list/sort",
+    "cppdoc": "cpp/library/container/list/sort"
+  },
+  {
+    "cppref": "cpp/container/list/push_front",
+    "cppdoc": "cpp/library/container/list/push_front"
+  },
+  {
+    "cppref": "cpp/container/list/operator=",
+    "cppdoc": "cpp/library/container/list/operator="
+  },
+  {
+    "cppref": "cpp/container/list/push_back",
+    "cppdoc": "cpp/library/container/list/push_back"
+  },
+  {
+    "cppref": "cpp/container/list/prepend_range",
+    "cppdoc": "cpp/library/container/list/prepend_range"
+  },
+  {
+    "cppref": "cpp/container/list/append_range",
+    "cppdoc": "cpp/library/container/list/append_range"
+  },
+  {
+    "cppref": "cpp/container/list/clear",
+    "cppdoc": "cpp/library/container/list/clear"
+  },
+  {
+    "cppref": "cpp/container/list/reverse",
+    "cppdoc": "cpp/library/container/list/reverse"
+  },
+  {
+    "cppref": "cpp/container/stack/stack",
+    "cppdoc": "cpp/library/container/stack/stack"
+  },
+  {
+    "cppref": "cpp/container/stack/push",
+    "cppdoc": "cpp/library/container/stack/push"
+  },
+  {
+    "cppref": "cpp/container/stack/emplace",
+    "cppdoc": "cpp/library/container/stack/emplace"
+  },
+  {
+    "cppref": "cpp/container/stack/empty",
+    "cppdoc": "cpp/library/container/stack/empty"
+  },
+  {
+    "cppref": "cpp/container/stack/size",
+    "cppdoc": "cpp/library/container/stack/size"
+  },
+  {
+    "cppref": "cpp/container/stack/swap2",
+    "cppdoc": "cpp/library/container/stack/swap2"
+  },
+  {
+    "cppref": "cpp/container/stack/formatter",
+    "cppdoc": "cpp/library/container/stack/formatter"
+  },
+  {
+    "cppref": "cpp/container/stack/top",
+    "cppdoc": "cpp/library/container/stack/top"
+  },
+  {
+    "cppref": "cpp/container/stack/deduction_guides",
+    "cppdoc": "cpp/library/container/stack/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/stack/~stack",
+    "cppdoc": "cpp/library/container/stack/~stack"
+  },
+  {
+    "cppref": "cpp/container/stack/swap",
+    "cppdoc": "cpp/library/container/stack/swap"
+  },
+  {
+    "cppref": "cpp/container/stack/push_range",
+    "cppdoc": "cpp/library/container/stack/push_range"
+  },
+  {
+    "cppref": "cpp/container/stack/operator_cmp",
+    "cppdoc": "cpp/library/container/stack/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/stack/operator=",
+    "cppdoc": "cpp/library/container/stack/operator="
+  },
+  {
+    "cppref": "cpp/container/stack/pop",
+    "cppdoc": "cpp/library/container/stack/pop"
+  },
+  {
+    "cppref": "cpp/container/stack/uses_allocator",
+    "cppdoc": "cpp/library/container/stack/uses_allocator"
+  },
+  {
+    "cppref": "cpp/container/vector/operator_at",
+    "cppdoc": "cpp/library/container/vector/operator_at"
+  },
+  {
+    "cppref": "cpp/container/vector/at",
+    "cppdoc": "cpp/library/container/vector/at"
+  },
+  {
+    "cppref": "cpp/container/vector/back",
+    "cppdoc": "cpp/library/container/vector/back"
+  },
+  {
+    "cppref": "cpp/container/vector/assign",
+    "cppdoc": "cpp/library/container/vector/assign"
+  },
+  {
+    "cppref": "cpp/container/vector/emplace_back",
+    "cppdoc": "cpp/library/container/vector/emplace_back"
+  },
+  {
+    "cppref": "cpp/container/vector/insert",
+    "cppdoc": "cpp/library/container/vector/insert"
+  },
+  {
+    "cppref": "cpp/container/vector/emplace",
+    "cppdoc": "cpp/library/container/vector/emplace"
+  },
+  {
+    "cppref": "cpp/container/vector/empty",
+    "cppdoc": "cpp/library/container/vector/empty"
+  },
+  {
+    "cppref": "cpp/container/vector/max_size",
+    "cppdoc": "cpp/library/container/vector/max_size"
+  },
+  {
+    "cppref": "cpp/container/vector/size",
+    "cppdoc": "cpp/library/container/vector/size"
+  },
+  {
+    "cppref": "cpp/container/vector/swap2",
+    "cppdoc": "cpp/library/container/vector/swap2"
+  },
+  {
+    "cppref": "cpp/container/vector/end",
+    "cppdoc": "cpp/library/container/vector/end"
+  },
+  {
+    "cppref": "cpp/container/vector/rend",
+    "cppdoc": "cpp/library/container/vector/rend"
+  },
+  {
+    "cppref": "cpp/container/vector/begin",
+    "cppdoc": "cpp/library/container/vector/begin"
+  },
+  {
+    "cppref": "cpp/container/vector/deduction_guides",
+    "cppdoc": "cpp/library/container/vector/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/vector/pop_back",
+    "cppdoc": "cpp/library/container/vector/pop_back"
+  },
+  {
+    "cppref": "cpp/container/vector/assign_range",
+    "cppdoc": "cpp/library/container/vector/assign_range"
+  },
+  {
+    "cppref": "cpp/container/vector/swap",
+    "cppdoc": "cpp/library/container/vector/swap"
+  },
+  {
+    "cppref": "cpp/container/vector/front",
+    "cppdoc": "cpp/library/container/vector/front"
+  },
+  {
+    "cppref": "cpp/container/vector/resize",
+    "cppdoc": "cpp/library/container/vector/resize"
+  },
+  {
+    "cppref": "cpp/container/vector/rbegin",
+    "cppdoc": "cpp/library/container/vector/rbegin"
+  },
+  {
+    "cppref": "cpp/container/vector/reserve",
+    "cppdoc": "cpp/library/container/vector/reserve"
+  },
+  {
+    "cppref": "cpp/container/vector/erase",
+    "cppdoc": "cpp/library/container/vector/erase"
+  },
+  {
+    "cppref": "cpp/container/vector/operator_cmp",
+    "cppdoc": "cpp/library/container/vector/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/vector/get_allocator",
+    "cppdoc": "cpp/library/container/vector/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/vector/insert_range",
+    "cppdoc": "cpp/library/container/vector/insert_range"
+  },
+  {
+    "cppref": "cpp/container/vector/erase2",
+    "cppdoc": "cpp/library/container/vector/erase2"
+  },
+  {
+    "cppref": "cpp/container/vector/~vector",
+    "cppdoc": "cpp/library/container/vector/~vector"
+  },
+  {
+    "cppref": "cpp/container/vector/capacity",
+    "cppdoc": "cpp/library/container/vector/capacity"
+  },
+  {
+    "cppref": "cpp/container/vector/operator=",
+    "cppdoc": "cpp/library/container/vector/operator="
+  },
+  {
+    "cppref": "cpp/container/vector/data",
+    "cppdoc": "cpp/library/container/vector/data"
+  },
+  {
+    "cppref": "cpp/container/vector/push_back",
+    "cppdoc": "cpp/library/container/vector/push_back"
+  },
+  {
+    "cppref": "cpp/container/vector/shrink_to_fit",
+    "cppdoc": "cpp/library/container/vector/shrink_to_fit"
+  },
+  {
+    "cppref": "cpp/container/vector/append_range",
+    "cppdoc": "cpp/library/container/vector/append_range"
+  },
+  {
+    "cppref": "cpp/container/vector/clear",
+    "cppdoc": "cpp/library/container/vector/clear"
+  },
+  {
+    "cppref": "cpp/container/vector/vector",
+    "cppdoc": "cpp/library/container/vector/vector"
+  },
+  {
+    "cppref": "cpp/container/multimap/extract",
+    "cppdoc": "cpp/library/container/multimap/extract"
+  },
+  {
+    "cppref": "cpp/container/multimap/insert",
+    "cppdoc": "cpp/library/container/multimap/insert"
+  },
+  {
+    "cppref": "cpp/container/multimap/emplace",
+    "cppdoc": "cpp/library/container/multimap/emplace"
+  },
+  {
+    "cppref": "cpp/container/multimap/empty",
+    "cppdoc": "cpp/library/container/multimap/empty"
+  },
+  {
+    "cppref": "cpp/container/multimap/find",
+    "cppdoc": "cpp/library/container/multimap/find"
+  },
+  {
+    "cppref": "cpp/container/multimap/equal_range",
+    "cppdoc": "cpp/library/container/multimap/equal_range"
+  },
+  {
+    "cppref": "cpp/container/multimap/max_size",
+    "cppdoc": "cpp/library/container/multimap/max_size"
+  },
+  {
+    "cppref": "cpp/container/multimap/size",
+    "cppdoc": "cpp/library/container/multimap/size"
+  },
+  {
+    "cppref": "cpp/container/multimap/swap2",
+    "cppdoc": "cpp/library/container/multimap/swap2"
+  },
+  {
+    "cppref": "cpp/container/multimap/end",
+    "cppdoc": "cpp/library/container/multimap/end"
+  },
+  {
+    "cppref": "cpp/container/multimap/value_compare",
+    "cppdoc": "cpp/library/container/multimap/value_compare"
+  },
+  {
+    "cppref": "cpp/container/multimap/rend",
+    "cppdoc": "cpp/library/container/multimap/rend"
+  },
+  {
+    "cppref": "cpp/container/multimap/begin",
+    "cppdoc": "cpp/library/container/multimap/begin"
+  },
+  {
+    "cppref": "cpp/container/multimap/deduction_guides",
+    "cppdoc": "cpp/library/container/multimap/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/multimap/value_comp",
+    "cppdoc": "cpp/library/container/multimap/value_comp"
+  },
+  {
+    "cppref": "cpp/container/multimap/swap",
+    "cppdoc": "cpp/library/container/multimap/swap"
+  },
+  {
+    "cppref": "cpp/container/multimap/upper_bound",
+    "cppdoc": "cpp/library/container/multimap/upper_bound"
+  },
+  {
+    "cppref": "cpp/container/multimap/rbegin",
+    "cppdoc": "cpp/library/container/multimap/rbegin"
+  },
+  {
+    "cppref": "cpp/container/multimap/lower_bound",
+    "cppdoc": "cpp/library/container/multimap/lower_bound"
+  },
+  {
+    "cppref": "cpp/container/multimap/count",
+    "cppdoc": "cpp/library/container/multimap/count"
+  },
+  {
+    "cppref": "cpp/container/multimap/erase",
+    "cppdoc": "cpp/library/container/multimap/erase"
+  },
+  {
+    "cppref": "cpp/container/multimap/operator_cmp",
+    "cppdoc": "cpp/library/container/multimap/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/multimap/get_allocator",
+    "cppdoc": "cpp/library/container/multimap/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/multimap/contains",
+    "cppdoc": "cpp/library/container/multimap/contains"
+  },
+  {
+    "cppref": "cpp/container/multimap/merge",
+    "cppdoc": "cpp/library/container/multimap/merge"
+  },
+  {
+    "cppref": "cpp/container/multimap/erase_if",
+    "cppdoc": "cpp/library/container/multimap/erase_if"
+  },
+  {
+    "cppref": "cpp/container/multimap/insert_range",
+    "cppdoc": "cpp/library/container/multimap/insert_range"
+  },
+  {
+    "cppref": "cpp/container/multimap/multimap",
+    "cppdoc": "cpp/library/container/multimap/multimap"
+  },
+  {
+    "cppref": "cpp/container/multimap/emplace_hint",
+    "cppdoc": "cpp/library/container/multimap/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/multimap/~multimap",
+    "cppdoc": "cpp/library/container/multimap/~multimap"
+  },
+  {
+    "cppref": "cpp/container/multimap/key_comp",
+    "cppdoc": "cpp/library/container/multimap/key_comp"
+  },
+  {
+    "cppref": "cpp/container/multimap/operator=",
+    "cppdoc": "cpp/library/container/multimap/operator="
+  },
+  {
+    "cppref": "cpp/container/multimap/clear",
+    "cppdoc": "cpp/library/container/multimap/clear"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/replace",
+    "cppdoc": "cpp/library/container/flat_multiset/replace"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/extract",
+    "cppdoc": "cpp/library/container/flat_multiset/extract"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/insert",
+    "cppdoc": "cpp/library/container/flat_multiset/insert"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/emplace",
+    "cppdoc": "cpp/library/container/flat_multiset/emplace"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/empty",
+    "cppdoc": "cpp/library/container/flat_multiset/empty"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/find",
+    "cppdoc": "cpp/library/container/flat_multiset/find"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/equal_range",
+    "cppdoc": "cpp/library/container/flat_multiset/equal_range"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/max_size",
+    "cppdoc": "cpp/library/container/flat_multiset/max_size"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/size",
+    "cppdoc": "cpp/library/container/flat_multiset/size"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/swap2",
+    "cppdoc": "cpp/library/container/flat_multiset/swap2"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/end",
+    "cppdoc": "cpp/library/container/flat_multiset/end"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/rend",
+    "cppdoc": "cpp/library/container/flat_multiset/rend"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/begin",
+    "cppdoc": "cpp/library/container/flat_multiset/begin"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/deduction_guides",
+    "cppdoc": "cpp/library/container/flat_multiset/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/value_comp",
+    "cppdoc": "cpp/library/container/flat_multiset/value_comp"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/swap",
+    "cppdoc": "cpp/library/container/flat_multiset/swap"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/upper_bound",
+    "cppdoc": "cpp/library/container/flat_multiset/upper_bound"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/rbegin",
+    "cppdoc": "cpp/library/container/flat_multiset/rbegin"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/lower_bound",
+    "cppdoc": "cpp/library/container/flat_multiset/lower_bound"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/count",
+    "cppdoc": "cpp/library/container/flat_multiset/count"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/erase",
+    "cppdoc": "cpp/library/container/flat_multiset/erase"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/operator_cmp",
+    "cppdoc": "cpp/library/container/flat_multiset/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/contains",
+    "cppdoc": "cpp/library/container/flat_multiset/contains"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/erase_if",
+    "cppdoc": "cpp/library/container/flat_multiset/erase_if"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/insert_range",
+    "cppdoc": "cpp/library/container/flat_multiset/insert_range"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/emplace_hint",
+    "cppdoc": "cpp/library/container/flat_multiset/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/key_comp",
+    "cppdoc": "cpp/library/container/flat_multiset/key_comp"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/operator=",
+    "cppdoc": "cpp/library/container/flat_multiset/operator="
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/clear",
+    "cppdoc": "cpp/library/container/flat_multiset/clear"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/flat_multiset",
+    "cppdoc": "cpp/library/container/flat_multiset/flat_multiset"
+  },
+  {
+    "cppref": "cpp/container/flat_multiset/uses_allocator",
+    "cppdoc": "cpp/library/container/flat_multiset/uses_allocator"
+  },
+  {
+    "cppref": "cpp/container/flat_set/replace",
+    "cppdoc": "cpp/library/container/flat_set/replace"
+  },
+  {
+    "cppref": "cpp/container/flat_set/extract",
+    "cppdoc": "cpp/library/container/flat_set/extract"
+  },
+  {
+    "cppref": "cpp/container/flat_set/insert",
+    "cppdoc": "cpp/library/container/flat_set/insert"
+  },
+  {
+    "cppref": "cpp/container/flat_set/emplace",
+    "cppdoc": "cpp/library/container/flat_set/emplace"
+  },
+  {
+    "cppref": "cpp/container/flat_set/empty",
+    "cppdoc": "cpp/library/container/flat_set/empty"
+  },
+  {
+    "cppref": "cpp/container/flat_set/find",
+    "cppdoc": "cpp/library/container/flat_set/find"
+  },
+  {
+    "cppref": "cpp/container/flat_set/equal_range",
+    "cppdoc": "cpp/library/container/flat_set/equal_range"
+  },
+  {
+    "cppref": "cpp/container/flat_set/max_size",
+    "cppdoc": "cpp/library/container/flat_set/max_size"
+  },
+  {
+    "cppref": "cpp/container/flat_set/size",
+    "cppdoc": "cpp/library/container/flat_set/size"
+  },
+  {
+    "cppref": "cpp/container/flat_set/swap2",
+    "cppdoc": "cpp/library/container/flat_set/swap2"
+  },
+  {
+    "cppref": "cpp/container/flat_set/end",
+    "cppdoc": "cpp/library/container/flat_set/end"
+  },
+  {
+    "cppref": "cpp/container/flat_set/rend",
+    "cppdoc": "cpp/library/container/flat_set/rend"
+  },
+  {
+    "cppref": "cpp/container/flat_set/begin",
+    "cppdoc": "cpp/library/container/flat_set/begin"
+  },
+  {
+    "cppref": "cpp/container/flat_set/deduction_guides",
+    "cppdoc": "cpp/library/container/flat_set/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/flat_set/value_comp",
+    "cppdoc": "cpp/library/container/flat_set/value_comp"
+  },
+  {
+    "cppref": "cpp/container/flat_set/swap",
+    "cppdoc": "cpp/library/container/flat_set/swap"
+  },
+  {
+    "cppref": "cpp/container/flat_set/flat_set",
+    "cppdoc": "cpp/library/container/flat_set/flat_set"
+  },
+  {
+    "cppref": "cpp/container/flat_set/upper_bound",
+    "cppdoc": "cpp/library/container/flat_set/upper_bound"
+  },
+  {
+    "cppref": "cpp/container/flat_set/rbegin",
+    "cppdoc": "cpp/library/container/flat_set/rbegin"
+  },
+  {
+    "cppref": "cpp/container/flat_set/lower_bound",
+    "cppdoc": "cpp/library/container/flat_set/lower_bound"
+  },
+  {
+    "cppref": "cpp/container/flat_set/count",
+    "cppdoc": "cpp/library/container/flat_set/count"
+  },
+  {
+    "cppref": "cpp/container/flat_set/erase",
+    "cppdoc": "cpp/library/container/flat_set/erase"
+  },
+  {
+    "cppref": "cpp/container/flat_set/operator_cmp",
+    "cppdoc": "cpp/library/container/flat_set/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/flat_set/contains",
+    "cppdoc": "cpp/library/container/flat_set/contains"
+  },
+  {
+    "cppref": "cpp/container/flat_set/erase_if",
+    "cppdoc": "cpp/library/container/flat_set/erase_if"
+  },
+  {
+    "cppref": "cpp/container/flat_set/insert_range",
+    "cppdoc": "cpp/library/container/flat_set/insert_range"
+  },
+  {
+    "cppref": "cpp/container/flat_set/emplace_hint",
+    "cppdoc": "cpp/library/container/flat_set/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/flat_set/key_comp",
+    "cppdoc": "cpp/library/container/flat_set/key_comp"
+  },
+  {
+    "cppref": "cpp/container/flat_set/operator=",
+    "cppdoc": "cpp/library/container/flat_set/operator="
+  },
+  {
+    "cppref": "cpp/container/flat_set/clear",
+    "cppdoc": "cpp/library/container/flat_set/clear"
+  },
+  {
+    "cppref": "cpp/container/flat_set/uses_allocator",
+    "cppdoc": "cpp/library/container/flat_set/uses_allocator"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/bucket_count",
+    "cppdoc": "cpp/library/container/unordered_multiset/bucket_count"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/end2",
+    "cppdoc": "cpp/library/container/unordered_multiset/end2"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/extract",
+    "cppdoc": "cpp/library/container/unordered_multiset/extract"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/insert",
+    "cppdoc": "cpp/library/container/unordered_multiset/insert"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/emplace",
+    "cppdoc": "cpp/library/container/unordered_multiset/emplace"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/empty",
+    "cppdoc": "cpp/library/container/unordered_multiset/empty"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/find",
+    "cppdoc": "cpp/library/container/unordered_multiset/find"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/equal_range",
+    "cppdoc": "cpp/library/container/unordered_multiset/equal_range"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/max_size",
+    "cppdoc": "cpp/library/container/unordered_multiset/max_size"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/size",
+    "cppdoc": "cpp/library/container/unordered_multiset/size"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/swap2",
+    "cppdoc": "cpp/library/container/unordered_multiset/swap2"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/end",
+    "cppdoc": "cpp/library/container/unordered_multiset/end"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/load_factor",
+    "cppdoc": "cpp/library/container/unordered_multiset/load_factor"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/rehash",
+    "cppdoc": "cpp/library/container/unordered_multiset/rehash"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/begin2",
+    "cppdoc": "cpp/library/container/unordered_multiset/begin2"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/begin",
+    "cppdoc": "cpp/library/container/unordered_multiset/begin"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/deduction_guides",
+    "cppdoc": "cpp/library/container/unordered_multiset/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/unordered_multiset",
+    "cppdoc": "cpp/library/container/unordered_multiset/unordered_multiset"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/max_bucket_count",
+    "cppdoc": "cpp/library/container/unordered_multiset/max_bucket_count"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/swap",
+    "cppdoc": "cpp/library/container/unordered_multiset/swap"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/reserve",
+    "cppdoc": "cpp/library/container/unordered_multiset/reserve"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/count",
+    "cppdoc": "cpp/library/container/unordered_multiset/count"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/erase",
+    "cppdoc": "cpp/library/container/unordered_multiset/erase"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/operator_cmp",
+    "cppdoc": "cpp/library/container/unordered_multiset/operator_cmp"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/get_allocator",
+    "cppdoc": "cpp/library/container/unordered_multiset/get_allocator"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/contains",
+    "cppdoc": "cpp/library/container/unordered_multiset/contains"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/merge",
+    "cppdoc": "cpp/library/container/unordered_multiset/merge"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/erase_if",
+    "cppdoc": "cpp/library/container/unordered_multiset/erase_if"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/insert_range",
+    "cppdoc": "cpp/library/container/unordered_multiset/insert_range"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/key_eq",
+    "cppdoc": "cpp/library/container/unordered_multiset/key_eq"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/~unordered_multiset",
+    "cppdoc": "cpp/library/container/unordered_multiset/~unordered_multiset"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/bucket",
+    "cppdoc": "cpp/library/container/unordered_multiset/bucket"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/emplace_hint",
+    "cppdoc": "cpp/library/container/unordered_multiset/emplace_hint"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/hash_function",
+    "cppdoc": "cpp/library/container/unordered_multiset/hash_function"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/operator=",
+    "cppdoc": "cpp/library/container/unordered_multiset/operator="
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/max_load_factor",
+    "cppdoc": "cpp/library/container/unordered_multiset/max_load_factor"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/bucket_size",
+    "cppdoc": "cpp/library/container/unordered_multiset/bucket_size"
+  },
+  {
+    "cppref": "cpp/container/unordered_multiset/clear",
+    "cppdoc": "cpp/library/container/unordered_multiset/clear"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/push",
+    "cppdoc": "cpp/library/container/priority_queue/push"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/emplace",
+    "cppdoc": "cpp/library/container/priority_queue/emplace"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/empty",
+    "cppdoc": "cpp/library/container/priority_queue/empty"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/size",
+    "cppdoc": "cpp/library/container/priority_queue/size"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/priority_queue",
+    "cppdoc": "cpp/library/container/priority_queue/priority_queue"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/swap2",
+    "cppdoc": "cpp/library/container/priority_queue/swap2"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/formatter",
+    "cppdoc": "cpp/library/container/priority_queue/formatter"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/~priority_queue",
+    "cppdoc": "cpp/library/container/priority_queue/~priority_queue"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/top",
+    "cppdoc": "cpp/library/container/priority_queue/top"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/deduction_guides",
+    "cppdoc": "cpp/library/container/priority_queue/deduction_guides"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/swap",
+    "cppdoc": "cpp/library/container/priority_queue/swap"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/push_range",
+    "cppdoc": "cpp/library/container/priority_queue/push_range"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/operator=",
+    "cppdoc": "cpp/library/container/priority_queue/operator="
+  },
+  {
+    "cppref": "cpp/container/priority_queue/pop",
+    "cppdoc": "cpp/library/container/priority_queue/pop"
+  },
+  {
+    "cppref": "cpp/container/priority_queue/uses_allocator",
+    "cppdoc": "cpp/library/container/priority_queue/uses_allocator"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day",
+    "cppdoc": "cpp/library/chrono/year_month_day"
+  },
+  {
+    "cppref": "cpp/chrono/steady_clock",
+    "cppdoc": "cpp/library/chrono/steady_clock"
+  },
+  {
+    "cppref": "cpp/chrono/tzdb_functions",
+    "cppdoc": "cpp/library/chrono/tzdb_functions"
+  },
+  {
+    "cppref": "cpp/chrono/locate_zone",
+    "cppdoc": "cpp/library/chrono/locate_zone"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday_last",
+    "cppdoc": "cpp/library/chrono/month_weekday_last"
+  },
+  {
+    "cppref": "cpp/chrono/duration",
+    "cppdoc": "cpp/library/chrono/duration"
+  },
+  {
+    "cppref": "cpp/chrono/operator_q__q_ms",
+    "cppdoc": "cpp/library/chrono/duration/operator_q__q_ms"
+  },
+  {
+    "cppref": "cpp/chrono/utc_clock",
+    "cppdoc": "cpp/library/chrono/utc_clock"
+  },
+  {
+    "cppref": "cpp/chrono/system_clock",
+    "cppdoc": "cpp/library/chrono/system_clock"
+  },
+  {
+    "cppref": "cpp/chrono/operator_slash",
+    "cppdoc": "cpp/library/chrono/operator_slash"
+  },
+  {
+    "cppref": "cpp/chrono/operator_q__q_us",
+    "cppdoc": "cpp/library/chrono/duration/operator_q__q_us"
+  },
+  {
+    "cppref": "cpp/chrono/leap_second",
+    "cppdoc": "cpp/library/chrono/leap_second"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last",
+    "cppdoc": "cpp/library/chrono/year_month_day_last"
+  },
+  {
+    "cppref": "cpp/chrono/clock_time_conversion",
+    "cppdoc": "cpp/library/chrono/clock_time_conversion"
+  },
+  {
+    "cppref": "cpp/chrono/duration_values",
+    "cppdoc": "cpp/library/chrono/duration/../duration_values"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday",
+    "cppdoc": "cpp/library/chrono/year_month_weekday"
+  },
+  {
+    "cppref": "cpp/chrono/local_info",
+    "cppdoc": "cpp/library/chrono/local_info"
+  },
+  {
+    "cppref": "cpp/chrono/sys_info",
+    "cppdoc": "cpp/library/chrono/sys_info"
+  },
+  {
+    "cppref": "cpp/chrono/tzdb",
+    "cppdoc": "cpp/library/chrono/tzdb"
+  },
+  {
+    "cppref": "cpp/chrono/gps_clock",
+    "cppdoc": "cpp/library/chrono/gps_clock"
+  },
+  {
+    "cppref": "cpp/chrono/nonexistent_local_time",
+    "cppdoc": "cpp/library/chrono/nonexistent_local_time"
+  },
+  {
+    "cppref": "cpp/chrono/local_t",
+    "cppdoc": "cpp/library/chrono/local_t"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_indexed",
+    "cppdoc": "cpp/library/chrono/weekday_indexed"
+  },
+  {
+    "cppref": "cpp/chrono/time_point",
+    "cppdoc": "cpp/library/chrono/time_point"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday",
+    "cppdoc": "cpp/library/chrono/month_weekday"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last"
+  },
+  {
+    "cppref": "cpp/chrono/ambiguous_local_time",
+    "cppdoc": "cpp/library/chrono/ambiguous_local_time"
+  },
+  {
+    "cppref": "cpp/chrono/tzdb_list",
+    "cppdoc": "cpp/library/chrono/tzdb_list"
+  },
+  {
+    "cppref": "cpp/chrono/weekday",
+    "cppdoc": "cpp/library/chrono/weekday"
+  },
+  {
+    "cppref": "cpp/chrono/hh_mm_ss",
+    "cppdoc": "cpp/library/chrono/hh_mm_ss"
+  },
+  {
+    "cppref": "cpp/chrono/parse",
+    "cppdoc": "cpp/library/chrono/parse"
+  },
+  {
+    "cppref": "cpp/chrono/year_month",
+    "cppdoc": "cpp/library/chrono/year_month"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_last",
+    "cppdoc": "cpp/library/chrono/weekday_last"
+  },
+  {
+    "cppref": "cpp/chrono/month_day_last",
+    "cppdoc": "cpp/library/chrono/month_day_last"
+  },
+  {
+    "cppref": "cpp/chrono/c",
+    "cppdoc": "cpp/library/chrono/c"
+  },
+  {
+    "cppref": "cpp/chrono/time_zone",
+    "cppdoc": "cpp/library/chrono/time_zone"
+  },
+  {
+    "cppref": "cpp/chrono/tai_clock",
+    "cppdoc": "cpp/library/chrono/tai_clock"
+  },
+  {
+    "cppref": "cpp/chrono/hour_fun",
+    "cppdoc": "cpp/library/chrono/hour_fun"
+  },
+  {
+    "cppref": "cpp/chrono/last_spec",
+    "cppdoc": "cpp/library/chrono/last_spec"
+  },
+  {
+    "cppref": "cpp/chrono/clock_cast",
+    "cppdoc": "cpp/library/chrono/clock_cast"
+  },
+  {
+    "cppref": "cpp/chrono/year",
+    "cppdoc": "cpp/library/chrono/year"
+  },
+  {
+    "cppref": "cpp/chrono/current_zone",
+    "cppdoc": "cpp/library/chrono/current_zone"
+  },
+  {
+    "cppref": "cpp/chrono/file_clock",
+    "cppdoc": "cpp/library/chrono/file_clock"
+  },
+  {
+    "cppref": "cpp/chrono/month",
+    "cppdoc": "cpp/library/chrono/month"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time",
+    "cppdoc": "cpp/library/chrono/zoned_time"
+  },
+  {
+    "cppref": "cpp/chrono/day",
+    "cppdoc": "cpp/library/chrono/day"
+  },
+  {
+    "cppref": "cpp/chrono/month_day",
+    "cppdoc": "cpp/library/chrono/month_day"
+  },
+  {
+    "cppref": "cpp/chrono/treat_as_floating_point",
+    "cppdoc": "cpp/library/chrono/duration/treat_as_floating_point"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_traits",
+    "cppdoc": "cpp/library/chrono/zoned_traits"
+  },
+  {
+    "cppref": "cpp/chrono/operator_q__q_h",
+    "cppdoc": "cpp/library/chrono/duration/operator_q__q_h"
+  },
+  {
+    "cppref": "cpp/chrono/is_clock",
+    "cppdoc": "cpp/library/chrono/is_clock"
+  },
+  {
+    "cppref": "cpp/chrono/time_zone_link",
+    "cppdoc": "cpp/library/chrono/time_zone_link"
+  },
+  {
+    "cppref": "cpp/chrono/operator_q__q_ns",
+    "cppdoc": "cpp/library/chrono/duration/operator_q__q_ns"
+  },
+  {
+    "cppref": "cpp/chrono/high_resolution_clock",
+    "cppdoc": "cpp/library/chrono/high_resolution_clock"
+  },
+  {
+    "cppref": "cpp/chrono/choose",
+    "cppdoc": "cpp/library/chrono/choose"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/hash",
+    "cppdoc": "cpp/library/chrono/time_point/hash"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/min",
+    "cppdoc": "cpp/library/chrono/time_point/min"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/floor",
+    "cppdoc": "cpp/library/chrono/time_point/floor"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/ceil",
+    "cppdoc": "cpp/library/chrono/time_point/ceil"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/time_point_cast",
+    "cppdoc": "cpp/library/chrono/time_point/time_point_cast"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/time_point",
+    "cppdoc": "cpp/library/chrono/time_point/time_point"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/operator_arith",
+    "cppdoc": "cpp/library/chrono/time_point/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/max",
+    "cppdoc": "cpp/library/chrono/time_point/max"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/common_type",
+    "cppdoc": "cpp/library/chrono/time_point/common_type"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/operator_cmp",
+    "cppdoc": "cpp/library/chrono/time_point/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/operator_inc_dec",
+    "cppdoc": "cpp/library/chrono/time_point/operator_inc_dec"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/operator_arith2",
+    "cppdoc": "cpp/library/chrono/time_point/operator_arith2"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/round",
+    "cppdoc": "cpp/library/chrono/time_point/round"
+  },
+  {
+    "cppref": "cpp/chrono/time_point/time_since_epoch",
+    "cppdoc": "cpp/library/chrono/time_point/time_since_epoch"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last/hash",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last/hash"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last/formatter",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last/operator_arith",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last/year_month_weekday_last",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last/year_month_weekday_last"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last/operator_arith_2",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last/operator_arith_2"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last/operator_cmp",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last/accessors",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last/accessors"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last/operator_days",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last/operator_days"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday_last/ok",
+    "cppdoc": "cpp/library/chrono/year_month_weekday_last/ok"
+  },
+  {
+    "cppref": "cpp/chrono/file_clock/to_from_sys",
+    "cppdoc": "cpp/library/chrono/file_clock/to_from_sys"
+  },
+  {
+    "cppref": "cpp/chrono/file_clock/to_from_utc",
+    "cppdoc": "cpp/library/chrono/file_clock/to_from_utc"
+  },
+  {
+    "cppref": "cpp/chrono/file_clock/formatter",
+    "cppdoc": "cpp/library/chrono/file_clock/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/file_clock/now",
+    "cppdoc": "cpp/library/chrono/file_clock/now"
+  },
+  {
+    "cppref": "cpp/chrono/file_clock/from_stream",
+    "cppdoc": "cpp/library/chrono/file_clock/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/file_clock/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/file_clock/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/year_month/hash",
+    "cppdoc": "cpp/library/chrono/year_month/hash"
+  },
+  {
+    "cppref": "cpp/chrono/year_month/formatter",
+    "cppdoc": "cpp/library/chrono/year_month/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/year_month/operator_arith",
+    "cppdoc": "cpp/library/chrono/year_month/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/year_month/operator_arith_2",
+    "cppdoc": "cpp/library/chrono/year_month/operator_arith_2"
+  },
+  {
+    "cppref": "cpp/chrono/year_month/year_month",
+    "cppdoc": "cpp/library/chrono/year_month/year_month"
+  },
+  {
+    "cppref": "cpp/chrono/year_month/operator_cmp",
+    "cppdoc": "cpp/library/chrono/year_month/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/year_month/from_stream",
+    "cppdoc": "cpp/library/chrono/year_month/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/year_month/accessors",
+    "cppdoc": "cpp/library/chrono/year_month/accessors"
+  },
+  {
+    "cppref": "cpp/chrono/year_month/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/year_month/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/year_month/ok",
+    "cppdoc": "cpp/library/chrono/year_month/ok"
+  },
+  {
+    "cppref": "cpp/chrono/duration_values/zero",
+    "cppdoc": "cpp/library/chrono/duration/../duration_values/zero"
+  },
+  {
+    "cppref": "cpp/chrono/duration_values/min",
+    "cppdoc": "cpp/library/chrono/duration/../duration_values/min"
+  },
+  {
+    "cppref": "cpp/chrono/duration_values/max",
+    "cppdoc": "cpp/library/chrono/duration/../duration_values/max"
+  },
+  {
+    "cppref": "cpp/chrono/duration/zero",
+    "cppdoc": "cpp/library/chrono/duration/zero"
+  },
+  {
+    "cppref": "cpp/chrono/duration/duration",
+    "cppdoc": "cpp/library/chrono/duration/duration"
+  },
+  {
+    "cppref": "cpp/chrono/duration/hash",
+    "cppdoc": "cpp/library/chrono/duration/hash"
+  },
+  {
+    "cppref": "cpp/chrono/duration/min",
+    "cppdoc": "cpp/library/chrono/duration/min"
+  },
+  {
+    "cppref": "cpp/chrono/duration/floor",
+    "cppdoc": "cpp/library/chrono/duration/floor"
+  },
+  {
+    "cppref": "cpp/chrono/duration/formatter",
+    "cppdoc": "cpp/library/chrono/duration/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/duration/ceil",
+    "cppdoc": "cpp/library/chrono/duration/ceil"
+  },
+  {
+    "cppref": "cpp/chrono/duration/operator_arith",
+    "cppdoc": "cpp/library/chrono/duration/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/duration/operator_arith3",
+    "cppdoc": "cpp/library/chrono/duration/operator_arith3"
+  },
+  {
+    "cppref": "cpp/chrono/duration/max",
+    "cppdoc": "cpp/library/chrono/duration/max"
+  },
+  {
+    "cppref": "cpp/chrono/duration/common_type",
+    "cppdoc": "cpp/library/chrono/duration/common_type"
+  },
+  {
+    "cppref": "cpp/chrono/duration/count",
+    "cppdoc": "cpp/library/chrono/duration/count"
+  },
+  {
+    "cppref": "cpp/chrono/duration/duration_cast",
+    "cppdoc": "cpp/library/chrono/duration/duration_cast"
+  },
+  {
+    "cppref": "cpp/chrono/duration/operator_cmp",
+    "cppdoc": "cpp/library/chrono/duration/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/duration/from_stream",
+    "cppdoc": "cpp/library/chrono/duration/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/duration/operator_arith4",
+    "cppdoc": "cpp/library/chrono/duration/operator_arith4"
+  },
+  {
+    "cppref": "cpp/chrono/duration/operator_arith2",
+    "cppdoc": "cpp/library/chrono/duration/operator_arith2"
+  },
+  {
+    "cppref": "cpp/chrono/duration/operator=",
+    "cppdoc": "cpp/library/chrono/duration/operator="
+  },
+  {
+    "cppref": "cpp/chrono/duration/round",
+    "cppdoc": "cpp/library/chrono/duration/round"
+  },
+  {
+    "cppref": "cpp/chrono/duration/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/duration/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/duration/abs",
+    "cppdoc": "cpp/library/chrono/duration/abs"
+  },
+  {
+    "cppref": "cpp/chrono/gps_clock/to_utc",
+    "cppdoc": "cpp/library/chrono/gps_clock/to_utc"
+  },
+  {
+    "cppref": "cpp/chrono/gps_clock/formatter",
+    "cppdoc": "cpp/library/chrono/gps_clock/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/gps_clock/now",
+    "cppdoc": "cpp/library/chrono/gps_clock/now"
+  },
+  {
+    "cppref": "cpp/chrono/gps_clock/from_stream",
+    "cppdoc": "cpp/library/chrono/gps_clock/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/gps_clock/from_utc",
+    "cppdoc": "cpp/library/chrono/gps_clock/from_utc"
+  },
+  {
+    "cppref": "cpp/chrono/gps_clock/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/gps_clock/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/leap_second/hash",
+    "cppdoc": "cpp/library/chrono/leap_second/hash"
+  },
+  {
+    "cppref": "cpp/chrono/leap_second/date",
+    "cppdoc": "cpp/library/chrono/leap_second/date"
+  },
+  {
+    "cppref": "cpp/chrono/leap_second/operator_cmp",
+    "cppdoc": "cpp/library/chrono/leap_second/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/utc_clock/get_leap_second_info",
+    "cppdoc": "cpp/library/chrono/utc_clock/get_leap_second_info"
+  },
+  {
+    "cppref": "cpp/chrono/utc_clock/to_sys",
+    "cppdoc": "cpp/library/chrono/utc_clock/to_sys"
+  },
+  {
+    "cppref": "cpp/chrono/utc_clock/leap_second_info",
+    "cppdoc": "cpp/library/chrono/utc_clock/leap_second_info"
+  },
+  {
+    "cppref": "cpp/chrono/utc_clock/from_sys",
+    "cppdoc": "cpp/library/chrono/utc_clock/from_sys"
+  },
+  {
+    "cppref": "cpp/chrono/utc_clock/formatter",
+    "cppdoc": "cpp/library/chrono/utc_clock/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/utc_clock/now",
+    "cppdoc": "cpp/library/chrono/utc_clock/now"
+  },
+  {
+    "cppref": "cpp/chrono/utc_clock/from_stream",
+    "cppdoc": "cpp/library/chrono/utc_clock/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/utc_clock/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/utc_clock/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/month_day/hash",
+    "cppdoc": "cpp/library/chrono/month_day/hash"
+  },
+  {
+    "cppref": "cpp/chrono/month_day/formatter",
+    "cppdoc": "cpp/library/chrono/month_day/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/month_day/operator_cmp",
+    "cppdoc": "cpp/library/chrono/month_day/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/month_day/from_stream",
+    "cppdoc": "cpp/library/chrono/month_day/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/month_day/accessors",
+    "cppdoc": "cpp/library/chrono/month_day/accessors"
+  },
+  {
+    "cppref": "cpp/chrono/month_day/month_day",
+    "cppdoc": "cpp/library/chrono/month_day/month_day"
+  },
+  {
+    "cppref": "cpp/chrono/month_day/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/month_day/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/month_day/ok",
+    "cppdoc": "cpp/library/chrono/month_day/ok"
+  },
+  {
+    "cppref": "cpp/chrono/local_info/formatter",
+    "cppdoc": "cpp/library/chrono/local_info/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/local_info/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/local_info/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/steady_clock/now",
+    "cppdoc": "cpp/library/chrono/steady_clock/now"
+  },
+  {
+    "cppref": "cpp/chrono/high_resolution_clock/now",
+    "cppdoc": "cpp/library/chrono/high_resolution_clock/now"
+  },
+  {
+    "cppref": "cpp/chrono/year/operator_sign",
+    "cppdoc": "cpp/library/chrono/year/operator_sign"
+  },
+  {
+    "cppref": "cpp/chrono/year/hash",
+    "cppdoc": "cpp/library/chrono/year/hash"
+  },
+  {
+    "cppref": "cpp/chrono/year/min",
+    "cppdoc": "cpp/library/chrono/year/min"
+  },
+  {
+    "cppref": "cpp/chrono/year/formatter",
+    "cppdoc": "cpp/library/chrono/year/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/year/operator_arith",
+    "cppdoc": "cpp/library/chrono/year/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/year/operator_arith_2",
+    "cppdoc": "cpp/library/chrono/year/operator_arith_2"
+  },
+  {
+    "cppref": "cpp/chrono/year/max",
+    "cppdoc": "cpp/library/chrono/year/max"
+  },
+  {
+    "cppref": "cpp/chrono/year/operator_cmp",
+    "cppdoc": "cpp/library/chrono/year/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/year/from_stream",
+    "cppdoc": "cpp/library/chrono/year/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/year/operator_int",
+    "cppdoc": "cpp/library/chrono/year/operator_int"
+  },
+  {
+    "cppref": "cpp/chrono/year/operator_inc_dec",
+    "cppdoc": "cpp/library/chrono/year/operator_inc_dec"
+  },
+  {
+    "cppref": "cpp/chrono/year/year",
+    "cppdoc": "cpp/library/chrono/year/year"
+  },
+  {
+    "cppref": "cpp/chrono/year/is_leap",
+    "cppdoc": "cpp/library/chrono/year/is_leap"
+  },
+  {
+    "cppref": "cpp/chrono/year/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/year/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/year/ok",
+    "cppdoc": "cpp/library/chrono/year/ok"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_indexed/index",
+    "cppdoc": "cpp/library/chrono/weekday_indexed/index"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_indexed/hash",
+    "cppdoc": "cpp/library/chrono/weekday_indexed/hash"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_indexed/formatter",
+    "cppdoc": "cpp/library/chrono/weekday_indexed/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_indexed/weekday_indexed",
+    "cppdoc": "cpp/library/chrono/weekday_indexed/weekday_indexed"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_indexed/weekday",
+    "cppdoc": "cpp/library/chrono/weekday_indexed/weekday"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_indexed/operator_cmp",
+    "cppdoc": "cpp/library/chrono/weekday_indexed/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_indexed/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/weekday_indexed/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_indexed/ok",
+    "cppdoc": "cpp/library/chrono/weekday_indexed/ok"
+  },
+  {
+    "cppref": "cpp/chrono/c/mktime",
+    "cppdoc": "cpp/library/chrono/c/mktime"
+  },
+  {
+    "cppref": "cpp/chrono/c/clock",
+    "cppdoc": "cpp/library/chrono/c/clock"
+  },
+  {
+    "cppref": "cpp/chrono/c/CLOCKS_PER_SEC",
+    "cppdoc": "cpp/library/chrono/c/CLOCKS_PER_SEC"
+  },
+  {
+    "cppref": "cpp/chrono/c/time_t",
+    "cppdoc": "cpp/library/chrono/c/time_t"
+  },
+  {
+    "cppref": "cpp/chrono/c/gmtime",
+    "cppdoc": "cpp/library/chrono/c/gmtime"
+  },
+  {
+    "cppref": "cpp/chrono/c/clock_t",
+    "cppdoc": "cpp/library/chrono/c/clock_t"
+  },
+  {
+    "cppref": "cpp/chrono/c/strftime",
+    "cppdoc": "cpp/library/chrono/c/strftime"
+  },
+  {
+    "cppref": "cpp/chrono/c/difftime",
+    "cppdoc": "cpp/library/chrono/c/difftime"
+  },
+  {
+    "cppref": "cpp/chrono/c/ctime",
+    "cppdoc": "cpp/library/chrono/c/ctime"
+  },
+  {
+    "cppref": "cpp/chrono/c/asctime",
+    "cppdoc": "cpp/library/chrono/c/asctime"
+  },
+  {
+    "cppref": "cpp/chrono/c/tm",
+    "cppdoc": "cpp/library/chrono/c/tm"
+  },
+  {
+    "cppref": "cpp/chrono/c/time",
+    "cppdoc": "cpp/library/chrono/c/time"
+  },
+  {
+    "cppref": "cpp/chrono/c/timespec",
+    "cppdoc": "cpp/library/chrono/c/timespec"
+  },
+  {
+    "cppref": "cpp/chrono/c/timespec_get",
+    "cppdoc": "cpp/library/chrono/c/timespec_get"
+  },
+  {
+    "cppref": "cpp/chrono/c/wcsftime",
+    "cppdoc": "cpp/library/chrono/c/wcsftime"
+  },
+  {
+    "cppref": "cpp/chrono/c/localtime",
+    "cppdoc": "cpp/library/chrono/c/localtime"
+  },
+  {
+    "cppref": "cpp/chrono/local_t/formatter",
+    "cppdoc": "cpp/library/chrono/local_t/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/local_t/from_stream",
+    "cppdoc": "cpp/library/chrono/local_t/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/local_t/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/local_t/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday/hash",
+    "cppdoc": "cpp/library/chrono/month_weekday/hash"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday/formatter",
+    "cppdoc": "cpp/library/chrono/month_weekday/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday/month_weekday",
+    "cppdoc": "cpp/library/chrono/month_weekday/month_weekday"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday/operator_cmp",
+    "cppdoc": "cpp/library/chrono/month_weekday/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday/accessors",
+    "cppdoc": "cpp/library/chrono/month_weekday/accessors"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/month_weekday/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday/ok",
+    "cppdoc": "cpp/library/chrono/month_weekday/ok"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/year_month_day",
+    "cppdoc": "cpp/library/chrono/year_month_day/year_month_day"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/hash",
+    "cppdoc": "cpp/library/chrono/year_month_day/hash"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/formatter",
+    "cppdoc": "cpp/library/chrono/year_month_day/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/operator_arith",
+    "cppdoc": "cpp/library/chrono/year_month_day/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/operator_arith_2",
+    "cppdoc": "cpp/library/chrono/year_month_day/operator_arith_2"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/operator_cmp",
+    "cppdoc": "cpp/library/chrono/year_month_day/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/from_stream",
+    "cppdoc": "cpp/library/chrono/year_month_day/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/accessors",
+    "cppdoc": "cpp/library/chrono/year_month_day/accessors"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/year_month_day/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/operator_days",
+    "cppdoc": "cpp/library/chrono/year_month_day/operator_days"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day/ok",
+    "cppdoc": "cpp/library/chrono/year_month_day/ok"
+  },
+  {
+    "cppref": "cpp/chrono/time_zone/to_sys",
+    "cppdoc": "cpp/library/chrono/time_zone/to_sys"
+  },
+  {
+    "cppref": "cpp/chrono/time_zone/to_local",
+    "cppdoc": "cpp/library/chrono/time_zone/to_local"
+  },
+  {
+    "cppref": "cpp/chrono/time_zone/name",
+    "cppdoc": "cpp/library/chrono/time_zone/name"
+  },
+  {
+    "cppref": "cpp/chrono/time_zone/get_info",
+    "cppdoc": "cpp/library/chrono/time_zone/get_info"
+  },
+  {
+    "cppref": "cpp/chrono/time_zone/operator_cmp",
+    "cppdoc": "cpp/library/chrono/time_zone/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/tai_clock/to_utc",
+    "cppdoc": "cpp/library/chrono/tai_clock/to_utc"
+  },
+  {
+    "cppref": "cpp/chrono/tai_clock/formatter",
+    "cppdoc": "cpp/library/chrono/tai_clock/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/tai_clock/now",
+    "cppdoc": "cpp/library/chrono/tai_clock/now"
+  },
+  {
+    "cppref": "cpp/chrono/tai_clock/from_stream",
+    "cppdoc": "cpp/library/chrono/tai_clock/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/tai_clock/from_utc",
+    "cppdoc": "cpp/library/chrono/tai_clock/from_utc"
+  },
+  {
+    "cppref": "cpp/chrono/tai_clock/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/tai_clock/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/hh_mm_ss/duration",
+    "cppdoc": "cpp/library/chrono/hh_mm_ss/duration"
+  },
+  {
+    "cppref": "cpp/chrono/hh_mm_ss/formatter",
+    "cppdoc": "cpp/library/chrono/hh_mm_ss/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/hh_mm_ss/hh_mm_ss",
+    "cppdoc": "cpp/library/chrono/hh_mm_ss/hh_mm_ss"
+  },
+  {
+    "cppref": "cpp/chrono/hh_mm_ss/accessors",
+    "cppdoc": "cpp/library/chrono/hh_mm_ss/accessors"
+  },
+  {
+    "cppref": "cpp/chrono/hh_mm_ss/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/hh_mm_ss/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday_last/month_weekday_last",
+    "cppdoc": "cpp/library/chrono/month_weekday_last/month_weekday_last"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday_last/hash",
+    "cppdoc": "cpp/library/chrono/month_weekday_last/hash"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday_last/formatter",
+    "cppdoc": "cpp/library/chrono/month_weekday_last/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday_last/operator_cmp",
+    "cppdoc": "cpp/library/chrono/month_weekday_last/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday_last/accessors",
+    "cppdoc": "cpp/library/chrono/month_weekday_last/accessors"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday_last/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/month_weekday_last/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/month_weekday_last/ok",
+    "cppdoc": "cpp/library/chrono/month_weekday_last/ok"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last/hash",
+    "cppdoc": "cpp/library/chrono/year_month_day_last/hash"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last/year_month_day_last",
+    "cppdoc": "cpp/library/chrono/year_month_day_last/year_month_day_last"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last/formatter",
+    "cppdoc": "cpp/library/chrono/year_month_day_last/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last/operator_arith",
+    "cppdoc": "cpp/library/chrono/year_month_day_last/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last/operator_arith_2",
+    "cppdoc": "cpp/library/chrono/year_month_day_last/operator_arith_2"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last/operator_cmp",
+    "cppdoc": "cpp/library/chrono/year_month_day_last/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last/accessors",
+    "cppdoc": "cpp/library/chrono/year_month_day_last/accessors"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/year_month_day_last/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last/operator_days",
+    "cppdoc": "cpp/library/chrono/year_month_day_last/operator_days"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_day_last/ok",
+    "cppdoc": "cpp/library/chrono/year_month_day_last/ok"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday/hash",
+    "cppdoc": "cpp/library/chrono/year_month_weekday/hash"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday/formatter",
+    "cppdoc": "cpp/library/chrono/year_month_weekday/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday/year_month_weekday",
+    "cppdoc": "cpp/library/chrono/year_month_weekday/year_month_weekday"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday/operator_arith",
+    "cppdoc": "cpp/library/chrono/year_month_weekday/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday/operator_arith_2",
+    "cppdoc": "cpp/library/chrono/year_month_weekday/operator_arith_2"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday/operator_cmp",
+    "cppdoc": "cpp/library/chrono/year_month_weekday/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday/accessors",
+    "cppdoc": "cpp/library/chrono/year_month_weekday/accessors"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/year_month_weekday/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday/operator_days",
+    "cppdoc": "cpp/library/chrono/year_month_weekday/operator_days"
+  },
+  {
+    "cppref": "cpp/chrono/year_month_weekday/ok",
+    "cppdoc": "cpp/library/chrono/year_month_weekday/ok"
+  },
+  {
+    "cppref": "cpp/chrono/time_zone_link/operator_cmp",
+    "cppdoc": "cpp/library/chrono/time_zone_link/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/time_zone_link/accessors",
+    "cppdoc": "cpp/library/chrono/time_zone_link/accessors"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_last/hash",
+    "cppdoc": "cpp/library/chrono/weekday_last/hash"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_last/formatter",
+    "cppdoc": "cpp/library/chrono/weekday_last/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_last/weekday",
+    "cppdoc": "cpp/library/chrono/weekday_last/weekday"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_last/weekday_last",
+    "cppdoc": "cpp/library/chrono/weekday_last/weekday_last"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_last/operator_cmp",
+    "cppdoc": "cpp/library/chrono/weekday_last/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_last/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/weekday_last/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/weekday_last/ok",
+    "cppdoc": "cpp/library/chrono/weekday_last/ok"
+  },
+  {
+    "cppref": "cpp/chrono/month_day_last/hash",
+    "cppdoc": "cpp/library/chrono/month_day_last/hash"
+  },
+  {
+    "cppref": "cpp/chrono/month_day_last/formatter",
+    "cppdoc": "cpp/library/chrono/month_day_last/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/month_day_last/month_day_last",
+    "cppdoc": "cpp/library/chrono/month_day_last/month_day_last"
+  },
+  {
+    "cppref": "cpp/chrono/month_day_last/operator_cmp",
+    "cppdoc": "cpp/library/chrono/month_day_last/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/month_day_last/month",
+    "cppdoc": "cpp/library/chrono/month_day_last/month"
+  },
+  {
+    "cppref": "cpp/chrono/month_day_last/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/month_day_last/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/month_day_last/ok",
+    "cppdoc": "cpp/library/chrono/month_day_last/ok"
+  },
+  {
+    "cppref": "cpp/chrono/day/operator_unsigned",
+    "cppdoc": "cpp/library/chrono/day/operator_unsigned"
+  },
+  {
+    "cppref": "cpp/chrono/day/hash",
+    "cppdoc": "cpp/library/chrono/day/hash"
+  },
+  {
+    "cppref": "cpp/chrono/day/formatter",
+    "cppdoc": "cpp/library/chrono/day/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/day/operator_arith",
+    "cppdoc": "cpp/library/chrono/day/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/day/operator_arith_2",
+    "cppdoc": "cpp/library/chrono/day/operator_arith_2"
+  },
+  {
+    "cppref": "cpp/chrono/day/operator_cmp",
+    "cppdoc": "cpp/library/chrono/day/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/day/from_stream",
+    "cppdoc": "cpp/library/chrono/day/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/day/operator_inc_dec",
+    "cppdoc": "cpp/library/chrono/day/operator_inc_dec"
+  },
+  {
+    "cppref": "cpp/chrono/day/day",
+    "cppdoc": "cpp/library/chrono/day/day"
+  },
+  {
+    "cppref": "cpp/chrono/day/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/day/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/day/ok",
+    "cppdoc": "cpp/library/chrono/day/ok"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/get_time_zone",
+    "cppdoc": "cpp/library/chrono/zoned_time/get_time_zone"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/get_local_time",
+    "cppdoc": "cpp/library/chrono/zoned_time/get_local_time"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/hash",
+    "cppdoc": "cpp/library/chrono/zoned_time/hash"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/formatter",
+    "cppdoc": "cpp/library/chrono/zoned_time/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/deduction_guides",
+    "cppdoc": "cpp/library/chrono/zoned_time/deduction_guides"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/get_info",
+    "cppdoc": "cpp/library/chrono/zoned_time/get_info"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/operator_cmp",
+    "cppdoc": "cpp/library/chrono/zoned_time/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/operator=",
+    "cppdoc": "cpp/library/chrono/zoned_time/operator="
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/zoned_time",
+    "cppdoc": "cpp/library/chrono/zoned_time/zoned_time"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/zoned_time/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/zoned_time/get_sys_time",
+    "cppdoc": "cpp/library/chrono/zoned_time/get_sys_time"
+  },
+  {
+    "cppref": "cpp/chrono/sys_info/formatter",
+    "cppdoc": "cpp/library/chrono/sys_info/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/sys_info/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/sys_info/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/system_clock/from_time_t",
+    "cppdoc": "cpp/library/chrono/system_clock/from_time_t"
+  },
+  {
+    "cppref": "cpp/chrono/system_clock/formatter",
+    "cppdoc": "cpp/library/chrono/system_clock/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/system_clock/now",
+    "cppdoc": "cpp/library/chrono/system_clock/now"
+  },
+  {
+    "cppref": "cpp/chrono/system_clock/to_time_t",
+    "cppdoc": "cpp/library/chrono/system_clock/to_time_t"
+  },
+  {
+    "cppref": "cpp/chrono/system_clock/from_stream",
+    "cppdoc": "cpp/library/chrono/system_clock/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/system_clock/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/system_clock/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/tzdb_list/erase_after",
+    "cppdoc": "cpp/library/chrono/tzdb_list/erase_after"
+  },
+  {
+    "cppref": "cpp/chrono/tzdb_list/end",
+    "cppdoc": "cpp/library/chrono/tzdb_list/end"
+  },
+  {
+    "cppref": "cpp/chrono/tzdb_list/begin",
+    "cppdoc": "cpp/library/chrono/tzdb_list/begin"
+  },
+  {
+    "cppref": "cpp/chrono/tzdb_list/front",
+    "cppdoc": "cpp/library/chrono/tzdb_list/front"
+  },
+  {
+    "cppref": "cpp/chrono/month/operator_unsigned",
+    "cppdoc": "cpp/library/chrono/month/operator_unsigned"
+  },
+  {
+    "cppref": "cpp/chrono/month/hash",
+    "cppdoc": "cpp/library/chrono/month/hash"
+  },
+  {
+    "cppref": "cpp/chrono/month/formatter",
+    "cppdoc": "cpp/library/chrono/month/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/month/operator_arith",
+    "cppdoc": "cpp/library/chrono/month/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/month/operator_arith_2",
+    "cppdoc": "cpp/library/chrono/month/operator_arith_2"
+  },
+  {
+    "cppref": "cpp/chrono/month/operator_cmp",
+    "cppdoc": "cpp/library/chrono/month/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/month/from_stream",
+    "cppdoc": "cpp/library/chrono/month/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/month/operator_inc_dec",
+    "cppdoc": "cpp/library/chrono/month/operator_inc_dec"
+  },
+  {
+    "cppref": "cpp/chrono/month/month",
+    "cppdoc": "cpp/library/chrono/month/month"
+  },
+  {
+    "cppref": "cpp/chrono/month/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/month/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/month/ok",
+    "cppdoc": "cpp/library/chrono/month/ok"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/operator_at",
+    "cppdoc": "cpp/library/chrono/weekday/operator_at"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/hash",
+    "cppdoc": "cpp/library/chrono/weekday/hash"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/formatter",
+    "cppdoc": "cpp/library/chrono/weekday/formatter"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/operator_arith",
+    "cppdoc": "cpp/library/chrono/weekday/operator_arith"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/operator_arith_2",
+    "cppdoc": "cpp/library/chrono/weekday/operator_arith_2"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/weekday",
+    "cppdoc": "cpp/library/chrono/weekday/weekday"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/operator_cmp",
+    "cppdoc": "cpp/library/chrono/weekday/operator_cmp"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/from_stream",
+    "cppdoc": "cpp/library/chrono/weekday/from_stream"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/operator_inc_dec",
+    "cppdoc": "cpp/library/chrono/weekday/operator_inc_dec"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/encoding",
+    "cppdoc": "cpp/library/chrono/weekday/encoding"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/operator_ltlt",
+    "cppdoc": "cpp/library/chrono/weekday/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/chrono/weekday/ok",
+    "cppdoc": "cpp/library/chrono/weekday/ok"
+  },
+  {
+    "cppref": "cpp/chrono/tzdb/locate_zone",
+    "cppdoc": "cpp/library/chrono/tzdb/locate_zone"
+  },
+  {
+    "cppref": "cpp/chrono/tzdb/current_zone",
+    "cppdoc": "cpp/library/chrono/tzdb/current_zone"
+  },
+  {
+    "cppref": "cpp/filesystem/copy_file",
+    "cppdoc": "cpp/library/filesystem/copy_file"
+  },
+  {
+    "cppref": "cpp/filesystem/create_symlink",
+    "cppdoc": "cpp/library/filesystem/create_symlink"
+  },
+  {
+    "cppref": "cpp/filesystem/copy_options",
+    "cppdoc": "cpp/library/filesystem/copy_options"
+  },
+  {
+    "cppref": "cpp/filesystem/read_symlink",
+    "cppdoc": "cpp/library/filesystem/read_symlink"
+  },
+  {
+    "cppref": "cpp/filesystem/remove",
+    "cppdoc": "cpp/library/filesystem/remove"
+  },
+  {
+    "cppref": "cpp/filesystem/file_type",
+    "cppdoc": "cpp/library/filesystem/file_type"
+  },
+  {
+    "cppref": "cpp/filesystem/is_directory",
+    "cppdoc": "cpp/library/filesystem/is_directory"
+  },
+  {
+    "cppref": "cpp/filesystem/current_path",
+    "cppdoc": "cpp/library/filesystem/current_path"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_options",
+    "cppdoc": "cpp/library/filesystem/directory_options"
+  },
+  {
+    "cppref": "cpp/filesystem/permissions",
+    "cppdoc": "cpp/library/filesystem/permissions"
+  },
+  {
+    "cppref": "cpp/filesystem/resize_file",
+    "cppdoc": "cpp/library/filesystem/resize_file"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_iterator",
+    "cppdoc": "cpp/library/filesystem/directory_iterator"
+  },
+  {
+    "cppref": "cpp/filesystem/copy",
+    "cppdoc": "cpp/library/filesystem/copy"
+  },
+  {
+    "cppref": "cpp/filesystem/is_character_file",
+    "cppdoc": "cpp/library/filesystem/is_character_file"
+  },
+  {
+    "cppref": "cpp/filesystem/canonical",
+    "cppdoc": "cpp/library/filesystem/canonical"
+  },
+  {
+    "cppref": "cpp/filesystem/create_directory",
+    "cppdoc": "cpp/library/filesystem/create_directory"
+  },
+  {
+    "cppref": "cpp/filesystem/is_socket",
+    "cppdoc": "cpp/library/filesystem/is_socket"
+  },
+  {
+    "cppref": "cpp/filesystem/perm_options",
+    "cppdoc": "cpp/library/filesystem/perm_options"
+  },
+  {
+    "cppref": "cpp/filesystem/rename",
+    "cppdoc": "cpp/library/filesystem/rename"
+  },
+  {
+    "cppref": "cpp/filesystem/status",
+    "cppdoc": "cpp/library/filesystem/status"
+  },
+  {
+    "cppref": "cpp/filesystem/copy_symlink",
+    "cppdoc": "cpp/library/filesystem/copy_symlink"
+  },
+  {
+    "cppref": "cpp/filesystem/temp_directory_path",
+    "cppdoc": "cpp/library/filesystem/temp_directory_path"
+  },
+  {
+    "cppref": "cpp/filesystem/file_status",
+    "cppdoc": "cpp/library/filesystem/file_status"
+  },
+  {
+    "cppref": "cpp/filesystem/create_hard_link",
+    "cppdoc": "cpp/library/filesystem/create_hard_link"
+  },
+  {
+    "cppref": "cpp/filesystem/space",
+    "cppdoc": "cpp/library/filesystem/space"
+  },
+  {
+    "cppref": "cpp/filesystem/file_time_type",
+    "cppdoc": "cpp/library/filesystem/file_time_type"
+  },
+  {
+    "cppref": "cpp/filesystem/last_write_time",
+    "cppdoc": "cpp/library/filesystem/last_write_time"
+  },
+  {
+    "cppref": "cpp/filesystem/hard_link_count",
+    "cppdoc": "cpp/library/filesystem/hard_link_count"
+  },
+  {
+    "cppref": "cpp/filesystem/is_regular_file",
+    "cppdoc": "cpp/library/filesystem/is_regular_file"
+  },
+  {
+    "cppref": "cpp/filesystem/absolute",
+    "cppdoc": "cpp/library/filesystem/absolute"
+  },
+  {
+    "cppref": "cpp/filesystem/perms",
+    "cppdoc": "cpp/library/filesystem/perms"
+  },
+  {
+    "cppref": "cpp/filesystem/path",
+    "cppdoc": "cpp/library/filesystem/path"
+  },
+  {
+    "cppref": "cpp/filesystem/is_other",
+    "cppdoc": "cpp/library/filesystem/is_other"
+  },
+  {
+    "cppref": "cpp/filesystem/is_empty",
+    "cppdoc": "cpp/library/filesystem/is_empty"
+  },
+  {
+    "cppref": "cpp/filesystem/space_info",
+    "cppdoc": "cpp/library/filesystem/space_info"
+  },
+  {
+    "cppref": "cpp/filesystem/file_size",
+    "cppdoc": "cpp/library/filesystem/file_size"
+  },
+  {
+    "cppref": "cpp/filesystem/is_symlink",
+    "cppdoc": "cpp/library/filesystem/is_symlink"
+  },
+  {
+    "cppref": "cpp/filesystem/status_known",
+    "cppdoc": "cpp/library/filesystem/status_known"
+  },
+  {
+    "cppref": "cpp/filesystem/is_block_file",
+    "cppdoc": "cpp/library/filesystem/is_block_file"
+  },
+  {
+    "cppref": "cpp/filesystem/relative",
+    "cppdoc": "cpp/library/filesystem/relative"
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator"
+  },
+  {
+    "cppref": "cpp/filesystem/is_fifo",
+    "cppdoc": "cpp/library/filesystem/is_fifo"
+  },
+  {
+    "cppref": "cpp/filesystem/equivalent",
+    "cppdoc": "cpp/library/filesystem/equivalent"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry",
+    "cppdoc": "cpp/library/filesystem/directory_entry"
+  },
+  {
+    "cppref": "cpp/filesystem/exists",
+    "cppdoc": "cpp/library/filesystem/exists"
+  },
+  {
+    "cppref": "cpp/filesystem/filesystem_error",
+    "cppdoc": "cpp/library/filesystem/filesystem_error"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/assign",
+    "cppdoc": "cpp/library/filesystem/directory_entry/assign"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/replace_filename",
+    "cppdoc": "cpp/library/filesystem/directory_entry/replace_filename"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/is_directory",
+    "cppdoc": "cpp/library/filesystem/directory_entry/is_directory"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/is_character_file",
+    "cppdoc": "cpp/library/filesystem/directory_entry/is_character_file"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/is_socket",
+    "cppdoc": "cpp/library/filesystem/directory_entry/is_socket"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/status",
+    "cppdoc": "cpp/library/filesystem/directory_entry/status"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/last_write_time",
+    "cppdoc": "cpp/library/filesystem/directory_entry/last_write_time"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/hard_link_count",
+    "cppdoc": "cpp/library/filesystem/directory_entry/hard_link_count"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/refresh",
+    "cppdoc": "cpp/library/filesystem/directory_entry/refresh"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/is_regular_file",
+    "cppdoc": "cpp/library/filesystem/directory_entry/is_regular_file"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/operator_cmp",
+    "cppdoc": "cpp/library/filesystem/directory_entry/operator_cmp"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/path",
+    "cppdoc": "cpp/library/filesystem/directory_entry/path"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/is_other",
+    "cppdoc": "cpp/library/filesystem/directory_entry/is_other"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/file_size",
+    "cppdoc": "cpp/library/filesystem/directory_entry/file_size"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/is_symlink",
+    "cppdoc": "cpp/library/filesystem/directory_entry/is_symlink"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/is_block_file",
+    "cppdoc": "cpp/library/filesystem/directory_entry/is_block_file"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/operator=",
+    "cppdoc": "cpp/library/filesystem/directory_entry/operator="
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/operator_ltlt",
+    "cppdoc": "cpp/library/filesystem/directory_entry/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/is_fifo",
+    "cppdoc": "cpp/library/filesystem/directory_entry/is_fifo"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/directory_entry",
+    "cppdoc": "cpp/library/filesystem/directory_entry/directory_entry"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_entry/exists",
+    "cppdoc": "cpp/library/filesystem/directory_entry/exists"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_iterator/directory_iterator",
+    "cppdoc": "cpp/library/filesystem/directory_iterator/directory_iterator"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_iterator/begin",
+    "cppdoc": "cpp/library/filesystem/directory_iterator/begin"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_iterator/operator_star_",
+    "cppdoc": "cpp/library/filesystem/directory_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/filesystem/directory_iterator/operator=",
+    "cppdoc": "cpp/library/filesystem/directory_iterator/operator="
+  },
+  {
+    "cppref": "cpp/filesystem/directory_iterator/increment",
+    "cppdoc": "cpp/library/filesystem/directory_iterator/increment"
+  },
+  {
+    "cppref": "cpp/filesystem/file_status/operator==",
+    "cppdoc": "cpp/library/filesystem/file_status/operator=="
+  },
+  {
+    "cppref": "cpp/filesystem/file_status/permissions",
+    "cppdoc": "cpp/library/filesystem/file_status/permissions"
+  },
+  {
+    "cppref": "cpp/filesystem/file_status/file_status",
+    "cppdoc": "cpp/library/filesystem/file_status/file_status"
+  },
+  {
+    "cppref": "cpp/filesystem/file_status/type",
+    "cppdoc": "cpp/library/filesystem/file_status/type"
+  },
+  {
+    "cppref": "cpp/filesystem/file_status/operator=",
+    "cppdoc": "cpp/library/filesystem/file_status/operator="
+  },
+  {
+    "cppref": "cpp/filesystem/path/stem",
+    "cppdoc": "cpp/library/filesystem/path/stem"
+  },
+  {
+    "cppref": "cpp/filesystem/path/assign",
+    "cppdoc": "cpp/library/filesystem/path/assign"
+  },
+  {
+    "cppref": "cpp/filesystem/path/remove_filename",
+    "cppdoc": "cpp/library/filesystem/path/remove_filename"
+  },
+  {
+    "cppref": "cpp/filesystem/path/root_path",
+    "cppdoc": "cpp/library/filesystem/path/root_path"
+  },
+  {
+    "cppref": "cpp/filesystem/path/replace_filename",
+    "cppdoc": "cpp/library/filesystem/path/replace_filename"
+  },
+  {
+    "cppref": "cpp/filesystem/path/has_path",
+    "cppdoc": "cpp/library/filesystem/path/has_path"
+  },
+  {
+    "cppref": "cpp/filesystem/path/empty",
+    "cppdoc": "cpp/library/filesystem/path/empty"
+  },
+  {
+    "cppref": "cpp/filesystem/path/hash",
+    "cppdoc": "cpp/library/filesystem/path/hash"
+  },
+  {
+    "cppref": "cpp/filesystem/path/operator_slash",
+    "cppdoc": "cpp/library/filesystem/path/operator_slash"
+  },
+  {
+    "cppref": "cpp/filesystem/path/relative_path",
+    "cppdoc": "cpp/library/filesystem/path/relative_path"
+  },
+  {
+    "cppref": "cpp/filesystem/path/root_directory",
+    "cppdoc": "cpp/library/filesystem/path/root_directory"
+  },
+  {
+    "cppref": "cpp/filesystem/path/operator_ltltgtgt",
+    "cppdoc": "cpp/library/filesystem/path/operator_ltltgtgt"
+  },
+  {
+    "cppref": "cpp/filesystem/path/swap2",
+    "cppdoc": "cpp/library/filesystem/path/swap2"
+  },
+  {
+    "cppref": "cpp/filesystem/path/native",
+    "cppdoc": "cpp/library/filesystem/path/native"
+  },
+  {
+    "cppref": "cpp/filesystem/path/formatter",
+    "cppdoc": "cpp/library/filesystem/path/formatter"
+  },
+  {
+    "cppref": "cpp/filesystem/path/format",
+    "cppdoc": "cpp/library/filesystem/path/format"
+  },
+  {
+    "cppref": "cpp/filesystem/path/begin",
+    "cppdoc": "cpp/library/filesystem/path/begin"
+  },
+  {
+    "cppref": "cpp/filesystem/path/lexically_normal",
+    "cppdoc": "cpp/library/filesystem/path/lexically_normal"
+  },
+  {
+    "cppref": "cpp/filesystem/path/root_name",
+    "cppdoc": "cpp/library/filesystem/path/root_name"
+  },
+  {
+    "cppref": "cpp/filesystem/path/extension",
+    "cppdoc": "cpp/library/filesystem/path/extension"
+  },
+  {
+    "cppref": "cpp/filesystem/path/string",
+    "cppdoc": "cpp/library/filesystem/path/string"
+  },
+  {
+    "cppref": "cpp/filesystem/path/generic_string",
+    "cppdoc": "cpp/library/filesystem/path/generic_string"
+  },
+  {
+    "cppref": "cpp/filesystem/path/filename",
+    "cppdoc": "cpp/library/filesystem/path/filename"
+  },
+  {
+    "cppref": "cpp/filesystem/path/swap",
+    "cppdoc": "cpp/library/filesystem/path/swap"
+  },
+  {
+    "cppref": "cpp/filesystem/path/compare",
+    "cppdoc": "cpp/library/filesystem/path/compare"
+  },
+  {
+    "cppref": "cpp/filesystem/path/append",
+    "cppdoc": "cpp/library/filesystem/path/append"
+  },
+  {
+    "cppref": "cpp/filesystem/path/operator_cmp",
+    "cppdoc": "cpp/library/filesystem/path/operator_cmp"
+  },
+  {
+    "cppref": "cpp/filesystem/path/path",
+    "cppdoc": "cpp/library/filesystem/path/path"
+  },
+  {
+    "cppref": "cpp/filesystem/path/replace_extension",
+    "cppdoc": "cpp/library/filesystem/path/replace_extension"
+  },
+  {
+    "cppref": "cpp/filesystem/path/~path",
+    "cppdoc": "cpp/library/filesystem/path/~path"
+  },
+  {
+    "cppref": "cpp/filesystem/path/hash_value",
+    "cppdoc": "cpp/library/filesystem/path/hash_value"
+  },
+  {
+    "cppref": "cpp/filesystem/path/concat",
+    "cppdoc": "cpp/library/filesystem/path/concat"
+  },
+  {
+    "cppref": "cpp/filesystem/path/is_absrel",
+    "cppdoc": "cpp/library/filesystem/path/is_absrel"
+  },
+  {
+    "cppref": "cpp/filesystem/path/operator=",
+    "cppdoc": "cpp/library/filesystem/path/operator="
+  },
+  {
+    "cppref": "cpp/filesystem/path/parent_path",
+    "cppdoc": "cpp/library/filesystem/path/parent_path"
+  },
+  {
+    "cppref": "cpp/filesystem/path/make_preferred",
+    "cppdoc": "cpp/library/filesystem/path/make_preferred"
+  },
+  {
+    "cppref": "cpp/filesystem/path/u8path",
+    "cppdoc": "cpp/library/filesystem/path/u8path"
+  },
+  {
+    "cppref": "cpp/filesystem/path/clear",
+    "cppdoc": "cpp/library/filesystem/path/clear"
+  },
+  {
+    "cppref": "cpp/filesystem/filesystem_error/what",
+    "cppdoc": "cpp/library/filesystem/filesystem_error/what"
+  },
+  {
+    "cppref": "cpp/filesystem/filesystem_error/path",
+    "cppdoc": "cpp/library/filesystem/filesystem_error/path"
+  },
+  {
+    "cppref": "cpp/filesystem/filesystem_error/operator=",
+    "cppdoc": "cpp/library/filesystem/filesystem_error/operator="
+  },
+  {
+    "cppref": "cpp/filesystem/filesystem_error/filesystem_error",
+    "cppdoc": "cpp/library/filesystem/filesystem_error/filesystem_error"
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator/recursion_pending",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator/recursion_pending"
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator/begin",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator/begin"
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator/depth",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator/depth"
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator/operator_star_",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator/options",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator/options"
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator/disable_recursion_pending",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator/disable_recursion_pending"
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator/operator=",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator/operator="
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator/pop",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator/pop"
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator/recursive_directory_iterator",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator/recursive_directory_iterator"
+  },
+  {
+    "cppref": "cpp/filesystem/recursive_directory_iterator/increment",
+    "cppdoc": "cpp/library/filesystem/recursive_directory_iterator/increment"
+  },
+  {
+    "cppref": "c/atomic",
+    "cppdoc": "c/library/atomic"
+  },
+  {
+    "cppref": "c/index",
+    "cppdoc": "c/library/index"
+  },
+  {
+    "cppref": "c/types",
+    "cppdoc": "c/library/types"
+  },
+  {
+    "cppref": "c/thread",
+    "cppdoc": "c/library/thread"
+  },
+  {
+    "cppref": "c/numeric",
+    "cppdoc": "c/library/numeric"
+  },
+  {
+    "cppref": "c/variadic",
+    "cppdoc": "c/library/variadic"
+  },
+  {
+    "cppref": "c/string",
+    "cppdoc": "c/library/string"
+  },
+  {
+    "cppref": "c/compiler_support",
+    "cppdoc": "c/library/compiler_support"
+  },
+  {
+    "cppref": "c/error",
+    "cppdoc": "c/library/error"
+  },
+  {
+    "cppref": "c/memory",
+    "cppdoc": "c/library/memory"
+  },
+  {
+    "cppref": "c/io",
+    "cppdoc": "c/library/io"
+  },
+  {
+    "cppref": "c/chrono",
+    "cppdoc": "c/library/chrono"
+  },
+  {
+    "cppref": "c/language",
+    "cppdoc": "c/language"
+  },
+  {
+    "cppref": "c/links",
+    "cppdoc": "c/library/links"
+  },
+  {
+    "cppref": "c/header",
+    "cppdoc": "c/library/header"
+  },
+  {
+    "cppref": "c/locale",
+    "cppdoc": "c/library/locale"
+  },
+  {
+    "cppref": "c/algorithm",
+    "cppdoc": "c/library/algorithm"
+  },
+  {
+    "cppref": "c/utility",
+    "cppdoc": "c/language/utility"
+  },
+  {
+    "cppref": "c/preprocessor",
+    "cppdoc": "c/language/preprocessor"
+  },
+  {
+    "cppref": "c/program",
+    "cppdoc": "c/library/program"
+  },
+  {
+    "cppref": "c/preprocessor/replace",
+    "cppdoc": "c/language/preprocessor/replace"
+  },
+  {
+    "cppref": "c/preprocessor/impl",
+    "cppdoc": "c/language/preprocessor/impl"
+  },
+  {
+    "cppref": "c/preprocessor/conditional",
+    "cppdoc": "c/language/preprocessor/conditional"
+  },
+  {
+    "cppref": "c/preprocessor/line",
+    "cppdoc": "c/language/preprocessor/line"
+  },
+  {
+    "cppref": "c/preprocessor/error",
+    "cppdoc": "c/language/preprocessor/error"
+  },
+  {
+    "cppref": "c/preprocessor/embed",
+    "cppdoc": "c/language/preprocessor/embed"
+  },
+  {
+    "cppref": "c/preprocessor/include",
+    "cppdoc": "c/language/preprocessor/include"
+  },
+  {
+    "cppref": "c/locale/LC_categories",
+    "cppdoc": "c/library/locale/LC_categories"
+  },
+  {
+    "cppref": "c/locale/localeconv",
+    "cppdoc": "c/library/locale/localeconv"
+  },
+  {
+    "cppref": "c/locale/setlocale",
+    "cppdoc": "c/library/locale/setlocale"
+  },
+  {
+    "cppref": "c/locale/lconv",
+    "cppdoc": "c/library/locale/lconv"
+  },
+  {
+    "cppref": "c/variadic/va_list",
+    "cppdoc": "c/library/variadic/va_list"
+  },
+  {
+    "cppref": "c/variadic/va_copy",
+    "cppdoc": "c/library/variadic/va_copy"
+  },
+  {
+    "cppref": "c/variadic/va_arg",
+    "cppdoc": "c/library/variadic/va_arg"
+  },
+  {
+    "cppref": "c/variadic/va_start",
+    "cppdoc": "c/library/variadic/va_start"
+  },
+  {
+    "cppref": "c/variadic/va_end",
+    "cppdoc": "c/library/variadic/va_end"
+  },
+  {
+    "cppref": "c/string/byte",
+    "cppdoc": "c/library/string/byte"
+  },
+  {
+    "cppref": "c/string/multibyte",
+    "cppdoc": "c/library/string/multibyte"
+  },
+  {
+    "cppref": "c/string/wide",
+    "cppdoc": "c/library/string/wide"
+  },
+  {
+    "cppref": "c/string/multibyte/mbsinit",
+    "cppdoc": "c/library/string/multibyte/mbsinit"
+  },
+  {
+    "cppref": "c/string/multibyte/mbrtoc16",
+    "cppdoc": "c/library/string/multibyte/mbrtoc16"
+  },
+  {
+    "cppref": "c/string/multibyte/wctomb",
+    "cppdoc": "c/library/string/multibyte/wctomb"
+  },
+  {
+    "cppref": "c/string/multibyte/mbstate_t",
+    "cppdoc": "c/library/string/multibyte/mbstate_t"
+  },
+  {
+    "cppref": "c/string/multibyte/char8_t",
+    "cppdoc": "c/library/string/multibyte/char8_t"
+  },
+  {
+    "cppref": "c/string/multibyte/mbtowc",
+    "cppdoc": "c/library/string/multibyte/mbtowc"
+  },
+  {
+    "cppref": "c/string/multibyte/mbrtoc32",
+    "cppdoc": "c/library/string/multibyte/mbrtoc32"
+  },
+  {
+    "cppref": "c/string/multibyte/wcsrtombs",
+    "cppdoc": "c/library/string/multibyte/wcsrtombs"
+  },
+  {
+    "cppref": "c/string/multibyte/wcrtomb",
+    "cppdoc": "c/library/string/multibyte/wcrtomb"
+  },
+  {
+    "cppref": "c/string/multibyte/wctob",
+    "cppdoc": "c/library/string/multibyte/wctob"
+  },
+  {
+    "cppref": "c/string/multibyte/mbrlen",
+    "cppdoc": "c/library/string/multibyte/mbrlen"
+  },
+  {
+    "cppref": "c/string/multibyte/c32rtomb",
+    "cppdoc": "c/library/string/multibyte/c32rtomb"
+  },
+  {
+    "cppref": "c/string/multibyte/mbrtowc",
+    "cppdoc": "c/library/string/multibyte/mbrtowc"
+  },
+  {
+    "cppref": "c/string/multibyte/c16rtomb",
+    "cppdoc": "c/library/string/multibyte/c16rtomb"
+  },
+  {
+    "cppref": "c/string/multibyte/btowc",
+    "cppdoc": "c/library/string/multibyte/btowc"
+  },
+  {
+    "cppref": "c/string/multibyte/char16_t",
+    "cppdoc": "c/library/string/multibyte/char16_t"
+  },
+  {
+    "cppref": "c/string/multibyte/mbstowcs",
+    "cppdoc": "c/library/string/multibyte/mbstowcs"
+  },
+  {
+    "cppref": "c/string/multibyte/wcstombs",
+    "cppdoc": "c/library/string/multibyte/wcstombs"
+  },
+  {
+    "cppref": "c/string/multibyte/c8rtomb",
+    "cppdoc": "c/library/string/multibyte/c8rtomb"
+  },
+  {
+    "cppref": "c/string/multibyte/mbsrtowcs",
+    "cppdoc": "c/library/string/multibyte/mbsrtowcs"
+  },
+  {
+    "cppref": "c/string/multibyte/mblen",
+    "cppdoc": "c/library/string/multibyte/mblen"
+  },
+  {
+    "cppref": "c/string/multibyte/mbrtoc8",
+    "cppdoc": "c/library/string/multibyte/mbrtoc8"
+  },
+  {
+    "cppref": "c/string/multibyte/char32_t",
+    "cppdoc": "c/library/string/multibyte/char32_t"
+  },
+  {
+    "cppref": "c/string/byte/memccpy",
+    "cppdoc": "c/library/string/byte/memccpy"
+  },
+  {
+    "cppref": "c/string/byte/islower",
+    "cppdoc": "c/library/string/byte/islower"
+  },
+  {
+    "cppref": "c/string/byte/memmove",
+    "cppdoc": "c/library/string/byte/memmove"
+  },
+  {
+    "cppref": "c/string/byte/strpbrk",
+    "cppdoc": "c/library/string/byte/strpbrk"
+  },
+  {
+    "cppref": "c/string/byte/iscntrl",
+    "cppdoc": "c/library/string/byte/iscntrl"
+  },
+  {
+    "cppref": "c/string/byte/strspn",
+    "cppdoc": "c/library/string/byte/strspn"
+  },
+  {
+    "cppref": "c/string/byte/strlen",
+    "cppdoc": "c/library/string/byte/strlen"
+  },
+  {
+    "cppref": "c/string/byte/toupper",
+    "cppdoc": "c/library/string/byte/toupper"
+  },
+  {
+    "cppref": "c/string/byte/isprint",
+    "cppdoc": "c/library/string/byte/isprint"
+  },
+  {
+    "cppref": "c/string/byte/strchr",
+    "cppdoc": "c/library/string/byte/strchr"
+  },
+  {
+    "cppref": "c/string/byte/strtoimax",
+    "cppdoc": "c/library/string/byte/strtoimax"
+  },
+  {
+    "cppref": "c/string/byte/strrchr",
+    "cppdoc": "c/library/string/byte/strrchr"
+  },
+  {
+    "cppref": "c/string/byte/memcpy",
+    "cppdoc": "c/library/string/byte/memcpy"
+  },
+  {
+    "cppref": "c/string/byte/strcat",
+    "cppdoc": "c/library/string/byte/strcat"
+  },
+  {
+    "cppref": "c/string/byte/strncpy",
+    "cppdoc": "c/library/string/byte/strncpy"
+  },
+  {
+    "cppref": "c/string/byte/isalpha",
+    "cppdoc": "c/library/string/byte/isalpha"
+  },
+  {
+    "cppref": "c/string/byte/strtol",
+    "cppdoc": "c/library/string/byte/strtol"
+  },
+  {
+    "cppref": "c/string/byte/memset",
+    "cppdoc": "c/library/string/byte/memset"
+  },
+  {
+    "cppref": "c/string/byte/strtoul",
+    "cppdoc": "c/library/string/byte/strtoul"
+  },
+  {
+    "cppref": "c/string/byte/strtok",
+    "cppdoc": "c/library/string/byte/strtok"
+  },
+  {
+    "cppref": "c/string/byte/ispunct",
+    "cppdoc": "c/library/string/byte/ispunct"
+  },
+  {
+    "cppref": "c/string/byte/atoi",
+    "cppdoc": "c/library/string/byte/atoi"
+  },
+  {
+    "cppref": "c/string/byte/strdup",
+    "cppdoc": "c/library/string/byte/strdup"
+  },
+  {
+    "cppref": "c/string/byte/strcoll",
+    "cppdoc": "c/library/string/byte/strcoll"
+  },
+  {
+    "cppref": "c/string/byte/strndup",
+    "cppdoc": "c/library/string/byte/strndup"
+  },
+  {
+    "cppref": "c/string/byte/isdigit",
+    "cppdoc": "c/library/string/byte/isdigit"
+  },
+  {
+    "cppref": "c/string/byte/memcmp",
+    "cppdoc": "c/library/string/byte/memcmp"
+  },
+  {
+    "cppref": "c/string/byte/strerror",
+    "cppdoc": "c/library/string/byte/strerror"
+  },
+  {
+    "cppref": "c/string/byte/isspace",
+    "cppdoc": "c/library/string/byte/isspace"
+  },
+  {
+    "cppref": "c/string/byte/strcspn",
+    "cppdoc": "c/library/string/byte/strcspn"
+  },
+  {
+    "cppref": "c/string/byte/strxfrm",
+    "cppdoc": "c/library/string/byte/strxfrm"
+  },
+  {
+    "cppref": "c/string/byte/strncat",
+    "cppdoc": "c/library/string/byte/strncat"
+  },
+  {
+    "cppref": "c/string/byte/isxdigit",
+    "cppdoc": "c/library/string/byte/isxdigit"
+  },
+  {
+    "cppref": "c/string/byte/atof",
+    "cppdoc": "c/library/string/byte/atof"
+  },
+  {
+    "cppref": "c/string/byte/strcmp",
+    "cppdoc": "c/library/string/byte/strcmp"
+  },
+  {
+    "cppref": "c/string/byte/strstr",
+    "cppdoc": "c/library/string/byte/strstr"
+  },
+  {
+    "cppref": "c/string/byte/isgraph",
+    "cppdoc": "c/library/string/byte/isgraph"
+  },
+  {
+    "cppref": "c/string/byte/tolower",
+    "cppdoc": "c/library/string/byte/tolower"
+  },
+  {
+    "cppref": "c/string/byte/isblank",
+    "cppdoc": "c/library/string/byte/isblank"
+  },
+  {
+    "cppref": "c/string/byte/strtof",
+    "cppdoc": "c/library/string/byte/strtof"
+  },
+  {
+    "cppref": "c/string/byte/isalnum",
+    "cppdoc": "c/library/string/byte/isalnum"
+  },
+  {
+    "cppref": "c/string/byte/strcpy",
+    "cppdoc": "c/library/string/byte/strcpy"
+  },
+  {
+    "cppref": "c/string/byte/strncmp",
+    "cppdoc": "c/library/string/byte/strncmp"
+  },
+  {
+    "cppref": "c/string/byte/memchr",
+    "cppdoc": "c/library/string/byte/memchr"
+  },
+  {
+    "cppref": "c/string/byte/strfromf",
+    "cppdoc": "c/library/string/byte/strfromf"
+  },
+  {
+    "cppref": "c/string/byte/isupper",
+    "cppdoc": "c/library/string/byte/isupper"
+  },
+  {
+    "cppref": "c/string/wide/towupper",
+    "cppdoc": "c/library/string/wide/towupper"
+  },
+  {
+    "cppref": "c/string/wide/wcsncat",
+    "cppdoc": "c/library/string/wide/wcsncat"
+  },
+  {
+    "cppref": "c/string/wide/wcscpy",
+    "cppdoc": "c/library/string/wide/wcscpy"
+  },
+  {
+    "cppref": "c/string/wide/wcscmp",
+    "cppdoc": "c/library/string/wide/wcscmp"
+  },
+  {
+    "cppref": "c/string/wide/wcsstr",
+    "cppdoc": "c/library/string/wide/wcsstr"
+  },
+  {
+    "cppref": "c/string/wide/wcstok",
+    "cppdoc": "c/library/string/wide/wcstok"
+  },
+  {
+    "cppref": "c/string/wide/wmemcpy",
+    "cppdoc": "c/library/string/wide/wmemcpy"
+  },
+  {
+    "cppref": "c/string/wide/wmemset",
+    "cppdoc": "c/library/string/wide/wmemset"
+  },
+  {
+    "cppref": "c/string/wide/wcstol",
+    "cppdoc": "c/library/string/wide/wcstol"
+  },
+  {
+    "cppref": "c/string/wide/towctrans",
+    "cppdoc": "c/library/string/wide/towctrans"
+  },
+  {
+    "cppref": "c/string/wide/wcspbrk",
+    "cppdoc": "c/library/string/wide/wcspbrk"
+  },
+  {
+    "cppref": "c/string/wide/wcschr",
+    "cppdoc": "c/library/string/wide/wcschr"
+  },
+  {
+    "cppref": "c/string/wide/wmemcmp",
+    "cppdoc": "c/library/string/wide/wmemcmp"
+  },
+  {
+    "cppref": "c/string/wide/iswdigit",
+    "cppdoc": "c/library/string/wide/iswdigit"
+  },
+  {
+    "cppref": "c/string/wide/wcscat",
+    "cppdoc": "c/library/string/wide/wcscat"
+  },
+  {
+    "cppref": "c/string/wide/wmemmove",
+    "cppdoc": "c/library/string/wide/wmemmove"
+  },
+  {
+    "cppref": "c/string/wide/iswupper",
+    "cppdoc": "c/library/string/wide/iswupper"
+  },
+  {
+    "cppref": "c/string/wide/iswblank",
+    "cppdoc": "c/library/string/wide/iswblank"
+  },
+  {
+    "cppref": "c/string/wide/iswpunct",
+    "cppdoc": "c/library/string/wide/iswpunct"
+  },
+  {
+    "cppref": "c/string/wide/iswlower",
+    "cppdoc": "c/library/string/wide/iswlower"
+  },
+  {
+    "cppref": "c/string/wide/wctype",
+    "cppdoc": "c/library/string/wide/wctype"
+  },
+  {
+    "cppref": "c/string/wide/wcsrchr",
+    "cppdoc": "c/library/string/wide/wcsrchr"
+  },
+  {
+    "cppref": "c/string/wide/wcscspn",
+    "cppdoc": "c/library/string/wide/wcscspn"
+  },
+  {
+    "cppref": "c/string/wide/iswcntrl",
+    "cppdoc": "c/library/string/wide/iswcntrl"
+  },
+  {
+    "cppref": "c/string/wide/wcstoul",
+    "cppdoc": "c/library/string/wide/wcstoul"
+  },
+  {
+    "cppref": "c/string/wide/wcstoimax",
+    "cppdoc": "c/library/string/wide/wcstoimax"
+  },
+  {
+    "cppref": "c/string/wide/iswalnum",
+    "cppdoc": "c/library/string/wide/iswalnum"
+  },
+  {
+    "cppref": "c/string/wide/iswctype",
+    "cppdoc": "c/library/string/wide/iswctype"
+  },
+  {
+    "cppref": "c/string/wide/towlower",
+    "cppdoc": "c/library/string/wide/towlower"
+  },
+  {
+    "cppref": "c/string/wide/iswalpha",
+    "cppdoc": "c/library/string/wide/iswalpha"
+  },
+  {
+    "cppref": "c/string/wide/wcsncmp",
+    "cppdoc": "c/library/string/wide/wcsncmp"
+  },
+  {
+    "cppref": "c/string/wide/iswprint",
+    "cppdoc": "c/library/string/wide/iswprint"
+  },
+  {
+    "cppref": "c/string/wide/iswxdigit",
+    "cppdoc": "c/library/string/wide/iswxdigit"
+  },
+  {
+    "cppref": "c/string/wide/wcsxfrm",
+    "cppdoc": "c/library/string/wide/wcsxfrm"
+  },
+  {
+    "cppref": "c/string/wide/wcsspn",
+    "cppdoc": "c/library/string/wide/wcsspn"
+  },
+  {
+    "cppref": "c/string/wide/wcstof",
+    "cppdoc": "c/library/string/wide/wcstof"
+  },
+  {
+    "cppref": "c/string/wide/wmemchr",
+    "cppdoc": "c/library/string/wide/wmemchr"
+  },
+  {
+    "cppref": "c/string/wide/wcsncpy",
+    "cppdoc": "c/library/string/wide/wcsncpy"
+  },
+  {
+    "cppref": "c/string/wide/wctrans",
+    "cppdoc": "c/library/string/wide/wctrans"
+  },
+  {
+    "cppref": "c/string/wide/iswgraph",
+    "cppdoc": "c/library/string/wide/iswgraph"
+  },
+  {
+    "cppref": "c/string/wide/iswspace",
+    "cppdoc": "c/library/string/wide/iswspace"
+  },
+  {
+    "cppref": "c/string/wide/wcscoll",
+    "cppdoc": "c/library/string/wide/wcscoll"
+  },
+  {
+    "cppref": "c/string/wide/wcslen",
+    "cppdoc": "c/library/string/wide/wcslen"
+  },
+  {
+    "cppref": "c/algorithm/qsort",
+    "cppdoc": "c/library/algorithm/qsort"
+  },
+  {
+    "cppref": "c/algorithm/bsearch",
+    "cppdoc": "c/library/algorithm/bsearch"
+  },
+  {
+    "cppref": "c/numeric/bit_manip",
+    "cppdoc": "c/library/numeric/bit_manip"
+  },
+  {
+    "cppref": "c/numeric/fenv",
+    "cppdoc": "c/library/numeric/fenv"
+  },
+  {
+    "cppref": "c/numeric/ckd_mul",
+    "cppdoc": "c/library/numeric/ckd_mul"
+  },
+  {
+    "cppref": "c/numeric/tgmath",
+    "cppdoc": "c/library/numeric/tgmath"
+  },
+  {
+    "cppref": "c/numeric/ckd_sub",
+    "cppdoc": "c/library/numeric/ckd_sub"
+  },
+  {
+    "cppref": "c/numeric/endian",
+    "cppdoc": "c/library/numeric/endian"
+  },
+  {
+    "cppref": "c/numeric/math",
+    "cppdoc": "c/library/numeric/math"
+  },
+  {
+    "cppref": "c/numeric/random",
+    "cppdoc": "c/library/numeric/random"
+  },
+  {
+    "cppref": "c/numeric/ckd_add",
+    "cppdoc": "c/library/numeric/ckd_add"
+  },
+  {
+    "cppref": "c/numeric/complex",
+    "cppdoc": "c/library/numeric/complex"
+  },
+  {
+    "cppref": "c/numeric/complex/casinh",
+    "cppdoc": "c/library/numeric/complex/casinh"
+  },
+  {
+    "cppref": "c/numeric/complex/ctan",
+    "cppdoc": "c/library/numeric/complex/ctan"
+  },
+  {
+    "cppref": "c/numeric/complex/csinh",
+    "cppdoc": "c/library/numeric/complex/csinh"
+  },
+  {
+    "cppref": "c/numeric/complex/cabs",
+    "cppdoc": "c/library/numeric/complex/cabs"
+  },
+  {
+    "cppref": "c/numeric/complex/ctanh",
+    "cppdoc": "c/library/numeric/complex/ctanh"
+  },
+  {
+    "cppref": "c/numeric/complex/ccosh",
+    "cppdoc": "c/library/numeric/complex/ccosh"
+  },
+  {
+    "cppref": "c/numeric/complex/catan",
+    "cppdoc": "c/library/numeric/complex/catan"
+  },
+  {
+    "cppref": "c/numeric/complex/carg",
+    "cppdoc": "c/library/numeric/complex/carg"
+  },
+  {
+    "cppref": "c/numeric/complex/conj",
+    "cppdoc": "c/library/numeric/complex/conj"
+  },
+  {
+    "cppref": "c/numeric/complex/cexp",
+    "cppdoc": "c/library/numeric/complex/cexp"
+  },
+  {
+    "cppref": "c/numeric/complex/ccos",
+    "cppdoc": "c/library/numeric/complex/ccos"
+  },
+  {
+    "cppref": "c/numeric/complex/casin",
+    "cppdoc": "c/library/numeric/complex/casin"
+  },
+  {
+    "cppref": "c/numeric/complex/I",
+    "cppdoc": "c/library/numeric/complex/I"
+  },
+  {
+    "cppref": "c/numeric/complex/CMPLX",
+    "cppdoc": "c/library/numeric/complex/CMPLX"
+  },
+  {
+    "cppref": "c/numeric/complex/clog",
+    "cppdoc": "c/library/numeric/complex/clog"
+  },
+  {
+    "cppref": "c/numeric/complex/cproj",
+    "cppdoc": "c/library/numeric/complex/cproj"
+  },
+  {
+    "cppref": "c/numeric/complex/imaginary",
+    "cppdoc": "c/library/numeric/complex/imaginary"
+  },
+  {
+    "cppref": "c/numeric/complex/Complex_I",
+    "cppdoc": "c/library/numeric/complex/Complex_I"
+  },
+  {
+    "cppref": "c/numeric/complex/csin",
+    "cppdoc": "c/library/numeric/complex/csin"
+  },
+  {
+    "cppref": "c/numeric/complex/csqrt",
+    "cppdoc": "c/library/numeric/complex/csqrt"
+  },
+  {
+    "cppref": "c/numeric/complex/catanh",
+    "cppdoc": "c/library/numeric/complex/catanh"
+  },
+  {
+    "cppref": "c/numeric/complex/cimag",
+    "cppdoc": "c/library/numeric/complex/cimag"
+  },
+  {
+    "cppref": "c/numeric/complex/creal",
+    "cppdoc": "c/library/numeric/complex/creal"
+  },
+  {
+    "cppref": "c/numeric/complex/cpow",
+    "cppdoc": "c/library/numeric/complex/cpow"
+  },
+  {
+    "cppref": "c/numeric/complex/Imaginary_I",
+    "cppdoc": "c/library/numeric/complex/Imaginary_I"
+  },
+  {
+    "cppref": "c/numeric/complex/cacosh",
+    "cppdoc": "c/library/numeric/complex/cacosh"
+  },
+  {
+    "cppref": "c/numeric/complex/cacos",
+    "cppdoc": "c/library/numeric/complex/cacos"
+  },
+  {
+    "cppref": "c/numeric/complex/complex",
+    "cppdoc": "c/library/numeric/complex/complex"
+  },
+  {
+    "cppref": "c/numeric/bit/endian",
+    "cppdoc": "c/library/numeric/bit/endian"
+  },
+  {
+    "cppref": "c/numeric/bit/stdc_leading_zeros",
+    "cppdoc": "c/library/numeric/bit/stdc_leading_zeros"
+  },
+  {
+    "cppref": "c/numeric/random/RAND_MAX",
+    "cppdoc": "c/library/numeric/random/RAND_MAX"
+  },
+  {
+    "cppref": "c/numeric/random/rand",
+    "cppdoc": "c/library/numeric/random/rand"
+  },
+  {
+    "cppref": "c/numeric/random/srand",
+    "cppdoc": "c/library/numeric/random/srand"
+  },
+  {
+    "cppref": "c/numeric/fenv/feupdateenv",
+    "cppdoc": "c/library/numeric/fenv/feupdateenv"
+  },
+  {
+    "cppref": "c/numeric/fenv/FE_exceptions",
+    "cppdoc": "c/library/numeric/fenv/FE_exceptions"
+  },
+  {
+    "cppref": "c/numeric/fenv/feexceptflag",
+    "cppdoc": "c/library/numeric/fenv/feexceptflag"
+  },
+  {
+    "cppref": "c/numeric/fenv/feholdexcept",
+    "cppdoc": "c/library/numeric/fenv/feholdexcept"
+  },
+  {
+    "cppref": "c/numeric/fenv/feraiseexcept",
+    "cppdoc": "c/library/numeric/fenv/feraiseexcept"
+  },
+  {
+    "cppref": "c/numeric/fenv/feround",
+    "cppdoc": "c/library/numeric/fenv/feround"
+  },
+  {
+    "cppref": "c/numeric/fenv/FE_round",
+    "cppdoc": "c/library/numeric/fenv/FE_round"
+  },
+  {
+    "cppref": "c/numeric/fenv/feenv",
+    "cppdoc": "c/library/numeric/fenv/feenv"
+  },
+  {
+    "cppref": "c/numeric/fenv/fetestexcept",
+    "cppdoc": "c/library/numeric/fenv/fetestexcept"
+  },
+  {
+    "cppref": "c/numeric/fenv/FE_DFL_ENV",
+    "cppdoc": "c/library/numeric/fenv/FE_DFL_ENV"
+  },
+  {
+    "cppref": "c/numeric/fenv/feclearexcept",
+    "cppdoc": "c/library/numeric/fenv/feclearexcept"
+  },
+  {
+    "cppref": "c/numeric/math/fma",
+    "cppdoc": "c/library/numeric/math/fma"
+  },
+  {
+    "cppref": "c/numeric/math/asin",
+    "cppdoc": "c/library/numeric/math/asin"
+  },
+  {
+    "cppref": "c/numeric/math/isnormal",
+    "cppdoc": "c/library/numeric/math/isnormal"
+  },
+  {
+    "cppref": "c/numeric/math/sin",
+    "cppdoc": "c/library/numeric/math/sin"
+  },
+  {
+    "cppref": "c/numeric/math/scalbn",
+    "cppdoc": "c/library/numeric/math/scalbn"
+  },
+  {
+    "cppref": "c/numeric/math/cospi",
+    "cppdoc": "c/library/numeric/math/cospi"
+  },
+  {
+    "cppref": "c/numeric/math/float_t",
+    "cppdoc": "c/library/numeric/math/float_t"
+  },
+  {
+    "cppref": "c/numeric/math/acos",
+    "cppdoc": "c/library/numeric/math/acos"
+  },
+  {
+    "cppref": "c/numeric/math/modf",
+    "cppdoc": "c/library/numeric/math/modf"
+  },
+  {
+    "cppref": "c/numeric/math/tan",
+    "cppdoc": "c/library/numeric/math/tan"
+  },
+  {
+    "cppref": "c/numeric/math/fmin",
+    "cppdoc": "c/library/numeric/math/fmin"
+  },
+  {
+    "cppref": "c/numeric/math/frexp",
+    "cppdoc": "c/library/numeric/math/frexp"
+  },
+  {
+    "cppref": "c/numeric/math/fabs",
+    "cppdoc": "c/library/numeric/math/fabs"
+  },
+  {
+    "cppref": "c/numeric/math/floor",
+    "cppdoc": "c/library/numeric/math/floor"
+  },
+  {
+    "cppref": "c/numeric/math/fdim",
+    "cppdoc": "c/library/numeric/math/fdim"
+  },
+  {
+    "cppref": "c/numeric/math/ldexp",
+    "cppdoc": "c/library/numeric/math/ldexp"
+  },
+  {
+    "cppref": "c/numeric/math/log2",
+    "cppdoc": "c/library/numeric/math/log2"
+  },
+  {
+    "cppref": "c/numeric/math/ceil",
+    "cppdoc": "c/library/numeric/math/ceil"
+  },
+  {
+    "cppref": "c/numeric/math/erfc",
+    "cppdoc": "c/library/numeric/math/erfc"
+  },
+  {
+    "cppref": "c/numeric/math/isless",
+    "cppdoc": "c/library/numeric/math/isless"
+  },
+  {
+    "cppref": "c/numeric/math/exp",
+    "cppdoc": "c/library/numeric/math/exp"
+  },
+  {
+    "cppref": "c/numeric/math/sqrt",
+    "cppdoc": "c/library/numeric/math/sqrt"
+  },
+  {
+    "cppref": "c/numeric/math/tgamma",
+    "cppdoc": "c/library/numeric/math/tgamma"
+  },
+  {
+    "cppref": "c/numeric/math/math_errhandling",
+    "cppdoc": "c/library/numeric/math/math_errhandling"
+  },
+  {
+    "cppref": "c/numeric/math/erf",
+    "cppdoc": "c/library/numeric/math/erf"
+  },
+  {
+    "cppref": "c/numeric/math/log1p",
+    "cppdoc": "c/library/numeric/math/log1p"
+  },
+  {
+    "cppref": "c/numeric/math/exp2",
+    "cppdoc": "c/library/numeric/math/exp2"
+  },
+  {
+    "cppref": "c/numeric/math/remainder",
+    "cppdoc": "c/library/numeric/math/remainder"
+  },
+  {
+    "cppref": "c/numeric/math/islessgreater",
+    "cppdoc": "c/library/numeric/math/islessgreater"
+  },
+  {
+    "cppref": "c/numeric/math/isunordered",
+    "cppdoc": "c/library/numeric/math/isunordered"
+  },
+  {
+    "cppref": "c/numeric/math/isnan",
+    "cppdoc": "c/library/numeric/math/isnan"
+  },
+  {
+    "cppref": "c/numeric/math/isfinite",
+    "cppdoc": "c/library/numeric/math/isfinite"
+  },
+  {
+    "cppref": "c/numeric/math/ilogb",
+    "cppdoc": "c/library/numeric/math/ilogb"
+  },
+  {
+    "cppref": "c/numeric/math/trunc",
+    "cppdoc": "c/library/numeric/math/trunc"
+  },
+  {
+    "cppref": "c/numeric/math/isinf",
+    "cppdoc": "c/library/numeric/math/isinf"
+  },
+  {
+    "cppref": "c/numeric/math/signbit",
+    "cppdoc": "c/library/numeric/math/signbit"
+  },
+  {
+    "cppref": "c/numeric/math/HUGE_VAL",
+    "cppdoc": "c/library/numeric/math/HUGE_VAL"
+  },
+  {
+    "cppref": "c/numeric/math/cosh",
+    "cppdoc": "c/library/numeric/math/cosh"
+  },
+  {
+    "cppref": "c/numeric/math/pow",
+    "cppdoc": "c/library/numeric/math/pow"
+  },
+  {
+    "cppref": "c/numeric/math/isgreaterequal",
+    "cppdoc": "c/library/numeric/math/isgreaterequal"
+  },
+  {
+    "cppref": "c/numeric/math/INFINITY",
+    "cppdoc": "c/library/numeric/math/INFINITY"
+  },
+  {
+    "cppref": "c/numeric/math/logb",
+    "cppdoc": "c/library/numeric/math/logb"
+  },
+  {
+    "cppref": "c/numeric/math/NAN",
+    "cppdoc": "c/library/numeric/math/NAN"
+  },
+  {
+    "cppref": "c/numeric/math/asinh",
+    "cppdoc": "c/library/numeric/math/asinh"
+  },
+  {
+    "cppref": "c/numeric/math/lgamma",
+    "cppdoc": "c/library/numeric/math/lgamma"
+  },
+  {
+    "cppref": "c/numeric/math/FP_categories",
+    "cppdoc": "c/library/numeric/math/FP_categories"
+  },
+  {
+    "cppref": "c/numeric/math/tanh",
+    "cppdoc": "c/library/numeric/math/tanh"
+  },
+  {
+    "cppref": "c/numeric/math/sinpi",
+    "cppdoc": "c/library/numeric/math/sinpi"
+  },
+  {
+    "cppref": "c/numeric/math/copysign",
+    "cppdoc": "c/library/numeric/math/copysign"
+  },
+  {
+    "cppref": "c/numeric/math/cbrt",
+    "cppdoc": "c/library/numeric/math/cbrt"
+  },
+  {
+    "cppref": "c/numeric/math/hypot",
+    "cppdoc": "c/library/numeric/math/hypot"
+  },
+  {
+    "cppref": "c/numeric/math/cos",
+    "cppdoc": "c/library/numeric/math/cos"
+  },
+  {
+    "cppref": "c/numeric/math/rint",
+    "cppdoc": "c/library/numeric/math/rint"
+  },
+  {
+    "cppref": "c/numeric/math/nextafter",
+    "cppdoc": "c/library/numeric/math/nextafter"
+  },
+  {
+    "cppref": "c/numeric/math/sinh",
+    "cppdoc": "c/library/numeric/math/sinh"
+  },
+  {
+    "cppref": "c/numeric/math/isgreater",
+    "cppdoc": "c/library/numeric/math/isgreater"
+  },
+  {
+    "cppref": "c/numeric/math/nearbyint",
+    "cppdoc": "c/library/numeric/math/nearbyint"
+  },
+  {
+    "cppref": "c/numeric/math/atan",
+    "cppdoc": "c/library/numeric/math/atan"
+  },
+  {
+    "cppref": "c/numeric/math/atan2",
+    "cppdoc": "c/library/numeric/math/atan2"
+  },
+  {
+    "cppref": "c/numeric/math/log10",
+    "cppdoc": "c/library/numeric/math/log10"
+  },
+  {
+    "cppref": "c/numeric/math/round",
+    "cppdoc": "c/library/numeric/math/round"
+  },
+  {
+    "cppref": "c/numeric/math/nan.2",
+    "cppdoc": "c/library/numeric/math/nan.2"
+  },
+  {
+    "cppref": "c/numeric/math/fmax",
+    "cppdoc": "c/library/numeric/math/fmax"
+  },
+  {
+    "cppref": "c/numeric/math/remquo",
+    "cppdoc": "c/library/numeric/math/remquo"
+  },
+  {
+    "cppref": "c/numeric/math/acosh",
+    "cppdoc": "c/library/numeric/math/acosh"
+  },
+  {
+    "cppref": "c/numeric/math/roundeven",
+    "cppdoc": "c/library/numeric/math/roundeven"
+  },
+  {
+    "cppref": "c/numeric/math/islessequal",
+    "cppdoc": "c/library/numeric/math/islessequal"
+  },
+  {
+    "cppref": "c/numeric/math/nexttoward",
+    "cppdoc": "c/library/numeric/math/nexttoward"
+  },
+  {
+    "cppref": "c/numeric/math/abs",
+    "cppdoc": "c/library/numeric/math/abs"
+  },
+  {
+    "cppref": "c/numeric/math/div",
+    "cppdoc": "c/library/numeric/math/div"
+  },
+  {
+    "cppref": "c/numeric/math/log",
+    "cppdoc": "c/library/numeric/math/log"
+  },
+  {
+    "cppref": "c/numeric/math/fpclassify",
+    "cppdoc": "c/library/numeric/math/fpclassify"
+  },
+  {
+    "cppref": "c/numeric/math/fmod",
+    "cppdoc": "c/library/numeric/math/fmod"
+  },
+  {
+    "cppref": "c/numeric/math/expm1",
+    "cppdoc": "c/library/numeric/math/expm1"
+  },
+  {
+    "cppref": "c/numeric/math/atanh",
+    "cppdoc": "c/library/numeric/math/atanh"
+  },
+  {
+    "cppref": "c/language/file_scope",
+    "cppdoc": "c/language/file_scope"
+  },
+  {
+    "cppref": "c/language/declarations",
+    "cppdoc": "c/language/declarations"
+  },
+  {
+    "cppref": "c/language/extern",
+    "cppdoc": "c/language/declarations/extern"
+  },
+  {
+    "cppref": "c/language/expressions",
+    "cppdoc": "c/language/expressions"
+  },
+  {
+    "cppref": "c/language/operator_alternative",
+    "cppdoc": "c/language/operator_alternative"
+  },
+  {
+    "cppref": "c/language/floating_constant",
+    "cppdoc": "c/language/expressions/floating_constant"
+  },
+  {
+    "cppref": "c/language/attributes",
+    "cppdoc": "c/language/declarations/attributes"
+  },
+  {
+    "cppref": "c/language/compound_literal",
+    "cppdoc": "c/language/expressions/compound_literal"
+  },
+  {
+    "cppref": "c/language/conformance",
+    "cppdoc": "c/language/conformance"
+  },
+  {
+    "cppref": "c/language/static_storage_duration",
+    "cppdoc": "c/language/static_storage_duration"
+  },
+  {
+    "cppref": "c/language/operator_logical",
+    "cppdoc": "c/language/expressions/operator_logical"
+  },
+  {
+    "cppref": "c/language/operator_incdec",
+    "cppdoc": "c/language/expressions/operator_incdec"
+  },
+  {
+    "cppref": "c/language/conversion",
+    "cppdoc": "c/language/expressions/conversion"
+  },
+  {
+    "cppref": "c/language/ndr",
+    "cppdoc": "c/language/ndr"
+  },
+  {
+    "cppref": "c/language/alignof",
+    "cppdoc": "c/language/expressions/alignof"
+  },
+  {
+    "cppref": "c/language/volatile",
+    "cppdoc": "c/language/declarations/volatile"
+  },
+  {
+    "cppref": "c/language/operator_other",
+    "cppdoc": "c/language/expressions/operator_other"
+  },
+  {
+    "cppref": "c/language/_Static_assert",
+    "cppdoc": "c/language/declarations/_Static_assert"
+  },
+  {
+    "cppref": "c/language/escape",
+    "cppdoc": "c/language/expressions/escape"
+  },
+  {
+    "cppref": "c/language/statements",
+    "cppdoc": "c/language/statements"
+  },
+  {
+    "cppref": "c/language/operator_precedence",
+    "cppdoc": "c/language/expressions/operator_precedence"
+  },
+  {
+    "cppref": "c/language/analyzability",
+    "cppdoc": "c/language/analyzability"
+  },
+  {
+    "cppref": "c/language/constant_expression",
+    "cppdoc": "c/language/expressions/constant_expression"
+  },
+  {
+    "cppref": "c/language/switch",
+    "cppdoc": "c/language/statements/switch"
+  },
+  {
+    "cppref": "c/language/sizeof",
+    "cppdoc": "c/language/expressions/sizeof"
+  },
+  {
+    "cppref": "c/language/restrict",
+    "cppdoc": "c/language/declarations/restrict"
+  },
+  {
+    "cppref": "c/language/for",
+    "cppdoc": "c/language/statements/for"
+  },
+  {
+    "cppref": "c/language/eval_order",
+    "cppdoc": "c/language/expressions/eval_order"
+  },
+  {
+    "cppref": "c/language/const",
+    "cppdoc": "c/language/declarations/const"
+  },
+  {
+    "cppref": "c/language/continue",
+    "cppdoc": "c/language/statements/continue"
+  },
+  {
+    "cppref": "c/language/if",
+    "cppdoc": "c/language/statements/if"
+  },
+  {
+    "cppref": "c/language/array",
+    "cppdoc": "c/language/declarations/array"
+  },
+  {
+    "cppref": "c/language/operator_arithmetic",
+    "cppdoc": "c/language/expressions/operator_arithmetic"
+  },
+  {
+    "cppref": "c/language/value_category",
+    "cppdoc": "c/language/expressions/value_category"
+  },
+  {
+    "cppref": "c/language/typedef",
+    "cppdoc": "c/language/declarations/typedef"
+  },
+  {
+    "cppref": "c/language/nullptr",
+    "cppdoc": "c/language/expressions/nullptr"
+  },
+  {
+    "cppref": "c/language/_Alignof",
+    "cppdoc": "c/language/expressions/_Alignof"
+  },
+  {
+    "cppref": "c/language/static_assert",
+    "cppdoc": "c/language/declarations/static_assert"
+  },
+  {
+    "cppref": "c/language/string_literal",
+    "cppdoc": "c/language/expressions/string_literal"
+  },
+  {
+    "cppref": "c/language/character_constant",
+    "cppdoc": "c/language/expressions/character_constant"
+  },
+  {
+    "cppref": "c/language/pointer",
+    "cppdoc": "c/language/declarations/pointer"
+  },
+  {
+    "cppref": "c/language/operator_assignment",
+    "cppdoc": "c/language/expressions/operator_assignment"
+  },
+  {
+    "cppref": "c/language/enum",
+    "cppdoc": "c/language/declarations/enum"
+  },
+  {
+    "cppref": "c/language/storage_duration",
+    "cppdoc": "c/language/declarations/storage_duration"
+  },
+  {
+    "cppref": "c/language/thread_storage_duration",
+    "cppdoc": "c/language/thread_storage_duration"
+  },
+  {
+    "cppref": "c/language/asm",
+    "cppdoc": "c/language/asm"
+  },
+  {
+    "cppref": "c/language/typeof",
+    "cppdoc": "c/language/expressions/typeof"
+  },
+  {
+    "cppref": "c/language/while",
+    "cppdoc": "c/language/statements/while"
+  },
+  {
+    "cppref": "c/language/union",
+    "cppdoc": "c/language/declarations/union"
+  },
+  {
+    "cppref": "c/language/break",
+    "cppdoc": "c/language/statements/break"
+  },
+  {
+    "cppref": "c/language/functions",
+    "cppdoc": "c/language/functions"
+  },
+  {
+    "cppref": "c/language/cast",
+    "cppdoc": "c/language/expressions/cast"
+  },
+  {
+    "cppref": "c/language/constexpr",
+    "cppdoc": "c/language/declarations/constexpr"
+  },
+  {
+    "cppref": "c/language/_Alignas",
+    "cppdoc": "c/language/declarations/_Alignas"
+  },
+  {
+    "cppref": "c/language/generic",
+    "cppdoc": "c/language/expressions/generic"
+  },
+  {
+    "cppref": "c/language/typeof_unqual",
+    "cppdoc": "c/language/expressions/typeof_unqual"
+  },
+  {
+    "cppref": "c/language/operator_member_access",
+    "cppdoc": "c/language/expressions/operator_member_access"
+  },
+  {
+    "cppref": "c/language/struct",
+    "cppdoc": "c/language/declarations/struct"
+  },
+  {
+    "cppref": "c/language/inline",
+    "cppdoc": "c/language/functions/inline"
+  },
+  {
+    "cppref": "c/language/history",
+    "cppdoc": "c/language/history"
+  },
+  {
+    "cppref": "c/language/initialization",
+    "cppdoc": "c/language/initialization"
+  },
+  {
+    "cppref": "c/language/struct_initialization",
+    "cppdoc": "c/language/initialization/struct_initialization"
+  },
+  {
+    "cppref": "c/language/bit_field",
+    "cppdoc": "c/language/declarations/bit_field"
+  },
+  {
+    "cppref": "c/language/basic_concepts",
+    "cppdoc": "c/language/basic_concepts"
+  },
+  {
+    "cppref": "c/language/function_definition",
+    "cppdoc": "c/language/functions/function_definition"
+  },
+  {
+    "cppref": "c/language/goto",
+    "cppdoc": "c/language/statements/goto"
+  },
+  {
+    "cppref": "c/language/operator_comparison",
+    "cppdoc": "c/language/expressions/operator_comparison"
+  },
+  {
+    "cppref": "c/language/auto",
+    "cppdoc": "c/language/auto"
+  },
+  {
+    "cppref": "c/language/attributes/fallthrough",
+    "cppdoc": "c/language/declarations/attributes/fallthrough"
+  },
+  {
+    "cppref": "c/language/attributes/deprecated",
+    "cppdoc": "c/language/declarations/attributes/deprecated"
+  },
+  {
+    "cppref": "c/language/attributes/maybe_unused",
+    "cppdoc": "c/language/declarations/attributes/maybe_unused"
+  },
+  {
+    "cppref": "c/language/attributes/reproducible",
+    "cppdoc": "c/language/declarations/attributes/reproducible"
+  },
+  {
+    "cppref": "c/language/attributes/noreturn",
+    "cppdoc": "c/language/declarations/attributes/noreturn"
+  },
+  {
+    "cppref": "c/language/attributes/nodiscard",
+    "cppdoc": "c/language/declarations/attributes/nodiscard"
+  },
+  {
+    "cppref": "c/links/libs",
+    "cppdoc": "c/library/links/libs"
+  },
+  {
+    "cppref": "c/memory/free",
+    "cppdoc": "c/library/memory/free"
+  },
+  {
+    "cppref": "c/memory/calloc",
+    "cppdoc": "c/library/memory/calloc"
+  },
+  {
+    "cppref": "c/memory/free_sized",
+    "cppdoc": "c/library/memory/free_sized"
+  },
+  {
+    "cppref": "c/memory/realloc",
+    "cppdoc": "c/library/memory/realloc"
+  },
+  {
+    "cppref": "c/memory/free_aligned_sized",
+    "cppdoc": "c/library/memory/free_aligned_sized"
+  },
+  {
+    "cppref": "c/memory/malloc",
+    "cppdoc": "c/library/memory/malloc"
+  },
+  {
+    "cppref": "c/memory/aligned_alloc",
+    "cppdoc": "c/library/memory/aligned_alloc"
+  },
+  {
+    "cppref": "c/atomic/atomic_is_lock_free",
+    "cppdoc": "c/library/thread/atomic_is_lock_free"
+  },
+  {
+    "cppref": "c/atomic/atomic_flag",
+    "cppdoc": "c/library/thread/atomic_flag"
+  },
+  {
+    "cppref": "c/atomic/ATOMIC_LOCK_FREE_consts",
+    "cppdoc": "c/library/thread/ATOMIC_LOCK_FREE_consts"
+  },
+  {
+    "cppref": "c/atomic/atomic_load",
+    "cppdoc": "c/library/thread/atomic_load"
+  },
+  {
+    "cppref": "c/atomic/atomic_signal_fence",
+    "cppdoc": "c/library/thread/atomic_signal_fence"
+  },
+  {
+    "cppref": "c/atomic/atomic_store",
+    "cppdoc": "c/library/thread/atomic_store"
+  },
+  {
+    "cppref": "c/atomic/atomic_fetch_sub",
+    "cppdoc": "c/library/thread/atomic_fetch_sub"
+  },
+  {
+    "cppref": "c/atomic/atomic_fetch_and",
+    "cppdoc": "c/library/thread/atomic_fetch_and"
+  },
+  {
+    "cppref": "c/atomic/ATOMIC_FLAG_INIT",
+    "cppdoc": "c/library/thread/ATOMIC_FLAG_INIT"
+  },
+  {
+    "cppref": "c/atomic/kill_dependency",
+    "cppdoc": "c/library/thread/kill_dependency"
+  },
+  {
+    "cppref": "c/atomic/atomic_flag_clear",
+    "cppdoc": "c/library/thread/atomic_flag_clear"
+  },
+  {
+    "cppref": "c/atomic/atomic_fetch_or",
+    "cppdoc": "c/library/thread/atomic_fetch_or"
+  },
+  {
+    "cppref": "c/atomic/memory_order",
+    "cppdoc": "c/library/thread/memory_order"
+  },
+  {
+    "cppref": "c/atomic/atomic_init",
+    "cppdoc": "c/library/thread/atomic_init"
+  },
+  {
+    "cppref": "c/atomic/atomic_fetch_xor",
+    "cppdoc": "c/library/thread/atomic_fetch_xor"
+  },
+  {
+    "cppref": "c/atomic/atomic_exchange",
+    "cppdoc": "c/library/thread/atomic_exchange"
+  },
+  {
+    "cppref": "c/atomic/ATOMIC_VAR_INIT",
+    "cppdoc": "c/library/thread/ATOMIC_VAR_INIT"
+  },
+  {
+    "cppref": "c/atomic/atomic_flag_test_and_set",
+    "cppdoc": "c/library/thread/atomic_flag_test_and_set"
+  },
+  {
+    "cppref": "c/atomic/atomic_compare_exchange",
+    "cppdoc": "c/library/thread/atomic_compare_exchange"
+  },
+  {
+    "cppref": "c/atomic/atomic_thread_fence",
+    "cppdoc": "c/library/thread/atomic_thread_fence"
+  },
+  {
+    "cppref": "c/atomic/atomic_fetch_add",
+    "cppdoc": "c/library/thread/atomic_fetch_add"
+  },
+  {
+    "cppref": "c/thread/thrd_detach",
+    "cppdoc": "c/library/thread/thrd_detach"
+  },
+  {
+    "cppref": "c/thread/thrd_current",
+    "cppdoc": "c/library/thread/thrd_current"
+  },
+  {
+    "cppref": "c/thread/cnd_timedwait",
+    "cppdoc": "c/library/thread/cnd_timedwait"
+  },
+  {
+    "cppref": "c/thread/tss_set",
+    "cppdoc": "c/library/thread/tss_set"
+  },
+  {
+    "cppref": "c/thread/thrd_join",
+    "cppdoc": "c/library/thread/thrd_join"
+  },
+  {
+    "cppref": "c/thread/thrd_errors",
+    "cppdoc": "c/library/thread/thrd_errors"
+  },
+  {
+    "cppref": "c/thread/thrd_create",
+    "cppdoc": "c/library/thread/thrd_create"
+  },
+  {
+    "cppref": "c/thread/mtx_destroy",
+    "cppdoc": "c/library/thread/mtx_destroy"
+  },
+  {
+    "cppref": "c/thread/tss_create",
+    "cppdoc": "c/library/thread/tss_create"
+  },
+  {
+    "cppref": "c/thread/cnd_destroy",
+    "cppdoc": "c/library/thread/cnd_destroy"
+  },
+  {
+    "cppref": "c/thread/thread_local",
+    "cppdoc": "c/library/thread/thread_local"
+  },
+  {
+    "cppref": "c/thread/thrd_equal",
+    "cppdoc": "c/library/thread/thrd_equal"
+  },
+  {
+    "cppref": "c/thread/tss_delete",
+    "cppdoc": "c/library/thread/tss_delete"
+  },
+  {
+    "cppref": "c/thread/cnd_wait",
+    "cppdoc": "c/library/thread/cnd_wait"
+  },
+  {
+    "cppref": "c/thread/mtx_types",
+    "cppdoc": "c/library/thread/mtx_types"
+  },
+  {
+    "cppref": "c/thread/call_once",
+    "cppdoc": "c/library/thread/call_once"
+  },
+  {
+    "cppref": "c/thread/mtx_unlock",
+    "cppdoc": "c/library/thread/mtx_unlock"
+  },
+  {
+    "cppref": "c/thread/thrd_sleep",
+    "cppdoc": "c/library/thread/thrd_sleep"
+  },
+  {
+    "cppref": "c/thread/mtx_timedlock",
+    "cppdoc": "c/library/thread/mtx_timedlock"
+  },
+  {
+    "cppref": "c/thread/mtx_lock",
+    "cppdoc": "c/library/thread/mtx_lock"
+  },
+  {
+    "cppref": "c/thread/mtx_trylock",
+    "cppdoc": "c/library/thread/mtx_trylock"
+  },
+  {
+    "cppref": "c/thread/TSS_DTOR_ITERATIONS",
+    "cppdoc": "c/library/thread/TSS_DTOR_ITERATIONS"
+  },
+  {
+    "cppref": "c/thread/ONCE_FLAG_INIT",
+    "cppdoc": "c/library/thread/ONCE_FLAG_INIT"
+  },
+  {
+    "cppref": "c/thread/thrd_exit",
+    "cppdoc": "c/library/thread/thrd_exit"
+  },
+  {
+    "cppref": "c/thread/tss_get",
+    "cppdoc": "c/library/thread/tss_get"
+  },
+  {
+    "cppref": "c/thread/mtx_init",
+    "cppdoc": "c/library/thread/mtx_init"
+  },
+  {
+    "cppref": "c/thread/cnd_signal",
+    "cppdoc": "c/library/thread/cnd_signal"
+  },
+  {
+    "cppref": "c/thread/cnd_init",
+    "cppdoc": "c/library/thread/cnd_init"
+  },
+  {
+    "cppref": "c/thread/thrd_yield",
+    "cppdoc": "c/library/thread/thrd_yield"
+  },
+  {
+    "cppref": "c/thread/cnd_broadcast",
+    "cppdoc": "c/library/thread/cnd_broadcast"
+  },
+  {
+    "cppref": "c/symbol_index/macro",
+    "cppdoc": "c/library/symbol_index/macro"
+  },
+  {
+    "cppref": "c/io/fputwc",
+    "cppdoc": "c/library/io/fputwc"
+  },
+  {
+    "cppref": "c/io/fread",
+    "cppdoc": "c/library/io/fread"
+  },
+  {
+    "cppref": "c/io/fflush",
+    "cppdoc": "c/library/io/fflush"
+  },
+  {
+    "cppref": "c/io/remove",
+    "cppdoc": "c/library/io/remove"
+  },
+  {
+    "cppref": "c/io/fsetpos",
+    "cppdoc": "c/library/io/fsetpos"
+  },
+  {
+    "cppref": "c/io/fscanf",
+    "cppdoc": "c/library/io/fscanf"
+  },
+  {
+    "cppref": "c/io/ungetc",
+    "cppdoc": "c/library/io/ungetc"
+  },
+  {
+    "cppref": "c/io/fopen",
+    "cppdoc": "c/library/io/fopen"
+  },
+  {
+    "cppref": "c/io/getwchar",
+    "cppdoc": "c/library/io/getwchar"
+  },
+  {
+    "cppref": "c/io/fwscanf",
+    "cppdoc": "c/library/io/fwscanf"
+  },
+  {
+    "cppref": "c/io/fputs",
+    "cppdoc": "c/library/io/fputs"
+  },
+  {
+    "cppref": "c/io/gets",
+    "cppdoc": "c/library/io/gets"
+  },
+  {
+    "cppref": "c/io/clearerr",
+    "cppdoc": "c/library/io/clearerr"
+  },
+  {
+    "cppref": "c/io/fwide",
+    "cppdoc": "c/library/io/fwide"
+  },
+  {
+    "cppref": "c/io/fputws",
+    "cppdoc": "c/library/io/fputws"
+  },
+  {
+    "cppref": "c/io/ferror",
+    "cppdoc": "c/library/io/ferror"
+  },
+  {
+    "cppref": "c/io/fgets",
+    "cppdoc": "c/library/io/fgets"
+  },
+  {
+    "cppref": "c/io/fgetpos",
+    "cppdoc": "c/library/io/fgetpos"
+  },
+  {
+    "cppref": "c/io/tmpnam",
+    "cppdoc": "c/library/io/tmpnam"
+  },
+  {
+    "cppref": "c/io/perror",
+    "cppdoc": "c/library/io/perror"
+  },
+  {
+    "cppref": "c/io/vfwscanf",
+    "cppdoc": "c/library/io/vfwscanf"
+  },
+  {
+    "cppref": "c/io/fclose",
+    "cppdoc": "c/library/io/fclose"
+  },
+  {
+    "cppref": "c/io/fprintf",
+    "cppdoc": "c/library/io/fprintf"
+  },
+  {
+    "cppref": "c/io/tmpfile",
+    "cppdoc": "c/library/io/tmpfile"
+  },
+  {
+    "cppref": "c/io/rename",
+    "cppdoc": "c/library/io/rename"
+  },
+  {
+    "cppref": "c/io/fgetc",
+    "cppdoc": "c/library/io/fgetc"
+  },
+  {
+    "cppref": "c/io/freopen",
+    "cppdoc": "c/library/io/freopen"
+  },
+  {
+    "cppref": "c/io/std_streams",
+    "cppdoc": "c/library/io/std_streams"
+  },
+  {
+    "cppref": "c/io/fgetws",
+    "cppdoc": "c/library/io/fgetws"
+  },
+  {
+    "cppref": "c/io/fseek",
+    "cppdoc": "c/library/io/fseek"
+  },
+  {
+    "cppref": "c/io/FILE",
+    "cppdoc": "c/library/io/FILE"
+  },
+  {
+    "cppref": "c/io/getchar",
+    "cppdoc": "c/library/io/getchar"
+  },
+  {
+    "cppref": "c/io/fgetwc",
+    "cppdoc": "c/library/io/fgetwc"
+  },
+  {
+    "cppref": "c/io/ftell",
+    "cppdoc": "c/library/io/ftell"
+  },
+  {
+    "cppref": "c/io/vfwprintf",
+    "cppdoc": "c/library/io/vfwprintf"
+  },
+  {
+    "cppref": "c/io/putwchar",
+    "cppdoc": "c/library/io/putwchar"
+  },
+  {
+    "cppref": "c/io/fputc",
+    "cppdoc": "c/library/io/fputc"
+  },
+  {
+    "cppref": "c/io/setbuf",
+    "cppdoc": "c/library/io/setbuf"
+  },
+  {
+    "cppref": "c/io/puts",
+    "cppdoc": "c/library/io/puts"
+  },
+  {
+    "cppref": "c/io/fwprintf",
+    "cppdoc": "c/library/io/fwprintf"
+  },
+  {
+    "cppref": "c/io/rewind",
+    "cppdoc": "c/library/io/rewind"
+  },
+  {
+    "cppref": "c/io/vfprintf",
+    "cppdoc": "c/library/io/vfprintf"
+  },
+  {
+    "cppref": "c/io/fpos_t",
+    "cppdoc": "c/library/io/fpos_t"
+  },
+  {
+    "cppref": "c/io/putchar",
+    "cppdoc": "c/library/io/putchar"
+  },
+  {
+    "cppref": "c/io/ungetwc",
+    "cppdoc": "c/library/io/ungetwc"
+  },
+  {
+    "cppref": "c/io/putc",
+    "cppdoc": "c/library/io/putc"
+  },
+  {
+    "cppref": "c/io/feof",
+    "cppdoc": "c/library/io/feof"
+  },
+  {
+    "cppref": "c/io/fwrite",
+    "cppdoc": "c/library/io/fwrite"
+  },
+  {
+    "cppref": "c/io/setvbuf",
+    "cppdoc": "c/library/io/setvbuf"
+  },
+  {
+    "cppref": "c/io/vfscanf",
+    "cppdoc": "c/library/io/vfscanf"
+  },
+  {
+    "cppref": "c/experimental/fpext1/nextup",
+    "cppdoc": "c/library/experimental/fpext1/nextup"
+  },
+  {
+    "cppref": "c/error/ignore_handler_s",
+    "cppdoc": "c/library/error/ignore_handler_s"
+  },
+  {
+    "cppref": "c/error/assert",
+    "cppdoc": "c/library/error/assert"
+  },
+  {
+    "cppref": "c/error/errno_macros",
+    "cppdoc": "c/library/error/errno_macros"
+  },
+  {
+    "cppref": "c/error/errno",
+    "cppdoc": "c/library/error/errno"
+  },
+  {
+    "cppref": "c/error/static_assert",
+    "cppdoc": "c/library/error/static_assert"
+  },
+  {
+    "cppref": "c/error/set_constraint_handler_s",
+    "cppdoc": "c/library/error/set_constraint_handler_s"
+  },
+  {
+    "cppref": "c/error/abort_handler_s",
+    "cppdoc": "c/library/error/abort_handler_s"
+  },
+  {
+    "cppref": "c/types/size_t",
+    "cppdoc": "c/library/types/size_t"
+  },
+  {
+    "cppref": "c/types/limits",
+    "cppdoc": "c/library/types/limits"
+  },
+  {
+    "cppref": "c/types/NULL",
+    "cppdoc": "c/library/types/NULL"
+  },
+  {
+    "cppref": "c/types/max_align_t",
+    "cppdoc": "c/library/types/max_align_t"
+  },
+  {
+    "cppref": "c/types/integer",
+    "cppdoc": "c/library/types/integer"
+  },
+  {
+    "cppref": "c/types/nullptr_t",
+    "cppdoc": "c/library/types/nullptr_t"
+  },
+  {
+    "cppref": "c/types/offsetof",
+    "cppdoc": "c/library/types/offsetof"
+  },
+  {
+    "cppref": "c/types/ptrdiff_t",
+    "cppdoc": "c/library/types/ptrdiff_t"
+  },
+  {
+    "cppref": "c/types/limits/FLT_ROUNDS",
+    "cppdoc": "c/library/types/limits/FLT_ROUNDS"
+  },
+  {
+    "cppref": "c/types/limits/FLT_EVAL_METHOD",
+    "cppdoc": "c/library/types/limits/FLT_EVAL_METHOD"
+  },
+  {
+    "cppref": "c/compiler_support/23",
+    "cppdoc": "c/library/compiler_support/23"
+  },
+  {
+    "cppref": "c/compiler_support/99",
+    "cppdoc": "c/library/compiler_support/99"
+  },
+  {
+    "cppref": "c/program/at_quick_exit",
+    "cppdoc": "c/library/program/at_quick_exit"
+  },
+  {
+    "cppref": "c/program/raise",
+    "cppdoc": "c/library/program/raise"
+  },
+  {
+    "cppref": "c/program/EXIT_status",
+    "cppdoc": "c/library/program/EXIT_status"
+  },
+  {
+    "cppref": "c/program/longjmp",
+    "cppdoc": "c/library/program/longjmp"
+  },
+  {
+    "cppref": "c/program/jmp_buf",
+    "cppdoc": "c/library/program/jmp_buf"
+  },
+  {
+    "cppref": "c/program/quick_exit",
+    "cppdoc": "c/library/program/quick_exit"
+  },
+  {
+    "cppref": "c/program/atexit",
+    "cppdoc": "c/library/program/atexit"
+  },
+  {
+    "cppref": "c/program/signal",
+    "cppdoc": "c/library/program/signal"
+  },
+  {
+    "cppref": "c/program/sig_atomic_t",
+    "cppdoc": "c/library/program/sig_atomic_t"
+  },
+  {
+    "cppref": "c/program/SIG_types",
+    "cppdoc": "c/library/program/SIG_types"
+  },
+  {
+    "cppref": "c/program/abort",
+    "cppdoc": "c/library/program/abort"
+  },
+  {
+    "cppref": "c/program/system",
+    "cppdoc": "c/library/program/system"
+  },
+  {
+    "cppref": "c/program/exit",
+    "cppdoc": "c/library/program/exit"
+  },
+  {
+    "cppref": "c/program/unreachable",
+    "cppdoc": "c/library/program/unreachable"
+  },
+  {
+    "cppref": "c/program/setjmp",
+    "cppdoc": "c/library/program/setjmp"
+  },
+  {
+    "cppref": "c/program/memalignment",
+    "cppdoc": "c/library/program/memalignment"
+  },
+  {
+    "cppref": "c/program/_Exit",
+    "cppdoc": "c/library/program/_Exit"
+  },
+  {
+    "cppref": "c/program/getenv",
+    "cppdoc": "c/library/program/getenv"
+  },
+  {
+    "cppref": "c/program/SIG_strategies",
+    "cppdoc": "c/library/program/SIG_strategies"
+  },
+  {
+    "cppref": "c/program/SIG_ERR",
+    "cppdoc": "c/library/program/SIG_ERR"
+  },
+  {
+    "cppref": "c/chrono/mktime",
+    "cppdoc": "c/library/chrono/mktime"
+  },
+  {
+    "cppref": "c/chrono/clock",
+    "cppdoc": "c/library/chrono/clock"
+  },
+  {
+    "cppref": "c/chrono/CLOCKS_PER_SEC",
+    "cppdoc": "c/library/chrono/CLOCKS_PER_SEC"
+  },
+  {
+    "cppref": "c/chrono/time_t",
+    "cppdoc": "c/library/chrono/time_t"
+  },
+  {
+    "cppref": "c/chrono/gmtime",
+    "cppdoc": "c/library/chrono/gmtime"
+  },
+  {
+    "cppref": "c/chrono/clock_t",
+    "cppdoc": "c/library/chrono/clock_t"
+  },
+  {
+    "cppref": "c/chrono/strftime",
+    "cppdoc": "c/library/chrono/strftime"
+  },
+  {
+    "cppref": "c/chrono/difftime",
+    "cppdoc": "c/library/chrono/difftime"
+  },
+  {
+    "cppref": "c/chrono/ctime",
+    "cppdoc": "c/library/chrono/ctime"
+  },
+  {
+    "cppref": "c/chrono/asctime",
+    "cppdoc": "c/library/chrono/asctime"
+  },
+  {
+    "cppref": "c/chrono/tm",
+    "cppdoc": "c/library/chrono/tm"
+  },
+  {
+    "cppref": "c/chrono/time",
+    "cppdoc": "c/library/chrono/time"
+  },
+  {
+    "cppref": "c/chrono/timespec_getres",
+    "cppdoc": "c/library/chrono/timespec_getres"
+  },
+  {
+    "cppref": "c/chrono/timespec",
+    "cppdoc": "c/library/chrono/timespec"
+  },
+  {
+    "cppref": "c/chrono/timespec_get",
+    "cppdoc": "c/library/chrono/timespec_get"
+  },
+  {
+    "cppref": "c/chrono/wcsftime",
+    "cppdoc": "c/library/chrono/wcsftime"
+  },
+  {
+    "cppref": "c/chrono/localtime",
+    "cppdoc": "c/library/chrono/localtime"
+  },
+  {
+    "cppref": "cpp/keywords",
+    "cppdoc": "cpp/language/keywords"
+  },
+  {
+    "cppref": "cpp/types",
+    "cppdoc": "cpp/library/utility/types"
+  },
+  {
+    "cppref": "cpp/regex",
+    "cppdoc": "cpp/library/text/regex"
+  },
+  {
+    "cppref": "cpp/keyword",
+    "cppdoc": "cpp/language/keyword"
+  },
+  {
+    "cppref": "cpp/coroutine",
+    "cppdoc": "cpp/library/utility/coroutine"
+  },
+  {
+    "cppref": "cpp/comment",
+    "cppdoc": "cpp/language/basic_concepts/comment"
+  },
+  {
+    "cppref": "cpp/comments",
+    "cppdoc": "cpp/language/basic_concepts/comments"
+  },
+  {
+    "cppref": "cpp/regex/regex_token_iterator",
+    "cppdoc": "cpp/library/text/regex/regex_token_iterator"
+  },
+  {
+    "cppref": "cpp/regex/syntax_option_type",
+    "cppdoc": "cpp/library/text/regex/syntax_option_type"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits",
+    "cppdoc": "cpp/library/text/regex/regex_traits"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex",
+    "cppdoc": "cpp/library/text/regex/basic_regex"
+  },
+  {
+    "cppref": "cpp/regex/match_results",
+    "cppdoc": "cpp/library/text/regex/match_results"
+  },
+  {
+    "cppref": "cpp/regex/match_flag_type",
+    "cppdoc": "cpp/library/text/regex/match_flag_type"
+  },
+  {
+    "cppref": "cpp/regex/regex_match",
+    "cppdoc": "cpp/library/text/regex/regex_match"
+  },
+  {
+    "cppref": "cpp/regex/regex_replace",
+    "cppdoc": "cpp/library/text/regex/regex_replace"
+  },
+  {
+    "cppref": "cpp/regex/regex_search",
+    "cppdoc": "cpp/library/text/regex/regex_search"
+  },
+  {
+    "cppref": "cpp/regex/sub_match",
+    "cppdoc": "cpp/library/text/regex/sub_match"
+  },
+  {
+    "cppref": "cpp/regex/ecmascript",
+    "cppdoc": "cpp/library/text/regex/ecmascript"
+  },
+  {
+    "cppref": "cpp/regex/error_type",
+    "cppdoc": "cpp/library/text/regex/error_type"
+  },
+  {
+    "cppref": "cpp/regex/regex_error",
+    "cppdoc": "cpp/library/text/regex/regex_error"
+  },
+  {
+    "cppref": "cpp/regex/regex_iterator",
+    "cppdoc": "cpp/library/text/regex/regex_iterator"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/getloc",
+    "cppdoc": "cpp/library/text/regex/regex_traits/getloc"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/regex_traits",
+    "cppdoc": "cpp/library/text/regex/regex_traits/regex_traits"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/lookup_collatename",
+    "cppdoc": "cpp/library/text/regex/regex_traits/lookup_collatename"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/transform_primary",
+    "cppdoc": "cpp/library/text/regex/regex_traits/transform_primary"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/isctype",
+    "cppdoc": "cpp/library/text/regex/regex_traits/isctype"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/value",
+    "cppdoc": "cpp/library/text/regex/regex_traits/value"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/translate_nocase",
+    "cppdoc": "cpp/library/text/regex/regex_traits/translate_nocase"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/lookup_classname",
+    "cppdoc": "cpp/library/text/regex/regex_traits/lookup_classname"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/length",
+    "cppdoc": "cpp/library/text/regex/regex_traits/length"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/transform",
+    "cppdoc": "cpp/library/text/regex/regex_traits/transform"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/imbue",
+    "cppdoc": "cpp/library/text/regex/regex_traits/imbue"
+  },
+  {
+    "cppref": "cpp/regex/regex_traits/translate",
+    "cppdoc": "cpp/library/text/regex/regex_traits/translate"
+  },
+  {
+    "cppref": "cpp/regex/match_results/ready",
+    "cppdoc": "cpp/library/text/regex/match_results/ready"
+  },
+  {
+    "cppref": "cpp/regex/match_results/operator_at",
+    "cppdoc": "cpp/library/text/regex/match_results/operator_at"
+  },
+  {
+    "cppref": "cpp/regex/match_results/~match_results",
+    "cppdoc": "cpp/library/text/regex/match_results/~match_results"
+  },
+  {
+    "cppref": "cpp/regex/match_results/position",
+    "cppdoc": "cpp/library/text/regex/match_results/position"
+  },
+  {
+    "cppref": "cpp/regex/match_results/prefix",
+    "cppdoc": "cpp/library/text/regex/match_results/prefix"
+  },
+  {
+    "cppref": "cpp/regex/match_results/empty",
+    "cppdoc": "cpp/library/text/regex/match_results/empty"
+  },
+  {
+    "cppref": "cpp/regex/match_results/max_size",
+    "cppdoc": "cpp/library/text/regex/match_results/max_size"
+  },
+  {
+    "cppref": "cpp/regex/match_results/size",
+    "cppdoc": "cpp/library/text/regex/match_results/size"
+  },
+  {
+    "cppref": "cpp/regex/match_results/match_results",
+    "cppdoc": "cpp/library/text/regex/match_results/match_results"
+  },
+  {
+    "cppref": "cpp/regex/match_results/swap2",
+    "cppdoc": "cpp/library/text/regex/match_results/swap2"
+  },
+  {
+    "cppref": "cpp/regex/match_results/end",
+    "cppdoc": "cpp/library/text/regex/match_results/end"
+  },
+  {
+    "cppref": "cpp/regex/match_results/format",
+    "cppdoc": "cpp/library/text/regex/match_results/format"
+  },
+  {
+    "cppref": "cpp/regex/match_results/suffix",
+    "cppdoc": "cpp/library/text/regex/match_results/suffix"
+  },
+  {
+    "cppref": "cpp/regex/match_results/begin",
+    "cppdoc": "cpp/library/text/regex/match_results/begin"
+  },
+  {
+    "cppref": "cpp/regex/match_results/swap",
+    "cppdoc": "cpp/library/text/regex/match_results/swap"
+  },
+  {
+    "cppref": "cpp/regex/match_results/str",
+    "cppdoc": "cpp/library/text/regex/match_results/str"
+  },
+  {
+    "cppref": "cpp/regex/match_results/operator_cmp",
+    "cppdoc": "cpp/library/text/regex/match_results/operator_cmp"
+  },
+  {
+    "cppref": "cpp/regex/match_results/get_allocator",
+    "cppdoc": "cpp/library/text/regex/match_results/get_allocator"
+  },
+  {
+    "cppref": "cpp/regex/match_results/length",
+    "cppdoc": "cpp/library/text/regex/match_results/length"
+  },
+  {
+    "cppref": "cpp/regex/match_results/operator=",
+    "cppdoc": "cpp/library/text/regex/match_results/operator="
+  },
+  {
+    "cppref": "cpp/regex/regex_iterator/operator_arith",
+    "cppdoc": "cpp/library/text/regex/regex_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/regex/regex_iterator/operator_star_",
+    "cppdoc": "cpp/library/text/regex/regex_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/regex/regex_iterator/operator_cmp",
+    "cppdoc": "cpp/library/text/regex/regex_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/regex/regex_iterator/operator=",
+    "cppdoc": "cpp/library/text/regex/regex_iterator/operator="
+  },
+  {
+    "cppref": "cpp/regex/regex_iterator/regex_iterator",
+    "cppdoc": "cpp/library/text/regex/regex_iterator/regex_iterator"
+  },
+  {
+    "cppref": "cpp/regex/sub_match/swap",
+    "cppdoc": "cpp/library/text/regex/sub_match/swap"
+  },
+  {
+    "cppref": "cpp/regex/sub_match/str",
+    "cppdoc": "cpp/library/text/regex/sub_match/str"
+  },
+  {
+    "cppref": "cpp/regex/sub_match/sub_match",
+    "cppdoc": "cpp/library/text/regex/sub_match/sub_match"
+  },
+  {
+    "cppref": "cpp/regex/sub_match/compare",
+    "cppdoc": "cpp/library/text/regex/sub_match/compare"
+  },
+  {
+    "cppref": "cpp/regex/sub_match/operator_cmp",
+    "cppdoc": "cpp/library/text/regex/sub_match/operator_cmp"
+  },
+  {
+    "cppref": "cpp/regex/sub_match/length",
+    "cppdoc": "cpp/library/text/regex/sub_match/length"
+  },
+  {
+    "cppref": "cpp/regex/sub_match/operator_ltlt",
+    "cppdoc": "cpp/library/text/regex/sub_match/operator_ltlt"
+  },
+  {
+    "cppref": "cpp/regex/regex_error/code",
+    "cppdoc": "cpp/library/text/regex/regex_error/code"
+  },
+  {
+    "cppref": "cpp/regex/regex_error/regex_error",
+    "cppdoc": "cpp/library/text/regex/regex_error/regex_error"
+  },
+  {
+    "cppref": "cpp/regex/regex_error/operator=",
+    "cppdoc": "cpp/library/text/regex/regex_error/operator="
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/assign",
+    "cppdoc": "cpp/library/text/regex/basic_regex/assign"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/mark_count",
+    "cppdoc": "cpp/library/text/regex/basic_regex/mark_count"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/getloc",
+    "cppdoc": "cpp/library/text/regex/basic_regex/getloc"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/basic_regex",
+    "cppdoc": "cpp/library/text/regex/basic_regex/basic_regex"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/swap2",
+    "cppdoc": "cpp/library/text/regex/basic_regex/swap2"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/constants",
+    "cppdoc": "cpp/library/text/regex/basic_regex/constants"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/deduction_guides",
+    "cppdoc": "cpp/library/text/regex/basic_regex/deduction_guides"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/flags",
+    "cppdoc": "cpp/library/text/regex/basic_regex/flags"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/swap",
+    "cppdoc": "cpp/library/text/regex/basic_regex/swap"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/~basic_regex",
+    "cppdoc": "cpp/library/text/regex/basic_regex/~basic_regex"
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/operator=",
+    "cppdoc": "cpp/library/text/regex/basic_regex/operator="
+  },
+  {
+    "cppref": "cpp/regex/basic_regex/imbue",
+    "cppdoc": "cpp/library/text/regex/basic_regex/imbue"
+  },
+  {
+    "cppref": "cpp/regex/regex_token_iterator/regex_token_iterator",
+    "cppdoc": "cpp/library/text/regex/regex_token_iterator/regex_token_iterator"
+  },
+  {
+    "cppref": "cpp/regex/regex_token_iterator/operator_arith",
+    "cppdoc": "cpp/library/text/regex/regex_token_iterator/operator_arith"
+  },
+  {
+    "cppref": "cpp/regex/regex_token_iterator/operator_star_",
+    "cppdoc": "cpp/library/text/regex/regex_token_iterator/operator_star_"
+  },
+  {
+    "cppref": "cpp/regex/regex_token_iterator/operator_cmp",
+    "cppdoc": "cpp/library/text/regex/regex_token_iterator/operator_cmp"
+  },
+  {
+    "cppref": "cpp/regex/regex_token_iterator/operator=",
+    "cppdoc": "cpp/library/text/regex/regex_token_iterator/operator="
+  },
+  {
+    "cppref": "cpp/identifier_with_special_meaning/import",
+    "cppdoc": "cpp/language/keywords/import"
+  },
+  {
+    "cppref": "cpp/identifier_with_special_meaning/final",
+    "cppdoc": "cpp/language/keywords/final"
+  },
+  {
+    "cppref": "cpp/identifier_with_special_meaning/override",
+    "cppdoc": "cpp/language/keywords/override"
+  },
+  {
+    "cppref": "cpp/identifier_with_special_meaning/module",
+    "cppdoc": "cpp/language/keywords/module"
+  },
+  {
+    "cppref": "cpp/numeric/bit_floor",
+    "cppdoc": "cpp/library/utility/bit/bit_floor"
+  },
+  {
+    "cppref": "cpp/numeric/countl_one",
+    "cppdoc": "cpp/library/utility/bit/countl_one"
+  },
+  {
+    "cppref": "cpp/numeric/popcount",
+    "cppdoc": "cpp/library/utility/bit/popcount"
+  },
+  {
+    "cppref": "cpp/numeric/has_single_bit",
+    "cppdoc": "cpp/library/utility/bit/has_single_bit"
+  },
+  {
+    "cppref": "cpp/numeric/rotr",
+    "cppdoc": "cpp/library/utility/bit/rotr"
+  },
+  {
+    "cppref": "cpp/numeric/bit_cast",
+    "cppdoc": "cpp/library/utility/bit/bit_cast"
+  },
+  {
+    "cppref": "cpp/numeric/rotl",
+    "cppdoc": "cpp/library/utility/bit/rotl"
+  },
+  {
+    "cppref": "cpp/numeric/countr_zero",
+    "cppdoc": "cpp/library/utility/bit/countr_zero"
+  },
+  {
+    "cppref": "cpp/numeric/byteswap",
+    "cppdoc": "cpp/library/utility/bit/byteswap"
+  },
+  {
+    "cppref": "cpp/numeric/countl_zero",
+    "cppdoc": "cpp/library/utility/bit/countl_zero"
+  },
+  {
+    "cppref": "cpp/numeric/bit_ceil",
+    "cppdoc": "cpp/library/utility/bit/bit_ceil"
+  },
+  {
+    "cppref": "cpp/numeric/bit_width",
+    "cppdoc": "cpp/library/utility/bit/bit_width"
+  },
+  {
+    "cppref": "cpp/numeric/countr_one",
+    "cppdoc": "cpp/library/utility/bit/countr_one"
+  },
+  {
+    "cppref": "cpp/language/alignas",
+    "cppdoc": "cpp/language/declarations/alignas"
+  },
+  {
+    "cppref": "cpp/language/implicit_conversion",
+    "cppdoc": "cpp/language/expressions/implicit_conversion"
+  },
+  {
+    "cppref": "cpp/language/overloaded_address",
+    "cppdoc": "cpp/language/functions/overloaded_address"
+  },
+  {
+    "cppref": "cpp/language/sfinae",
+    "cppdoc": "cpp/language/templates/sfinae"
+  },
+  {
+    "cppref": "cpp/language/qualified_lookup",
+    "cppdoc": "cpp/language/basic_concepts/qualified_lookup"
+  },
+  {
+    "cppref": "cpp/language/member_template",
+    "cppdoc": "cpp/language/templates/member_template"
+  },
+  {
+    "cppref": "cpp/language/list_initialization",
+    "cppdoc": "cpp/language/initialization/list_initialization"
+  },
+  {
+    "cppref": "cpp/language/unqualified_lookup",
+    "cppdoc": "cpp/language/basic_concepts/unqualified_lookup"
+  },
+  {
+    "cppref": "cpp/language/return",
+    "cppdoc": "cpp/language/statements/return"
+  },
+  {
+    "cppref": "cpp/language/do",
+    "cppdoc": "cpp/language/statements/do"
+  },
+  {
+    "cppref": "cpp/language/catch",
+    "cppdoc": "cpp/language/exceptions/catch"
+  },
+  {
+    "cppref": "cpp/language/types",
+    "cppdoc": "cpp/language/basic_concepts/types"
+  },
+  {
+    "cppref": "cpp/language/except_spec",
+    "cppdoc": "cpp/language/exceptions/except_spec"
+  },
+  {
+    "cppref": "cpp/language/multithread",
+    "cppdoc": "cpp/language/basic_concepts/multithread"
+  },
+  {
+    "cppref": "cpp/language/scope",
+    "cppdoc": "cpp/language/basic_concepts/scope"
+  },
+  {
+    "cppref": "cpp/language/default_arguments",
+    "cppdoc": "cpp/language/functions/default_arguments"
+  },
+  {
+    "cppref": "cpp/language/default_initialization",
+    "cppdoc": "cpp/language/initialization/default_initialization"
+  },
+  {
+    "cppref": "cpp/language/adl",
+    "cppdoc": "cpp/language/functions/adl"
+  },
+  {
+    "cppref": "cpp/language/objects",
+    "cppdoc": "cpp/language/basic_concepts/objects"
+  },
+  {
+    "cppref": "cpp/language/try",
+    "cppdoc": "cpp/language/exceptions/try"
+  },
+  {
+    "cppref": "cpp/language/noexcept_spec",
+    "cppdoc": "cpp/language/exceptions/noexcept_spec"
+  },
+  {
+    "cppref": "cpp/language/aggregate_initialization",
+    "cppdoc": "cpp/language/initialization/aggregate_initialization"
+  },
+  {
+    "cppref": "cpp/language/lambda",
+    "cppdoc": "cpp/language/functions/lambda"
+  },
+  {
+    "cppref": "cpp/language/modules",
+    "cppdoc": "cpp/language/basic_concepts/modules"
+  },
+  {
+    "cppref": "cpp/language/copy_initialization",
+    "cppdoc": "cpp/language/initialization/copy_initialization"
+  },
+  {
+    "cppref": "cpp/language/memory_model",
+    "cppdoc": "cpp/language/basic_concepts/memory_model"
+  },
+  {
+    "cppref": "cpp/language/constant_initialization",
+    "cppdoc": "cpp/language/initialization/constant_initialization"
+  },
+  {
+    "cppref": "cpp/language/variadic_arguments",
+    "cppdoc": "cpp/language/functions/variadic_arguments"
+  },
+  {
+    "cppref": "cpp/language/as_if",
+    "cppdoc": "cpp/language/basic_concepts/as_if"
+  },
+  {
+    "cppref": "cpp/language/incomplete_type",
+    "cppdoc": "cpp/language/basic_concepts/incomplete_type"
+  },
+  {
+    "cppref": "cpp/language/coroutines",
+    "cppdoc": "cpp/language/functions/coroutines"
+  },
+  {
+    "cppref": "cpp/language/ub",
+    "cppdoc": "cpp/language/basic_concepts/ub"
+  },
+  {
+    "cppref": "cpp/language/function",
+    "cppdoc": "cpp/language/functions/function"
+  },
+  {
+    "cppref": "cpp/language/name",
+    "cppdoc": "cpp/language/basic_concepts/name"
+  },
+  {
+    "cppref": "cpp/language/overload_resolution",
+    "cppdoc": "cpp/language/functions/overload_resolution"
+  },
+  {
+    "cppref": "cpp/language/type-id",
+    "cppdoc": "cpp/language/basic_concepts/type-id"
+  },
+  {
+    "cppref": "cpp/language/definition",
+    "cppdoc": "cpp/language/basic_concepts/definition"
+  },
+  {
+    "cppref": "cpp/language/zero_initialization",
+    "cppdoc": "cpp/language/initialization/zero_initialization"
+  },
+  {
+    "cppref": "cpp/language/charset",
+    "cppdoc": "cpp/language/basic_concepts/charset"
+  },
+  {
+    "cppref": "cpp/language/translation_phases",
+    "cppdoc": "cpp/language/basic_concepts/translation_phases"
+  },
+  {
+    "cppref": "cpp/language/lifetime",
+    "cppdoc": "cpp/language/basic_concepts/lifetime"
+  },
+  {
+    "cppref": "cpp/language/type",
+    "cppdoc": "cpp/language/basic_concepts/type"
+  },
+  {
+    "cppref": "cpp/language/copy_elision",
+    "cppdoc": "cpp/language/initialization/copy_elision"
+  },
+  {
+    "cppref": "cpp/language/punctuators",
+    "cppdoc": "cpp/language/basic_concepts/punctuators"
+  },
+  {
+    "cppref": "cpp/language/lookup",
+    "cppdoc": "cpp/language/basic_concepts/lookup"
+  },
+  {
+    "cppref": "cpp/language/direct_initialization",
+    "cppdoc": "cpp/language/initialization/direct_initialization"
+  },
+  {
+    "cppref": "cpp/language/object",
+    "cppdoc": "cpp/language/basic_concepts/object"
+  },
+  {
+    "cppref": "cpp/language/main_function",
+    "cppdoc": "cpp/language/basic_concepts/main_function"
+  },
+  {
+    "cppref": "cpp/language/value_initialization",
+    "cppdoc": "cpp/language/initialization/value_initialization"
+  },
+  {
+    "cppref": "cpp/language/identifiers",
+    "cppdoc": "cpp/language/basic_concepts/identifiers"
+  },
+  {
+    "cppref": "cpp/execution/into_variant",
+    "cppdoc": "cpp/library/experimental/execution/into_variant"
+  },
+  {
+    "cppref": "cpp/execution/upon_error",
+    "cppdoc": "cpp/library/experimental/execution/upon_error"
+  },
+  {
+    "cppref": "cpp/execution/just_stopped",
+    "cppdoc": "cpp/library/experimental/execution/just_stopped"
+  },
+  {
+    "cppref": "cpp/execution/ensure_started",
+    "cppdoc": "cpp/library/experimental/execution/ensure_started"
+  },
+  {
+    "cppref": "cpp/execution/stopped_as_error",
+    "cppdoc": "cpp/library/experimental/execution/stopped_as_error"
+  },
+  {
+    "cppref": "cpp/execution/just",
+    "cppdoc": "cpp/library/experimental/execution/just"
+  },
+  {
+    "cppref": "cpp/execution/scheduler",
+    "cppdoc": "cpp/library/experimental/execution/scheduler"
+  },
+  {
+    "cppref": "cpp/execution/let_stopped",
+    "cppdoc": "cpp/library/experimental/execution/let_stopped"
+  },
+  {
+    "cppref": "cpp/execution/upon_stopped",
+    "cppdoc": "cpp/library/experimental/execution/upon_stopped"
+  },
+  {
+    "cppref": "cpp/execution/then",
+    "cppdoc": "cpp/library/experimental/execution/then"
+  },
+  {
+    "cppref": "cpp/execution/on",
+    "cppdoc": "cpp/library/experimental/execution/on"
+  },
+  {
+    "cppref": "cpp/execution/read_env",
+    "cppdoc": "cpp/library/experimental/execution/read_env"
+  },
+  {
+    "cppref": "cpp/execution/stopped_as_optional",
+    "cppdoc": "cpp/library/experimental/execution/stopped_as_optional"
+  },
+  {
+    "cppref": "cpp/execution/just_error",
+    "cppdoc": "cpp/library/experimental/execution/just_error"
+  },
+  {
+    "cppref": "cpp/execution/let_value",
+    "cppdoc": "cpp/library/experimental/execution/let_value"
+  },
+  {
+    "cppref": "cpp/execution/schedule",
+    "cppdoc": "cpp/library/experimental/execution/schedule"
+  },
+  {
+    "cppref": "cpp/execution/let_error",
+    "cppdoc": "cpp/library/experimental/execution/let_error"
+  },
+  {
+    "cppref": "cpp/execution/when_all",
+    "cppdoc": "cpp/library/experimental/execution/when_all"
+  },
+  {
+    "cppref": "cpp/utility/piecewise_construct_t",
+    "cppdoc": "cpp/library/utility/pair/piecewise_construct_t"
+  },
+  {
+    "cppref": "cpp/utility/unreachable",
+    "cppdoc": "cpp/library/utility/program/unreachable"
+  },
+  {
+    "cppref": "cpp/utility/piecewise_construct",
+    "cppdoc": "cpp/library/utility/pair/piecewise_construct"
+  },
+  {
+    "cppref": "cpp/utility/nontype",
+    "cppdoc": "cpp/library/utility/functional/nontype"
+  },
+  {
+    "cppref": "cpp/thread/this_thread/sync_wait",
+    "cppdoc": "cpp/library/experimental/execution/sync_wait"
+  },
+  {
+    "cppref": "cpp/symbol_index/string_view_literals",
+    "cppdoc": null
+  },
+  {
+    "cppref": "cpp/keywords/static",
+    "cppdoc": "cpp/language/keywords/static"
+  },
+  {
+    "cppref": "cpp/keywords/if",
+    "cppdoc": "cpp/language/keywords/if"
+  },
+  {
+    "cppref": "cpp/keywords/typename",
+    "cppdoc": "cpp/language/keywords/typename"
+  },
+  {
+    "cppref": "cpp/io/cerr",
+    "cppdoc": "cpp/library/io/basic_ostream/cerr"
+  },
+  {
+    "cppref": "cpp/io/cout",
+    "cppdoc": "cpp/library/io/basic_ostream/cout"
+  },
+  {
+    "cppref": "cpp/io/clog",
+    "cppdoc": "cpp/library/io/basic_ostream/clog"
+  },
+  {
+    "cppref": "cpp/experimental/ostream_joiner",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/ostream_joiner"
+  },
+  {
+    "cppref": "cpp/experimental/transform_reduce",
+    "cppdoc": "cpp/library/experimental/parallelism/transform_reduce"
+  },
+  {
+    "cppref": "cpp/experimental/latch",
+    "cppdoc": "cpp/library/experimental/concurrency/latch"
+  },
+  {
+    "cppref": "cpp/experimental/boyer_moore_searcher",
+    "cppdoc": "cpp/library/experimental/memory/boyer_moore_searcher"
+  },
+  {
+    "cppref": "cpp/experimental/sample",
+    "cppdoc": "cpp/library/experimental/memory/sample"
+  },
+  {
+    "cppref": "cpp/experimental/type_trait_variable_templates",
+    "cppdoc": "cpp/library/experimental/memory/type_trait_variable_templates"
+  },
+  {
+    "cppref": "cpp/experimental/set_default_resource",
+    "cppdoc": "cpp/library/experimental/memory/set_default_resource"
+  },
+  {
+    "cppref": "cpp/experimental/future",
+    "cppdoc": "cpp/library/experimental/concurrency/future"
+  },
+  {
+    "cppref": "cpp/experimental/search",
+    "cppdoc": "cpp/library/experimental/memory/search"
+  },
+  {
+    "cppref": "cpp/experimental/any",
+    "cppdoc": "cpp/library/experimental/memory/any"
+  },
+  {
+    "cppref": "cpp/experimental/default_searcher",
+    "cppdoc": "cpp/library/experimental/memory/default_searcher"
+  },
+  {
+    "cppref": "cpp/experimental/get_default_resource",
+    "cppdoc": "cpp/library/experimental/memory/get_default_resource"
+  },
+  {
+    "cppref": "cpp/experimental/polymorphic_allocator",
+    "cppdoc": "cpp/library/experimental/memory/polymorphic_allocator"
+  },
+  {
+    "cppref": "cpp/experimental/resource_adaptor",
+    "cppdoc": "cpp/library/experimental/memory/resource_adaptor"
+  },
+  {
+    "cppref": "cpp/experimental/monotonic_buffer_resource",
+    "cppdoc": "cpp/library/experimental/memory/monotonic_buffer_resource"
+  },
+  {
+    "cppref": "cpp/experimental/barrier",
+    "cppdoc": "cpp/library/experimental/concurrency/barrier"
+  },
+  {
+    "cppref": "cpp/experimental/make_exceptional_future",
+    "cppdoc": "cpp/library/experimental/concurrency/make_exceptional_future"
+  },
+  {
+    "cppref": "cpp/experimental/pool_options",
+    "cppdoc": "cpp/library/experimental/memory/pool_options"
+  },
+  {
+    "cppref": "cpp/experimental/shared_future",
+    "cppdoc": "cpp/library/experimental/concurrency/shared_future"
+  },
+  {
+    "cppref": "cpp/experimental/unsynchronized_pool_resource",
+    "cppdoc": "cpp/library/experimental/memory/unsynchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/experimental/new_delete_resource",
+    "cppdoc": "cpp/library/experimental/memory/new_delete_resource"
+  },
+  {
+    "cppref": "cpp/experimental/shared_ptr",
+    "cppdoc": "cpp/library/experimental/memory/shared_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/boyer_moore_horspool_searcher",
+    "cppdoc": "cpp/library/experimental/memory/boyer_moore_horspool_searcher"
+  },
+  {
+    "cppref": "cpp/experimental/weak_ptr",
+    "cppdoc": "cpp/library/experimental/memory/weak_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/simd",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd"
+  },
+  {
+    "cppref": "cpp/experimental/barrier/barrier",
+    "cppdoc": "cpp/library/experimental/concurrency/barrier/barrier"
+  },
+  {
+    "cppref": "cpp/experimental/barrier/arrive_and_wait",
+    "cppdoc": "cpp/library/experimental/concurrency/barrier/arrive_and_wait"
+  },
+  {
+    "cppref": "cpp/experimental/barrier/~barrier",
+    "cppdoc": "cpp/library/experimental/concurrency/barrier/~barrier"
+  },
+  {
+    "cppref": "cpp/experimental/barrier/arrive_and_drop",
+    "cppdoc": "cpp/library/experimental/concurrency/barrier/arrive_and_drop"
+  },
+  {
+    "cppref": "cpp/experimental/shared_future/then",
+    "cppdoc": "cpp/library/experimental/concurrency/shared_future/then"
+  },
+  {
+    "cppref": "cpp/experimental/shared_future/shared_future",
+    "cppdoc": "cpp/library/experimental/concurrency/shared_future/shared_future"
+  },
+  {
+    "cppref": "cpp/experimental/shared_future/is_ready",
+    "cppdoc": "cpp/library/experimental/concurrency/shared_future/is_ready"
+  },
+  {
+    "cppref": "cpp/experimental/shared_future/operator=",
+    "cppdoc": "cpp/library/experimental/concurrency/shared_future/operator="
+  },
+  {
+    "cppref": "cpp/experimental/latch/~latch",
+    "cppdoc": "cpp/library/experimental/concurrency/latch/~latch"
+  },
+  {
+    "cppref": "cpp/experimental/latch/latch",
+    "cppdoc": "cpp/library/experimental/concurrency/latch/latch"
+  },
+  {
+    "cppref": "cpp/experimental/latch/count_down_and_wait",
+    "cppdoc": "cpp/library/experimental/concurrency/latch/count_down_and_wait"
+  },
+  {
+    "cppref": "cpp/experimental/latch/is_ready",
+    "cppdoc": "cpp/library/experimental/concurrency/latch/is_ready"
+  },
+  {
+    "cppref": "cpp/experimental/latch/wait",
+    "cppdoc": "cpp/library/experimental/concurrency/latch/wait"
+  },
+  {
+    "cppref": "cpp/experimental/latch/count_down",
+    "cppdoc": "cpp/library/experimental/concurrency/latch/count_down"
+  },
+  {
+    "cppref": "cpp/experimental/any/~any",
+    "cppdoc": "cpp/library/experimental/memory/any/~any"
+  },
+  {
+    "cppref": "cpp/experimental/any/empty",
+    "cppdoc": "cpp/library/experimental/memory/any/empty"
+  },
+  {
+    "cppref": "cpp/experimental/any/any",
+    "cppdoc": "cpp/library/experimental/memory/any/any"
+  },
+  {
+    "cppref": "cpp/experimental/any/swap2",
+    "cppdoc": "cpp/library/experimental/memory/any/swap2"
+  },
+  {
+    "cppref": "cpp/experimental/any/swap",
+    "cppdoc": "cpp/library/experimental/memory/any/swap"
+  },
+  {
+    "cppref": "cpp/experimental/any/any_cast",
+    "cppdoc": "cpp/library/experimental/memory/any/any_cast"
+  },
+  {
+    "cppref": "cpp/experimental/any/type",
+    "cppdoc": "cpp/library/experimental/memory/any/type"
+  },
+  {
+    "cppref": "cpp/experimental/any/bad_any_cast",
+    "cppdoc": "cpp/library/experimental/memory/any/bad_any_cast"
+  },
+  {
+    "cppref": "cpp/experimental/any/operator=",
+    "cppdoc": "cpp/library/experimental/memory/any/operator="
+  },
+  {
+    "cppref": "cpp/experimental/any/clear",
+    "cppdoc": "cpp/library/experimental/memory/any/clear"
+  },
+  {
+    "cppref": "cpp/experimental/unsynchronized_pool_resource/do_is_equal",
+    "cppdoc": "cpp/library/experimental/memory/unsynchronized_pool_resource/do_is_equal"
+  },
+  {
+    "cppref": "cpp/experimental/unsynchronized_pool_resource/do_deallocate",
+    "cppdoc": "cpp/library/experimental/memory/unsynchronized_pool_resource/do_deallocate"
+  },
+  {
+    "cppref": "cpp/experimental/unsynchronized_pool_resource/unsynchronized_pool_resource",
+    "cppdoc": "cpp/library/experimental/memory/unsynchronized_pool_resource/unsynchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/experimental/unsynchronized_pool_resource/do_allocate",
+    "cppdoc": "cpp/library/experimental/memory/unsynchronized_pool_resource/do_allocate"
+  },
+  {
+    "cppref": "cpp/experimental/unsynchronized_pool_resource/options",
+    "cppdoc": "cpp/library/experimental/memory/unsynchronized_pool_resource/options"
+  },
+  {
+    "cppref": "cpp/experimental/unsynchronized_pool_resource/release",
+    "cppdoc": "cpp/library/experimental/memory/unsynchronized_pool_resource/release"
+  },
+  {
+    "cppref": "cpp/experimental/unsynchronized_pool_resource/~unsynchronized_pool_resource",
+    "cppdoc": "cpp/library/experimental/memory/unsynchronized_pool_resource/~unsynchronized_pool_resource"
+  },
+  {
+    "cppref": "cpp/experimental/unsynchronized_pool_resource/upstream_resource",
+    "cppdoc": "cpp/library/experimental/memory/unsynchronized_pool_resource/upstream_resource"
+  },
+  {
+    "cppref": "cpp/experimental/future/future",
+    "cppdoc": "cpp/library/experimental/concurrency/future/future"
+  },
+  {
+    "cppref": "cpp/experimental/future/then",
+    "cppdoc": "cpp/library/experimental/concurrency/future/then"
+  },
+  {
+    "cppref": "cpp/experimental/future/is_ready",
+    "cppdoc": "cpp/library/experimental/concurrency/future/is_ready"
+  },
+  {
+    "cppref": "cpp/experimental/future/operator=",
+    "cppdoc": "cpp/library/experimental/concurrency/future/operator="
+  },
+  {
+    "cppref": "cpp/experimental/monotonic_buffer_resource/~monotonic_buffer_resource",
+    "cppdoc": "cpp/library/experimental/memory/monotonic_buffer_resource/~monotonic_buffer_resource"
+  },
+  {
+    "cppref": "cpp/experimental/monotonic_buffer_resource/do_is_equal",
+    "cppdoc": "cpp/library/experimental/memory/monotonic_buffer_resource/do_is_equal"
+  },
+  {
+    "cppref": "cpp/experimental/monotonic_buffer_resource/monotonic_buffer_resource",
+    "cppdoc": "cpp/library/experimental/memory/monotonic_buffer_resource/monotonic_buffer_resource"
+  },
+  {
+    "cppref": "cpp/experimental/monotonic_buffer_resource/do_deallocate",
+    "cppdoc": "cpp/library/experimental/memory/monotonic_buffer_resource/do_deallocate"
+  },
+  {
+    "cppref": "cpp/experimental/monotonic_buffer_resource/do_allocate",
+    "cppdoc": "cpp/library/experimental/memory/monotonic_buffer_resource/do_allocate"
+  },
+  {
+    "cppref": "cpp/experimental/monotonic_buffer_resource/release",
+    "cppdoc": "cpp/library/experimental/memory/monotonic_buffer_resource/release"
+  },
+  {
+    "cppref": "cpp/experimental/monotonic_buffer_resource/upstream_resource",
+    "cppdoc": "cpp/library/experimental/memory/monotonic_buffer_resource/upstream_resource"
+  },
+  {
+    "cppref": "cpp/experimental/polymorphic_allocator/operator_eq",
+    "cppdoc": "cpp/library/experimental/memory/polymorphic_allocator/operator_eq"
+  },
+  {
+    "cppref": "cpp/experimental/polymorphic_allocator/allocate",
+    "cppdoc": "cpp/library/experimental/memory/polymorphic_allocator/allocate"
+  },
+  {
+    "cppref": "cpp/experimental/polymorphic_allocator/deallocate",
+    "cppdoc": "cpp/library/experimental/memory/polymorphic_allocator/deallocate"
+  },
+  {
+    "cppref": "cpp/experimental/polymorphic_allocator/polymorphic_allocator",
+    "cppdoc": "cpp/library/experimental/memory/polymorphic_allocator/polymorphic_allocator"
+  },
+  {
+    "cppref": "cpp/experimental/polymorphic_allocator/select_on_container_copy_construction",
+    "cppdoc": "cpp/library/experimental/memory/polymorphic_allocator/select_on_container_copy_construction"
+  },
+  {
+    "cppref": "cpp/experimental/polymorphic_allocator/construct",
+    "cppdoc": "cpp/library/experimental/memory/polymorphic_allocator/construct"
+  },
+  {
+    "cppref": "cpp/experimental/polymorphic_allocator/destroy",
+    "cppdoc": "cpp/library/experimental/memory/polymorphic_allocator/destroy"
+  },
+  {
+    "cppref": "cpp/experimental/polymorphic_allocator/operator=",
+    "cppdoc": "cpp/library/experimental/memory/polymorphic_allocator/operator="
+  },
+  {
+    "cppref": "cpp/experimental/polymorphic_allocator/resource",
+    "cppdoc": "cpp/library/experimental/memory/polymorphic_allocator/resource"
+  },
+  {
+    "cppref": "cpp/experimental/shared_ptr/operator_at",
+    "cppdoc": "cpp/library/experimental/memory/shared_ptr/operator_at"
+  },
+  {
+    "cppref": "cpp/experimental/shared_ptr/hash",
+    "cppdoc": "cpp/library/experimental/memory/shared_ptr/hash"
+  },
+  {
+    "cppref": "cpp/experimental/shared_ptr/shared_ptr",
+    "cppdoc": "cpp/library/experimental/memory/shared_ptr/shared_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/shared_ptr/operator_star_",
+    "cppdoc": "cpp/library/experimental/memory/shared_ptr/operator_star_"
+  },
+  {
+    "cppref": "cpp/experimental/shared_ptr/get",
+    "cppdoc": "cpp/library/experimental/memory/shared_ptr/get"
+  },
+  {
+    "cppref": "cpp/experimental/shared_ptr/pointer_cast",
+    "cppdoc": "cpp/library/experimental/memory/shared_ptr/pointer_cast"
+  },
+  {
+    "cppref": "cpp/experimental/ostream_joiner/ostream_joiner",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/ostream_joiner/ostream_joiner"
+  },
+  {
+    "cppref": "cpp/experimental/ostream_joiner/make_ostream_joiner",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/ostream_joiner/make_ostream_joiner"
+  },
+  {
+    "cppref": "cpp/experimental/ostream_joiner/operator_arith",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/ostream_joiner/operator_arith"
+  },
+  {
+    "cppref": "cpp/experimental/ostream_joiner/operator_star_",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/ostream_joiner/operator_star_"
+  },
+  {
+    "cppref": "cpp/experimental/ostream_joiner/operator=",
+    "cppdoc": "cpp/library/experimental/lib_extensions_2/ostream_joiner/operator="
+  },
+  {
+    "cppref": "cpp/experimental/weak_ptr/weak_ptr",
+    "cppdoc": "cpp/library/experimental/memory/weak_ptr/weak_ptr"
+  },
+  {
+    "cppref": "cpp/experimental/simd/is_simd",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/is_simd"
+  },
+  {
+    "cppref": "cpp/experimental/simd/const_where_expression",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/const_where_expression"
+  },
+  {
+    "cppref": "cpp/experimental/simd/popcount",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/popcount"
+  },
+  {
+    "cppref": "cpp/experimental/simd/clamp",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/clamp"
+  },
+  {
+    "cppref": "cpp/experimental/simd/scalar",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/scalar"
+  },
+  {
+    "cppref": "cpp/experimental/simd/where_expression",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/where_expression"
+  },
+  {
+    "cppref": "cpp/experimental/simd/deduce",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/deduce"
+  },
+  {
+    "cppref": "cpp/experimental/simd/min",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/min"
+  },
+  {
+    "cppref": "cpp/experimental/simd/minmax",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/minmax"
+  },
+  {
+    "cppref": "cpp/experimental/simd/native",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/native"
+  },
+  {
+    "cppref": "cpp/experimental/simd/max_fixed_size",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/max_fixed_size"
+  },
+  {
+    "cppref": "cpp/experimental/simd/overaligned",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/overaligned"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd_cast",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd_cast"
+  },
+  {
+    "cppref": "cpp/experimental/simd/memory_alignment",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/memory_alignment"
+  },
+  {
+    "cppref": "cpp/experimental/simd/element_aligned",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/element_aligned"
+  },
+  {
+    "cppref": "cpp/experimental/simd/vector_aligned",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/vector_aligned"
+  },
+  {
+    "cppref": "cpp/experimental/simd/max",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/max"
+  },
+  {
+    "cppref": "cpp/experimental/simd/find_first_set",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/find_first_set"
+  },
+  {
+    "cppref": "cpp/experimental/simd/split",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/split"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd"
+  },
+  {
+    "cppref": "cpp/experimental/simd/reduce",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/reduce"
+  },
+  {
+    "cppref": "cpp/experimental/simd/abi_cast",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/abi_cast"
+  },
+  {
+    "cppref": "cpp/experimental/simd/fixed_size",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/fixed_size"
+  },
+  {
+    "cppref": "cpp/experimental/simd/all_of",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/all_of"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd_mask",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd_mask"
+  },
+  {
+    "cppref": "cpp/experimental/simd/concat",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/concat"
+  },
+  {
+    "cppref": "cpp/experimental/simd/compatible",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/compatible"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd_size",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd_size"
+  },
+  {
+    "cppref": "cpp/experimental/simd/is_abi_tag",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/is_abi_tag"
+  },
+  {
+    "cppref": "cpp/experimental/simd/where",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/where"
+  },
+  {
+    "cppref": "cpp/experimental/simd/is_simd_flag_type",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/is_simd_flag_type"
+  },
+  {
+    "cppref": "cpp/experimental/simd/rebind_simd",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/rebind_simd"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd_mask/operator_at",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd_mask/operator_at"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd_mask/size",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd_mask/size"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd_mask/copy_to",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd_mask/copy_to"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd_mask/copy_from",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd_mask/copy_from"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd_mask/simd_mask",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd_mask/simd_mask"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd/operator_at",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd/operator_at"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd/operator_mem_arith",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd/operator_mem_arith"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd/size",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd/size"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd/operator_arith",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd/operator_arith"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd/simd",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd/simd"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd/copy_to",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd/copy_to"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd/operator_compound",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd/operator_compound"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd/copy_from",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd/copy_from"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd/operator_cmp",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd/operator_cmp"
+  },
+  {
+    "cppref": "cpp/experimental/simd/simd/operator_mem_arith2",
+    "cppdoc": "cpp/library/experimental/parallelism_2/simd/simd/operator_mem_arith2"
+  },
+  {
+    "cppref": "cpp/keyword/alignas",
+    "cppdoc": "cpp/language/keywords/alignas"
+  },
+  {
+    "cppref": "cpp/keyword/and",
+    "cppdoc": "cpp/language/keywords/and"
+  },
+  {
+    "cppref": "cpp/keyword/compl",
+    "cppdoc": "cpp/language/keywords/compl"
+  },
+  {
+    "cppref": "cpp/keyword/false",
+    "cppdoc": "cpp/language/keywords/false"
+  },
+  {
+    "cppref": "cpp/keyword/signed",
+    "cppdoc": "cpp/language/keywords/signed"
+  },
+  {
+    "cppref": "cpp/keyword/static",
+    "cppdoc": "cpp/language/keywords/static"
+  },
+  {
+    "cppref": "cpp/keyword/extern",
+    "cppdoc": "cpp/language/keywords/extern"
+  },
+  {
+    "cppref": "cpp/keyword/consteval",
+    "cppdoc": "cpp/language/keywords/consteval"
+  },
+  {
+    "cppref": "cpp/keyword/atomic_cancel",
+    "cppdoc": "cpp/language/keywords/atomic_cancel"
+  },
+  {
+    "cppref": "cpp/keyword/export",
+    "cppdoc": "cpp/language/keywords/export"
+  },
+  {
+    "cppref": "cpp/keyword/char",
+    "cppdoc": "cpp/language/keywords/char"
+  },
+  {
+    "cppref": "cpp/keyword/protected",
+    "cppdoc": "cpp/language/keywords/protected"
+  },
+  {
+    "cppref": "cpp/keyword/return",
+    "cppdoc": "cpp/language/keywords/return"
+  },
+  {
+    "cppref": "cpp/keyword/do",
+    "cppdoc": "cpp/language/keywords/do"
+  },
+  {
+    "cppref": "cpp/keyword/true",
+    "cppdoc": "cpp/language/keywords/true"
+  },
+  {
+    "cppref": "cpp/keyword/catch",
+    "cppdoc": "cpp/language/keywords/catch"
+  },
+  {
+    "cppref": "cpp/keyword/delete",
+    "cppdoc": "cpp/language/keywords/delete"
+  },
+  {
+    "cppref": "cpp/keyword/wchar_t",
+    "cppdoc": "cpp/language/keywords/wchar_t"
+  },
+  {
+    "cppref": "cpp/keyword/class",
+    "cppdoc": "cpp/language/keywords/class"
+  },
+  {
+    "cppref": "cpp/keyword/reflexpr",
+    "cppdoc": "cpp/language/keywords/reflexpr"
+  },
+  {
+    "cppref": "cpp/keyword/and_eq",
+    "cppdoc": "cpp/language/keywords/and_eq"
+  },
+  {
+    "cppref": "cpp/keyword/requires",
+    "cppdoc": "cpp/language/keywords/requires"
+  },
+  {
+    "cppref": "cpp/keyword/default",
+    "cppdoc": "cpp/language/keywords/default"
+  },
+  {
+    "cppref": "cpp/keyword/alignof",
+    "cppdoc": "cpp/language/keywords/alignof"
+  },
+  {
+    "cppref": "cpp/keyword/namespace",
+    "cppdoc": "cpp/language/keywords/namespace"
+  },
+  {
+    "cppref": "cpp/keyword/double",
+    "cppdoc": "cpp/language/keywords/double"
+  },
+  {
+    "cppref": "cpp/keyword/volatile",
+    "cppdoc": "cpp/language/keywords/volatile"
+  },
+  {
+    "cppref": "cpp/keyword/transaction_safe_dynamic",
+    "cppdoc": "cpp/language/keywords/transaction_safe_dynamic"
+  },
+  {
+    "cppref": "cpp/keyword/char8_t",
+    "cppdoc": "cpp/language/keywords/char8_t"
+  },
+  {
+    "cppref": "cpp/keyword/try",
+    "cppdoc": "cpp/language/keywords/try"
+  },
+  {
+    "cppref": "cpp/keyword/float",
+    "cppdoc": "cpp/language/keywords/float"
+  },
+  {
+    "cppref": "cpp/keyword/private",
+    "cppdoc": "cpp/language/keywords/private"
+  },
+  {
+    "cppref": "cpp/keyword/this",
+    "cppdoc": "cpp/language/keywords/this"
+  },
+  {
+    "cppref": "cpp/keyword/explicit",
+    "cppdoc": "cpp/language/keywords/explicit"
+  },
+  {
+    "cppref": "cpp/keyword/thread_local",
+    "cppdoc": "cpp/language/keywords/thread_local"
+  },
+  {
+    "cppref": "cpp/keyword/unsigned",
+    "cppdoc": "cpp/language/keywords/unsigned"
+  },
+  {
+    "cppref": "cpp/keyword/xor_eq",
+    "cppdoc": "cpp/language/keywords/xor_eq"
+  },
+  {
+    "cppref": "cpp/keyword/operator",
+    "cppdoc": "cpp/language/keywords/operator"
+  },
+  {
+    "cppref": "cpp/keyword/switch",
+    "cppdoc": "cpp/language/keywords/switch"
+  },
+  {
+    "cppref": "cpp/keyword/using",
+    "cppdoc": "cpp/language/keywords/using"
+  },
+  {
+    "cppref": "cpp/keyword/new",
+    "cppdoc": "cpp/language/keywords/new"
+  },
+  {
+    "cppref": "cpp/keyword/sizeof",
+    "cppdoc": "cpp/language/keywords/sizeof"
+  },
+  {
+    "cppref": "cpp/keyword/for",
+    "cppdoc": "cpp/language/keywords/for"
+  },
+  {
+    "cppref": "cpp/keyword/atomic_commit",
+    "cppdoc": "cpp/language/keywords/atomic_commit"
+  },
+  {
+    "cppref": "cpp/keyword/const",
+    "cppdoc": "cpp/language/keywords/const"
+  },
+  {
+    "cppref": "cpp/keyword/continue",
+    "cppdoc": "cpp/language/keywords/continue"
+  },
+  {
+    "cppref": "cpp/keyword/if",
+    "cppdoc": "cpp/language/keywords/if"
+  },
+  {
+    "cppref": "cpp/keyword/not",
+    "cppdoc": "cpp/language/keywords/not"
+  },
+  {
+    "cppref": "cpp/keyword/reinterpret_cast",
+    "cppdoc": "cpp/language/keywords/reinterpret_cast"
+  },
+  {
+    "cppref": "cpp/keyword/long",
+    "cppdoc": "cpp/language/keywords/long"
+  },
+  {
+    "cppref": "cpp/keyword/static_cast",
+    "cppdoc": "cpp/language/keywords/static_cast"
+  },
+  {
+    "cppref": "cpp/keyword/public",
+    "cppdoc": "cpp/language/keywords/public"
+  },
+  {
+    "cppref": "cpp/keyword/typedef",
+    "cppdoc": "cpp/language/keywords/typedef"
+  },
+  {
+    "cppref": "cpp/keyword/mutable",
+    "cppdoc": "cpp/language/keywords/mutable"
+  },
+  {
+    "cppref": "cpp/keyword/nullptr",
+    "cppdoc": "cpp/language/keywords/nullptr"
+  },
+  {
+    "cppref": "cpp/keyword/throw",
+    "cppdoc": "cpp/language/keywords/throw"
+  },
+  {
+    "cppref": "cpp/keyword/bitand",
+    "cppdoc": "cpp/language/keywords/bitand"
+  },
+  {
+    "cppref": "cpp/keyword/friend",
+    "cppdoc": "cpp/language/keywords/friend"
+  },
+  {
+    "cppref": "cpp/keyword/static_assert",
+    "cppdoc": "cpp/language/keywords/static_assert"
+  },
+  {
+    "cppref": "cpp/keyword/co_return",
+    "cppdoc": "cpp/language/keywords/co_return"
+  },
+  {
+    "cppref": "cpp/keyword/template",
+    "cppdoc": "cpp/language/keywords/template"
+  },
+  {
+    "cppref": "cpp/keyword/char16_t",
+    "cppdoc": "cpp/language/keywords/char16_t"
+  },
+  {
+    "cppref": "cpp/keyword/else",
+    "cppdoc": "cpp/language/keywords/else"
+  },
+  {
+    "cppref": "cpp/keyword/enum",
+    "cppdoc": "cpp/language/keywords/enum"
+  },
+  {
+    "cppref": "cpp/keyword/atomic_noexcept",
+    "cppdoc": "cpp/language/keywords/atomic_noexcept"
+  },
+  {
+    "cppref": "cpp/keyword/void",
+    "cppdoc": "cpp/language/keywords/void"
+  },
+  {
+    "cppref": "cpp/keyword/or",
+    "cppdoc": "cpp/language/keywords/or"
+  },
+  {
+    "cppref": "cpp/keyword/noexcept",
+    "cppdoc": "cpp/language/keywords/noexcept"
+  },
+  {
+    "cppref": "cpp/keyword/asm",
+    "cppdoc": "cpp/language/keywords/asm"
+  },
+  {
+    "cppref": "cpp/keyword/bool",
+    "cppdoc": "cpp/language/keywords/bool"
+  },
+  {
+    "cppref": "cpp/keyword/case",
+    "cppdoc": "cpp/language/keywords/case"
+  },
+  {
+    "cppref": "cpp/keyword/while",
+    "cppdoc": "cpp/language/keywords/while"
+  },
+  {
+    "cppref": "cpp/keyword/union",
+    "cppdoc": "cpp/language/keywords/union"
+  },
+  {
+    "cppref": "cpp/keyword/dynamic_cast",
+    "cppdoc": "cpp/language/keywords/dynamic_cast"
+  },
+  {
+    "cppref": "cpp/keyword/int",
+    "cppdoc": "cpp/language/keywords/int"
+  },
+  {
+    "cppref": "cpp/keyword/break",
+    "cppdoc": "cpp/language/keywords/break"
+  },
+  {
+    "cppref": "cpp/keyword/transaction_safe",
+    "cppdoc": "cpp/language/keywords/transaction_safe"
+  },
+  {
+    "cppref": "cpp/keyword/constexpr",
+    "cppdoc": "cpp/language/keywords/constexpr"
+  },
+  {
+    "cppref": "cpp/keyword/co_yield",
+    "cppdoc": "cpp/language/keywords/co_yield"
+  },
+  {
+    "cppref": "cpp/keyword/short",
+    "cppdoc": "cpp/language/keywords/short"
+  },
+  {
+    "cppref": "cpp/keyword/struct",
+    "cppdoc": "cpp/language/keywords/struct"
+  },
+  {
+    "cppref": "cpp/keyword/inline",
+    "cppdoc": "cpp/language/keywords/inline"
+  },
+  {
+    "cppref": "cpp/keyword/decltype",
+    "cppdoc": "cpp/language/keywords/decltype"
+  },
+  {
+    "cppref": "cpp/keyword/synchronized",
+    "cppdoc": "cpp/language/keywords/synchronized"
+  },
+  {
+    "cppref": "cpp/keyword/register",
+    "cppdoc": "cpp/language/keywords/register"
+  },
+  {
+    "cppref": "cpp/keyword/or_eq",
+    "cppdoc": "cpp/language/keywords/or_eq"
+  },
+  {
+    "cppref": "cpp/keyword/typeid",
+    "cppdoc": "cpp/language/keywords/typeid"
+  },
+  {
+    "cppref": "cpp/keyword/co_await",
+    "cppdoc": "cpp/language/keywords/co_await"
+  },
+  {
+    "cppref": "cpp/keyword/bitor",
+    "cppdoc": "cpp/language/keywords/bitor"
+  },
+  {
+    "cppref": "cpp/keyword/char32_t",
+    "cppdoc": "cpp/language/keywords/char32_t"
+  },
+  {
+    "cppref": "cpp/keyword/goto",
+    "cppdoc": "cpp/language/keywords/goto"
+  },
+  {
+    "cppref": "cpp/keyword/const_cast",
+    "cppdoc": "cpp/language/keywords/const_cast"
+  },
+  {
+    "cppref": "cpp/keyword/concept",
+    "cppdoc": "cpp/language/keywords/concept"
+  },
+  {
+    "cppref": "cpp/keyword/not_eq",
+    "cppdoc": "cpp/language/keywords/not_eq"
+  },
+  {
+    "cppref": "cpp/keyword/xor",
+    "cppdoc": "cpp/language/keywords/xor"
+  },
+  {
+    "cppref": "cpp/keyword/virtual",
+    "cppdoc": "cpp/language/keywords/virtual"
+  },
+  {
+    "cppref": "cpp/keyword/constinit",
+    "cppdoc": "cpp/language/keywords/constinit"
+  },
+  {
+    "cppref": "cpp/keyword/auto",
+    "cppdoc": "cpp/language/keywords/auto"
+  },
+  {
+    "cppref": "cpp/types/bad_typeid",
+    "cppdoc": "cpp/library/utility/types/bad_typeid"
+  },
+  {
+    "cppref": "cpp/types/size_t",
+    "cppdoc": "cpp/library/utility/types/size_t"
+  },
+  {
+    "cppref": "cpp/types/NULL",
+    "cppdoc": "cpp/library/utility/types/NULL"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits",
+    "cppdoc": "cpp/library/utility/types/numeric_limits"
+  },
+  {
+    "cppref": "cpp/types/max_align_t",
+    "cppdoc": "cpp/library/utility/types/max_align_t"
+  },
+  {
+    "cppref": "cpp/types/byte",
+    "cppdoc": "cpp/library/utility/types/byte"
+  },
+  {
+    "cppref": "cpp/types/type_index",
+    "cppdoc": "cpp/library/utility/types/type_index"
+  },
+  {
+    "cppref": "cpp/types/integer",
+    "cppdoc": "cpp/library/utility/types/integer"
+  },
+  {
+    "cppref": "cpp/types/nullptr_t",
+    "cppdoc": "cpp/library/utility/types/nullptr_t"
+  },
+  {
+    "cppref": "cpp/types/climits",
+    "cppdoc": "cpp/library/utility/types/climits"
+  },
+  {
+    "cppref": "cpp/types/bad_cast",
+    "cppdoc": "cpp/library/utility/types/bad_cast"
+  },
+  {
+    "cppref": "cpp/types/offsetof",
+    "cppdoc": "cpp/library/utility/types/offsetof"
+  },
+  {
+    "cppref": "cpp/types/type_info",
+    "cppdoc": "cpp/library/utility/types/type_info"
+  },
+  {
+    "cppref": "cpp/types/floating-point",
+    "cppdoc": "cpp/library/utility/types/floating-point"
+  },
+  {
+    "cppref": "cpp/types/ptrdiff_t",
+    "cppdoc": "cpp/library/utility/types/ptrdiff_t"
+  },
+  {
+    "cppref": "cpp/types/type_info/before",
+    "cppdoc": "cpp/library/utility/types/type_info/before"
+  },
+  {
+    "cppref": "cpp/types/type_info/~type_info",
+    "cppdoc": "cpp/library/utility/types/type_info/~type_info"
+  },
+  {
+    "cppref": "cpp/types/type_info/hash_code",
+    "cppdoc": "cpp/library/utility/types/type_info/hash_code"
+  },
+  {
+    "cppref": "cpp/types/type_info/name",
+    "cppdoc": "cpp/library/utility/types/type_info/name"
+  },
+  {
+    "cppref": "cpp/types/type_info/operator_cmp",
+    "cppdoc": "cpp/library/utility/types/type_info/operator_cmp"
+  },
+  {
+    "cppref": "cpp/types/type_index/hash",
+    "cppdoc": "cpp/library/utility/types/type_index/hash"
+  },
+  {
+    "cppref": "cpp/types/type_index/hash_code",
+    "cppdoc": "cpp/library/utility/types/type_index/hash_code"
+  },
+  {
+    "cppref": "cpp/types/type_index/type_index",
+    "cppdoc": "cpp/library/utility/types/type_index/type_index"
+  },
+  {
+    "cppref": "cpp/types/type_index/name",
+    "cppdoc": "cpp/library/utility/types/type_index/name"
+  },
+  {
+    "cppref": "cpp/types/type_index/operator_cmp",
+    "cppdoc": "cpp/library/utility/types/type_index/operator_cmp"
+  },
+  {
+    "cppref": "cpp/types/climits/FLT_ROUNDS",
+    "cppdoc": "cpp/library/utility/types/climits/FLT_ROUNDS"
+  },
+  {
+    "cppref": "cpp/types/climits/FLT_EVAL_METHOD",
+    "cppdoc": "cpp/library/utility/types/climits/FLT_EVAL_METHOD"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/signaling_NaN",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/signaling_NaN"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/radix",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/radix"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/min_exponent",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/min_exponent"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/has_denorm_loss",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/has_denorm_loss"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/is_iec559",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/is_iec559"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/digits10",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/digits10"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/min",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/min"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/has_denorm",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/has_denorm"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/traps",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/traps"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/digits",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/digits"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/tinyness_before",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/tinyness_before"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/is_signed",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/is_signed"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/round_error",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/round_error"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/has_infinity",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/has_infinity"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/lowest",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/lowest"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/float_denorm_style",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/float_denorm_style"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/min_exponent10",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/min_exponent10"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/is_modulo",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/is_modulo"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/infinity",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/infinity"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/max",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/max"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/max_exponent10",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/max_exponent10"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/round_style",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/round_style"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/has_signaling_NaN",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/has_signaling_NaN"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/float_round_style",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/float_round_style"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/is_integer",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/is_integer"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/quiet_NaN",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/quiet_NaN"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/max_digits10",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/max_digits10"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/has_quiet_NaN",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/has_quiet_NaN"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/denorm_min",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/denorm_min"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/is_exact",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/is_exact"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/is_bounded",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/is_bounded"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/max_exponent",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/max_exponent"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/is_specialized",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/is_specialized"
+  },
+  {
+    "cppref": "cpp/types/numeric_limits/epsilon",
+    "cppdoc": "cpp/library/utility/types/numeric_limits/epsilon"
+  },
+  {
+    "cppref": "cpp/coroutine/noop_coroutine",
+    "cppdoc": "cpp/library/utility/coroutine/noop_coroutine"
+  },
+  {
+    "cppref": "cpp/coroutine/suspend_never",
+    "cppdoc": "cpp/library/utility/coroutine/suspend_never"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle"
+  },
+  {
+    "cppref": "cpp/coroutine/suspend_always",
+    "cppdoc": "cpp/library/utility/coroutine/suspend_always"
+  },
+  {
+    "cppref": "cpp/coroutine/noop_coroutine_promise",
+    "cppdoc": "cpp/library/utility/coroutine/noop_coroutine_promise"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_traits",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_traits"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/promise",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/promise"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/resume",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/resume"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/hash",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/hash"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/operator_coroutine_handle_void",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/operator_coroutine_handle_void"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/address",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/address"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/from_promise",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/from_promise"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/from_address",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/from_address"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/coroutine_handle",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/coroutine_handle"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/operator_cmp",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/operator_cmp"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/destroy",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/destroy"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/operator_bool",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/operator_bool"
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/operator=",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/operator="
+  },
+  {
+    "cppref": "cpp/coroutine/coroutine_handle/done",
+    "cppdoc": "cpp/library/utility/coroutine/coroutine_handle/done"
+  },
+  {
+    "cppref": "cpp/chrono/operator_q__q_s",
+    "cppdoc": "cpp/library/chrono/duration/operator_q__q_s"
+  },
+  {
+    "cppref": "cpp/chrono/operator_q__q_y",
+    "cppdoc": "cpp/library/chrono/year/operator_q__q_y"
+  },
+  {
+    "cppref": "cpp/chrono/operator_q__q_min",
+    "cppdoc": "cpp/library/chrono/duration/operator_q__q_min"
+  },
+  {
+    "cppref": "cpp/chrono/operator_q__q_d",
+    "cppdoc": "cpp/library/chrono/day/operator_q__q_d"
+  },
+  {
+    "cppref": "c/11",
+    "cppdoc": "c/language/history/11"
+  },
+  {
+    "cppref": "c/17",
+    "cppdoc": "c/language/history/17"
+  },
+  {
+    "cppref": "c/keyword",
+    "cppdoc": "c/language/keyword"
+  },
+  {
+    "cppref": "c/current_status",
+    "cppdoc": "c/language/history/current_status"
+  },
+  {
+    "cppref": "c/23",
+    "cppdoc": "c/language/history/23"
+  },
+  {
+    "cppref": "c/experimental",
+    "cppdoc": "c/language/experimental"
+  },
+  {
+    "cppref": "c/99",
+    "cppdoc": "c/language/history/99"
+  },
+  {
+    "cppref": "c/95",
+    "cppdoc": "c/language/history/95"
+  },
+  {
+    "cppref": "c/comment",
+    "cppdoc": "c/language/basic_concepts/comment"
+  },
+  {
+    "cppref": "c/language/alignas",
+    "cppdoc": "c/language/declarations/alignas"
+  },
+  {
+    "cppref": "c/language/atomic",
+    "cppdoc": "c/language/declarations/atomic"
+  },
+  {
+    "cppref": "c/language/integer_constant",
+    "cppdoc": "c/language/expressions/integer_constant"
+  },
+  {
+    "cppref": "c/language/bool_constant",
+    "cppdoc": "c/language/expressions/bool_constant"
+  },
+  {
+    "cppref": "c/language/return",
+    "cppdoc": "c/language/statements/return"
+  },
+  {
+    "cppref": "c/language/do",
+    "cppdoc": "c/language/statements/do"
+  },
+  {
+    "cppref": "c/language/types",
+    "cppdoc": "c/language/basic_concepts/types"
+  },
+  {
+    "cppref": "c/language/_Noreturn",
+    "cppdoc": "c/language/functions/_Noreturn"
+  },
+  {
+    "cppref": "c/language/identifier",
+    "cppdoc": "c/language/basic_concepts/identifier"
+  },
+  {
+    "cppref": "c/language/scope",
+    "cppdoc": "c/language/basic_concepts/scope"
+  },
+  {
+    "cppref": "c/language/ascii",
+    "cppdoc": "c/language/basic_concepts/ascii"
+  },
+  {
+    "cppref": "c/language/variadic",
+    "cppdoc": "c/language/functions/variadic"
+  },
+  {
+    "cppref": "c/language/function_declaration",
+    "cppdoc": "c/language/functions/function_declaration"
+  },
+  {
+    "cppref": "c/language/memory_model",
+    "cppdoc": "c/language/basic_concepts/memory_model"
+  },
+  {
+    "cppref": "c/language/as_if",
+    "cppdoc": "c/language/basic_concepts/as_if"
+  },
+  {
+    "cppref": "c/language/compatible_type",
+    "cppdoc": "c/language/basic_concepts/compatible_type"
+  },
+  {
+    "cppref": "c/language/scalar_initialization",
+    "cppdoc": "c/language/initialization/scalar_initialization"
+  },
+  {
+    "cppref": "c/language/behavior",
+    "cppdoc": "c/language/basic_concepts/behavior"
+  },
+  {
+    "cppref": "c/language/arithmetic_types",
+    "cppdoc": "c/language/basic_concepts/arithmetic_types"
+  },
+  {
+    "cppref": "c/language/charset",
+    "cppdoc": "c/language/basic_concepts/charset"
+  },
+  {
+    "cppref": "c/language/translation_phases",
+    "cppdoc": "c/language/basic_concepts/translation_phases"
+  },
+  {
+    "cppref": "c/language/lifetime",
+    "cppdoc": "c/language/basic_concepts/lifetime"
+  },
+  {
+    "cppref": "c/language/type",
+    "cppdoc": "c/language/basic_concepts/type"
+  },
+  {
+    "cppref": "c/language/array_initialization",
+    "cppdoc": "c/language/initialization/array_initialization"
+  },
+  {
+    "cppref": "c/language/punctuators",
+    "cppdoc": "c/language/basic_concepts/punctuators"
+  },
+  {
+    "cppref": "c/language/object",
+    "cppdoc": "c/language/basic_concepts/object"
+  },
+  {
+    "cppref": "c/language/main_function",
+    "cppdoc": "c/language/basic_concepts/main_function"
+  },
+  {
+    "cppref": "c/language/name_space",
+    "cppdoc": "c/language/basic_concepts/name_space"
+  },
+  {
+    "cppref": "c/experimental/fpext1",
+    "cppdoc": "c/language/experimental/fpext1"
+  },
+  {
+    "cppref": "c/experimental/fpext4",
+    "cppdoc": "c/language/experimental/fpext4"
+  },
+  {
+    "cppref": "c/experimental/dynamic",
+    "cppdoc": "c/language/experimental/dynamic"
+  },
+  {
+    "cppref": "c/experimental/dynamic/getline",
+    "cppdoc": "c/language/experimental/dynamic/getline"
+  },
+  {
+    "cppref": "c/experimental/dynamic/strdup",
+    "cppdoc": "c/language/experimental/dynamic/strdup"
+  },
+  {
+    "cppref": "c/experimental/dynamic/strndup",
+    "cppdoc": "c/language/experimental/dynamic/strndup"
+  },
+  {
+    "cppref": "c/experimental/dynamic/asprintf",
+    "cppdoc": "c/language/experimental/dynamic/asprintf"
+  },
+  {
+    "cppref": "c/keyword/alignas",
+    "cppdoc": "c/language/keyword/alignas"
+  },
+  {
+    "cppref": "c/keyword/false",
+    "cppdoc": "c/language/keyword/false"
+  },
+  {
+    "cppref": "c/keyword/signed",
+    "cppdoc": "c/language/keyword/signed"
+  },
+  {
+    "cppref": "c/keyword/static",
+    "cppdoc": "c/language/keyword/static"
+  },
+  {
+    "cppref": "c/keyword/extern",
+    "cppdoc": "c/language/keyword/extern"
+  },
+  {
+    "cppref": "c/keyword/char",
+    "cppdoc": "c/language/keyword/char"
+  },
+  {
+    "cppref": "c/keyword/_Generic",
+    "cppdoc": "c/language/keyword/_Generic"
+  },
+  {
+    "cppref": "c/keyword/return",
+    "cppdoc": "c/language/keyword/return"
+  },
+  {
+    "cppref": "c/keyword/do",
+    "cppdoc": "c/language/keyword/do"
+  },
+  {
+    "cppref": "c/keyword/true",
+    "cppdoc": "c/language/keyword/true"
+  },
+  {
+    "cppref": "c/keyword/_Noreturn",
+    "cppdoc": "c/language/keyword/_Noreturn"
+  },
+  {
+    "cppref": "c/keyword/_Atomic",
+    "cppdoc": "c/language/keyword/_Atomic"
+  },
+  {
+    "cppref": "c/keyword/default",
+    "cppdoc": "c/language/keyword/default"
+  },
+  {
+    "cppref": "c/keyword/alignof",
+    "cppdoc": "c/language/keyword/alignof"
+  },
+  {
+    "cppref": "c/keyword/double",
+    "cppdoc": "c/language/keyword/double"
+  },
+  {
+    "cppref": "c/keyword/volatile",
+    "cppdoc": "c/language/keyword/volatile"
+  },
+  {
+    "cppref": "c/keyword/fortran",
+    "cppdoc": "c/language/keyword/fortran"
+  },
+  {
+    "cppref": "c/keyword/_Decimal128",
+    "cppdoc": "c/language/keyword/_Decimal128"
+  },
+  {
+    "cppref": "c/keyword/_Static_assert",
+    "cppdoc": "c/language/keyword/_Static_assert"
+  },
+  {
+    "cppref": "c/keyword/_Bool",
+    "cppdoc": "c/language/keyword/_Bool"
+  },
+  {
+    "cppref": "c/keyword/float",
+    "cppdoc": "c/language/keyword/float"
+  },
+  {
+    "cppref": "c/keyword/thread_local",
+    "cppdoc": "c/language/keyword/thread_local"
+  },
+  {
+    "cppref": "c/keyword/unsigned",
+    "cppdoc": "c/language/keyword/unsigned"
+  },
+  {
+    "cppref": "c/keyword/switch",
+    "cppdoc": "c/language/keyword/switch"
+  },
+  {
+    "cppref": "c/keyword/sizeof",
+    "cppdoc": "c/language/keyword/sizeof"
+  },
+  {
+    "cppref": "c/keyword/restrict",
+    "cppdoc": "c/language/keyword/restrict"
+  },
+  {
+    "cppref": "c/keyword/for",
+    "cppdoc": "c/language/keyword/for"
+  },
+  {
+    "cppref": "c/keyword/_Complex",
+    "cppdoc": "c/language/keyword/_Complex"
+  },
+  {
+    "cppref": "c/keyword/const",
+    "cppdoc": "c/language/keyword/const"
+  },
+  {
+    "cppref": "c/keyword/continue",
+    "cppdoc": "c/language/keyword/continue"
+  },
+  {
+    "cppref": "c/keyword/if",
+    "cppdoc": "c/language/keyword/if"
+  },
+  {
+    "cppref": "c/keyword/long",
+    "cppdoc": "c/language/keyword/long"
+  },
+  {
+    "cppref": "c/keyword/typedef",
+    "cppdoc": "c/language/keyword/typedef"
+  },
+  {
+    "cppref": "c/keyword/nullptr",
+    "cppdoc": "c/language/keyword/nullptr"
+  },
+  {
+    "cppref": "c/keyword/_Alignof",
+    "cppdoc": "c/language/keyword/_Alignof"
+  },
+  {
+    "cppref": "c/keyword/static_assert",
+    "cppdoc": "c/language/keyword/static_assert"
+  },
+  {
+    "cppref": "c/keyword/else",
+    "cppdoc": "c/language/keyword/else"
+  },
+  {
+    "cppref": "c/keyword/_Imaginary",
+    "cppdoc": "c/language/keyword/_Imaginary"
+  },
+  {
+    "cppref": "c/keyword/enum",
+    "cppdoc": "c/language/keyword/enum"
+  },
+  {
+    "cppref": "c/keyword/void",
+    "cppdoc": "c/language/keyword/void"
+  },
+  {
+    "cppref": "c/keyword/bool",
+    "cppdoc": "c/language/keyword/bool"
+  },
+  {
+    "cppref": "c/keyword/case",
+    "cppdoc": "c/language/keyword/case"
+  },
+  {
+    "cppref": "c/keyword/typeof",
+    "cppdoc": "c/language/keyword/typeof"
+  },
+  {
+    "cppref": "c/keyword/while",
+    "cppdoc": "c/language/keyword/while"
+  },
+  {
+    "cppref": "c/keyword/union",
+    "cppdoc": "c/language/keyword/union"
+  },
+  {
+    "cppref": "c/keyword/_Decimal32",
+    "cppdoc": "c/language/keyword/_Decimal32"
+  },
+  {
+    "cppref": "c/keyword/int",
+    "cppdoc": "c/language/keyword/int"
+  },
+  {
+    "cppref": "c/keyword/break",
+    "cppdoc": "c/language/keyword/break"
+  },
+  {
+    "cppref": "c/keyword/_Thread_local",
+    "cppdoc": "c/language/keyword/_Thread_local"
+  },
+  {
+    "cppref": "c/keyword/constexpr",
+    "cppdoc": "c/language/keyword/constexpr"
+  },
+  {
+    "cppref": "c/keyword/_Alignas",
+    "cppdoc": "c/language/keyword/_Alignas"
+  },
+  {
+    "cppref": "c/keyword/short",
+    "cppdoc": "c/language/keyword/short"
+  },
+  {
+    "cppref": "c/keyword/typeof_unqual",
+    "cppdoc": "c/language/keyword/typeof_unqual"
+  },
+  {
+    "cppref": "c/keyword/struct",
+    "cppdoc": "c/language/keyword/struct"
+  },
+  {
+    "cppref": "c/keyword/inline",
+    "cppdoc": "c/language/keyword/inline"
+  },
+  {
+    "cppref": "c/keyword/register",
+    "cppdoc": "c/language/keyword/register"
+  },
+  {
+    "cppref": "c/keyword/_Decimal64",
+    "cppdoc": "c/language/keyword/_Decimal64"
+  },
+  {
+    "cppref": "c/keyword/goto",
+    "cppdoc": "c/language/keyword/goto"
+  },
+  {
+    "cppref": "c/keyword/auto",
+    "cppdoc": "c/language/keyword/auto"
+  }
+]


### PR DESCRIPTION
This patch adds the file `slug_map.json`, which is generated by a script not checked in, under the migrate subdirectory. This file contains a mapping from cppreference slugs to CppDoc slugs.

A few entries in the slug map file has a `null` CppDoc slug. This is by design and these cppreference pages are intended to be migrated by hand. The CppDoc slugs of these pages will be determined when they are migrated in the future.