### PR TITLE
fix: component Header creates undefined DocLink

### DIFF
--- a/src/components/header/Header.astro
+++ b/src/components/header/Header.astro
@@ -10,13 +10,14 @@ export interface Props {
 }
 
 const { lang, name, displayName, nolink } = Astro.props;
-const dest = `${lang}.headers.${name}`;
+const langPrefix = lang == "C" ? "/c" : "/cpp";
+const src = `${langPrefix}/library/headers/${name}`;
 
 const extension = lang === "C" ? ".h" : "";
 const text = displayName ?? `<${name}${extension}>`;
 
 const As = nolink ? Fragment : DocLink;
-const asProps = nolink ? {} : { dest };
+const asProps = nolink ? {} : { src };
 ---
 
 <As {...asProps}>


### PR DESCRIPTION
Makes it points to the absolute path of header doc pages.