### PR TITLE
fix: add c/header/xxx pages to slug_map.json

### DIFF
--- a/migrate/slug_map.json
+++ b/migrate/slug_map.json
@@ -22224,14 +22224,6 @@
     "cppdoc": "c/library/headers/tgmath"
   },
   {
-    "cppref": "c/header/math",
-    "cppdoc": "c/library/headers/math"
-  },
-  {
-    "cppref": "c/header/complex",
-    "cppdoc": "c/library/headers/complex"
-  },
-  {
     "cppref": "c/header/threads",
     "cppdoc": "c/library/headers/threads"
   },


### PR DESCRIPTION
It seems that the slug map is not ordered, so I just put them under c/header.